### PR TITLE
Add `esnext` reference for BigInt

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="esnext" />
+
 // TODO: This can just be `export type Primitive = not object` when the `not` keyword is out.
 /**
 Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -1,4 +1,4 @@
-/// <reference lib="esnext" />
+/// <reference lib="esnext"/>
 
 // TODO: This can just be `export type Primitive = not object` when the `not` keyword is out.
 /**


### PR DESCRIPTION
We are forced to set the target to `esnext`. By adding this line, it works out of the box.
