### PR TITLE
Add `Promisable` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export {MergeExclusive} from './source/merge-exclusive';
 export {RequireAtLeastOne} from './source/require-at-least-one';
 export {ReadonlyDeep} from './source/readonly-deep';
 export {LiteralUnion} from './source/literal-union';
+export {Promisable} from './source/promisable';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Click the type names for complete docs.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
-- [`Promisable`](source/promisable.d.ts) - Create a type for values that can either be a promise or it's return value, and as such both accepts synchronous values and promise-likes of those values.
+- [`Promisable`](source/promisable.d.ts) - Create a type that represents either the value or the value wrapped in `PromiseLike`.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Click the type names for complete docs.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
+- [`Promisable`](source/promisable.d.ts) - Create a type for values that can either be a promise or it's return value.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Click the type names for complete docs.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
-- [`Promisable`](source/promisable.d.ts) - Create a type for values that can either be a promise or it's return value.
+- [`Promisable`](source/promisable.d.ts) - Create a type for values that can either be a promise or it's return value, and as such both accepts synchronous values and promise-likes of those values.
 
 ### Miscellaneous
 

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -1,9 +1,9 @@
 /**
 Create a type for values that can either be a promise or it's return value.
 
-Use cases:
+Use-cases:
 - A function accepts a callback that may either return a value synchronously or may return a promised value.
-- Specifically this type could be the return type of `Promise.then()`, `Promise.catch()` and `Promise.finally()` callbacks.
+- This type could be the return type of `Promise#then()`, `Promise#catch()`, and `Promise#finally()` callbacks.
 
 Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/31394) if you want to have this type as a built-in in TypeScript.
 

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -1,11 +1,11 @@
 /**
-Create a type for values that can either be a promise or it's return value
+Create a type for values that can either be a promise or it's return value.
 
 Use cases:
 - A function accepts a callback that may either return a value synchronously or may return a promised value.
-- Specifically this type could be the return type of Promise.then(), Promise.catch() and Promise.finally() callbacks.
+- Specifically this type could be the return type of `Promise.then()`, `Promise.catch()` and `Promise.finally()` callbacks.
 
-Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/31394) if you want to have this type as a built-in in TypeScript. 
+Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/31394) if you want to have this type as a built-in in TypeScript.
 
 @example
 ```

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -1,5 +1,5 @@
 /**
-Create a type for values that can either be a promise or it's return value.
+Create a type that represents either the value or the value wrapped in `PromiseLike`.
 
 Use-cases:
 - A function accepts a callback that may either return a value synchronously or may return a promised value.

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -1,0 +1,17 @@
+/**
+Create a type for values that can either be a promise or it's return value
+
+@example
+```
+import {Promisable} from 'type-fest';
+
+async function logger(getLogEntry: () => Awaitable<string>): Promise<void> {
+    const entry = await getLogEntry();
+    console.log(entry);
+}
+
+logger(() => 'foo');
+logger(() => Promise.resolve('bar'));
+```
+*/
+export type Promisable<T> = T | PromiseLike<T>;

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -1,11 +1,17 @@
 /**
 Create a type for values that can either be a promise or it's return value
 
+Use cases:
+- A function accepts a callback that may either return a value synchronously or may return a promised value.
+- Specifically this type could be the return type of Promise.then(), Promise.catch() and Promise.finally() callbacks.
+
+Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/31394) if you want to have this type as a built-in in TypeScript. 
+
 @example
 ```
 import {Promisable} from 'type-fest';
 
-async function logger(getLogEntry: () => Awaitable<string>): Promise<void> {
+async function logger(getLogEntry: () => Promisable<string>): Promise<void> {
     const entry = await getLogEntry();
     console.log(entry);
 }

--- a/test-d/promisable.ts
+++ b/test-d/promisable.ts
@@ -1,0 +1,5 @@
+import {expectType} from 'tsd';
+import {Promisable} from '..';
+
+declare const promisable: Promisable<string>;
+expectType<PromiseLike<string> | string>(promisable);


### PR DESCRIPTION
Fixes #40 
TypeScript proposal: [#31394](https://github.com/microsoft/TypeScript/issues/31394)

A type for values that can either be a promise or it's return value.

```TypeScript
type Promisable<T> = T | PromiseLike<T>;
```

**Example**

```TypeScript
async function logger(getLogEntry: () => Awaitable<string>): Promise<void> {
    const entry = await getLogEntry();
    console.log(entry);
}

logger(() => 'foo');
logger(() => Promise.resolve('bar'));
```

**Use cases**

* A function accepts a callback that may either return a value synchronously or may return a promised value.
* Specifically this type could be the return type of `Promise.then()`, `Promise.catch()` and `Promise.finally()` callbacks.

