### PR TITLE
Add global definition for Symbol.observable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,12 @@ Matches any valid JSON value.
 */
 export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
 
+declare global {
+	interface SymbolConstructor {
+		readonly observable: symbol;
+	}
+}
+
 /**
 Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
 */

--- a/test-d/index.ts
+++ b/test-d/index.ts
@@ -1,0 +1,10 @@
+import {expectType} from 'tsd';
+import {ObservableLike} from '..';
+
+// eslint-disable-next-line no-use-extend-native/no-use-extend-native
+expectType<symbol>(Symbol.observable);
+
+const observable = (null as any) as ObservableLike;
+
+observable.subscribe(() => {});
+observable.subscribe(value => expectType<unknown>(value));


### PR DESCRIPTION
This prevents errors for users who don't use node types in their projects.

Fixes #19.