### PR TITLE
Add `PartialDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export {Mutable} from './source/mutable';
 export {Merge} from './source/merge';
 export {MergeExclusive} from './source/merge-exclusive';
 export {RequireAtLeastOne} from './source/require-at-least-one';
+export {PartialDeep} from './source/partial-deep';
 export {ReadonlyDeep} from './source/readonly-deep';
 export {LiteralUnion} from './source/literal-union';
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive properties.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
-- [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which creates a type with properties of T that have a depth of 1 set to optional.
+- [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which creates a type with all properties of `T` set to optional, but only one level deep.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 

--- a/readme.md
+++ b/readme.md
@@ -69,8 +69,8 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive properties.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
-- [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which creates a type with all properties of `T` set to optional, but only one level deep.
-- [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
+- [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type. Use [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) if you only need one level deep.
+- [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of an `object`/`Map`/`Set`/`Array` type. Use [`Readonly<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1415-L1420) if you only need one level deep.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 
 ### Miscellaneous

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive properties.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
-- [`PartialDeep`](source/partial-deep.d.ts) - Create a type from another type with all properties set to optional and the nested properties of all properties set to optional, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which constructs a type with properties of T that have a depth of 1 set to optional.
+- [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which creates a type with properties of T that have a depth of 1 set to optional.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive properties.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given properties.
+- [`PartialDeep`](source/partial-deep.d.ts) - Create a type from another type with all properties set to optional and the nested properties of all properties set to optional, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which constructs a type with properties of T that have a depth of 1 set to optional.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of a `object`/`Map`/`Set`/`Array` type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,3 +1,5 @@
+import {Primitive} from './basic';
+
 /**
 Create a type from another type with all properties and nested properties set to optional.
 
@@ -26,12 +28,18 @@ const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
 settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```
 */
-export type PartialDeep<T> = T extends Primitive | ((...arguments: any[]) => unknown)
+export type PartialDeep<T> = T extends Primitive
 	? Partial<T>
-	: T extends PartialMap<infer KeyType, infer ValueType>
+	: T extends Map<infer KeyType, infer ValueType>
 	? PartialMapDeep<KeyType, ValueType>
-	: T extends PartialSet<infer ItemType>
+	: T extends Set<infer ItemType>
 	? PartialSetDeep<ItemType>
+	: T extends ReadonlyMap<infer KeyType, infer ValueType>
+	? PartialReadonlyMapDeep<KeyType, ValueType>
+	: T extends ReadonlySet<infer ItemType>
+	? PartialReadonlySetDeep<ItemType>
+	: T extends ((...arguments: any[]) => unknown)
+	? T | undefined
 	: T extends object
 	? PartialObjectDeep<T>
 	: unknown;
@@ -47,8 +55,18 @@ Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `P
 interface PartialSetDeep<T> extends Set<PartialDeep<T>> {}
 
 /**
+Same as `PartialDeep`, but accepts only `ReadonlyMap`s and  as inputs. Internal helper for `PartialDeep`.
+*/
+interface PartialReadonlyMapDeep<KeyType, ValueType> extends ReadonlyMap<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
+
+/**
+Same as `PartialDeep`, but accepts only `ReadonlySet`s as inputs. Internal helper for `PartialDeep`.
+*/
+interface PartialReadonlySetDeep<T> extends ReadonlySet<PartialDeep<T>> {}
+
+/**
 Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`.
 */
 type PartialObjectDeep<ObjectType extends object> = {
-	readonly [PropertyType in keyof ObjectType]: PartialDeep<ObjectType[PropertyType]>
+	[PropertyType in keyof ObjectType]: PartialDeep<ObjectType[PropertyType]> | undefined
 };

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,5 +1,5 @@
 /**
-Create a type from another type with all properties set to optional and the nested properties of all properties set to optional.
+Create a type from another type with all properties and nested properties set to optional.
 
 Use cases:
 - Merging a default settings/config object with another object, the second object would be a deep partial of the default object.

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -8,7 +8,7 @@ import {PartialDeep} from 'type-fest';
 interface Baz {
     qux: string;
     corge: {
-        waldo: Array<number>;
+        waldo: number[];
         fred: string;
     };
 }

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,0 +1,27 @@
+/**
+Create a type from another type with all properties set to optional and the nested properties of all properties set to optional
+
+@example
+```
+import {PartialDeep} from 'type-fest';
+
+interface Baz {
+    qux: string;
+    corge: {
+        waldo: Array<number>;
+        fred: string;
+    };
+}
+
+function foo(bar: PartialDeep<Baz>) { }
+
+foo({ corge: { waldo: [ 1, 2 ] } });
+```
+*/
+export type PartialDeep<T> = {
+    [KeyObject in keyof T]?: T[KeyObject] extends Array<infer InferredType>
+        ? Array<PartialDeep<InferredType>>
+        : T[KeyObject] extends ReadonlyArray<infer InferredType>
+            ? ReadonlyArray<PartialDeep<InferredType>>
+            : PartialDeep<T[KeyObject]>;
+};

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,5 +1,9 @@
 /**
-Create a type from another type with all properties set to optional and the nested properties of all properties set to optional
+Create a type from another type with all properties set to optional and the nested properties of all properties set to optional.
+
+Use cases:
+- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.
+- Mocking and testing complex entities, where populating an entire object with it's properties would be redundant in terms of the mock or test.
 
 @example
 ```
@@ -19,9 +23,24 @@ foo({ corge: { waldo: [ 1, 2 ] } });
 ```
 */
 export type PartialDeep<T> = {
-    [KeyObject in keyof T]?: T[KeyObject] extends Array<infer InferredType>
-        ? Array<PartialDeep<InferredType>>
-        : T[KeyObject] extends ReadonlyArray<infer InferredType>
-            ? ReadonlyArray<PartialDeep<InferredType>>
-            : PartialDeep<T[KeyObject]>;
+    [KeyType in keyof T]?:
+        T[KeyType] extends Map<infer MapKeyType, infer MapValueType>
+        ? PartialMap<MapKeyType, MapValueType>
+        : T[KeyType] extends Set<infer SetType>
+        ? PartialSet<SetType>
+        : T[KeyType] extends Array<infer ArrayType>
+        ? Array<PartialDeep<ArrayType>>
+        : T[KeyType] extends ReadonlyArray<infer ReadonlyArrayType>
+        ? ReadonlyArray<PartialDeep<ReadonlyArrayType>>
+        : PartialDeep<T[KeyType]>;
 };
+
+/**
+Same as `PartialDeep`, but accepts only `Map`s as inputs. Internal helper for `PartialDeep`.
+*/
+interface PartialMap<KeyType, ValueType> extends Map<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
+
+/**
+Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `PartialDeep`.
+*/
+interface PartialSet<T> extends Set<PartialDeep<T>> {}

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -3,7 +3,7 @@ Create a type from another type with all properties and nested properties set to
 
 Use cases:
 - Merging a default settings/config object with another object, the second object would be a deep partial of the default object.
-- Mocking and testing complex entities, where populating an entire object with it's properties would be redundant in terms of the mock or test.
+- Mocking and testing complex entities, where populating an entire object with its properties would be redundant in terms of the mock or test.
 
 @example
 ```

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -26,25 +26,29 @@ const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
 settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```
 */
-export type PartialDeep<T> = {
-	[KeyType in keyof T]?:
-		T[KeyType] extends Map<infer MapKeyType, infer MapValueType>
-		? PartialMap<MapKeyType, MapValueType>
-		: T[KeyType] extends Set<infer SetType>
-		? PartialSet<SetType>
-		: T[KeyType] extends Array<infer ArrayType>
-		? Array<PartialDeep<ArrayType>>
-		: T[KeyType] extends ReadonlyArray<infer ReadonlyArrayType>
-		? ReadonlyArray<PartialDeep<ReadonlyArrayType>>
-		: PartialDeep<T[KeyType]>;
-};
+export type PartialDeep<T> = T extends Primitive | ((...arguments: any[]) => unknown)
+	? Partial<T>
+	: T extends PartialMap<infer KeyType, infer ValueType>
+	? PartialMapDeep<KeyType, ValueType>
+	: T extends PartialSet<infer ItemType>
+	? PartialSetDeep<ItemType>
+	: T extends object
+	? PartialObjectDeep<T>
+	: unknown;
 
 /**
-Same as `PartialDeep`, but accepts only `Map`s as inputs. Internal helper for `PartialDeep`.
+Same as `PartialDeep`, but accepts only `Map`s and  as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialMap<KeyType, ValueType> extends Map<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
+interface PartialMapDeep<KeyType, ValueType> extends Map<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
 
 /**
 Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialSet<T> extends Set<PartialDeep<T>> {}
+interface PartialSetDeep<T> extends Set<PartialDeep<T>> {}
+
+/**
+Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`.
+*/
+type PartialObjectDeep<ObjectType extends object> = {
+	readonly [PropertyType in keyof ObjectType]: PartialDeep<ObjectType[PropertyType]>
+};

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -9,30 +9,34 @@ Use cases:
 ```
 import {PartialDeep} from 'type-fest';
 
-interface Baz {
-    qux: string;
-    corge: {
-        waldo: number[];
-        fred: string;
-    };
+const settings: Settings = {
+	textEditor: {
+		fontSize: 14;
+		fontColor: '#000000';
+		fontWeight: 400;
+	}
+	autocomplete: false;
+	autosave: true;
+};
+
+const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
+	return {...settings, ...savedSettings};
 }
 
-function foo(bar: PartialDeep<Baz>) { }
-
-foo({ corge: { waldo: [ 1, 2 ] } });
+settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```
 */
 export type PartialDeep<T> = {
-    [KeyType in keyof T]?:
-        T[KeyType] extends Map<infer MapKeyType, infer MapValueType>
-        ? PartialMap<MapKeyType, MapValueType>
-        : T[KeyType] extends Set<infer SetType>
-        ? PartialSet<SetType>
-        : T[KeyType] extends Array<infer ArrayType>
-        ? Array<PartialDeep<ArrayType>>
-        : T[KeyType] extends ReadonlyArray<infer ReadonlyArrayType>
-        ? ReadonlyArray<PartialDeep<ReadonlyArrayType>>
-        : PartialDeep<T[KeyType]>;
+	[KeyType in keyof T]?:
+		T[KeyType] extends Map<infer MapKeyType, infer MapValueType>
+		? PartialMap<MapKeyType, MapValueType>
+		: T[KeyType] extends Set<infer SetType>
+		? PartialSet<SetType>
+		: T[KeyType] extends Array<infer ArrayType>
+		? Array<PartialDeep<ArrayType>>
+		: T[KeyType] extends ReadonlyArray<infer ReadonlyArrayType>
+		? ReadonlyArray<PartialDeep<ReadonlyArrayType>>
+		: PartialDeep<T[KeyType]>;
 };
 
 /**

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,9 +1,9 @@
 import {Primitive} from './basic';
 
 /**
-Create a type from another type with all properties and nested properties set to optional.
+Create a type from another type with all keys and nested keys set to optional.
 
-Use cases:
+Use-cases:
 - Merging a default settings/config object with another object, the second object would be a deep partial of the default object.
 - Mocking and testing complex entities, where populating an entire object with its properties would be redundant in terms of the mock or test.
 
@@ -55,7 +55,7 @@ Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `P
 interface PartialSetDeep<T> extends Set<PartialDeep<T>> {}
 
 /**
-Same as `PartialDeep`, but accepts only `ReadonlyMap`s and  as inputs. Internal helper for `PartialDeep`.
+Same as `PartialDeep`, but accepts only `ReadonlyMap`s as inputs. Internal helper for `PartialDeep`.
 */
 interface PartialReadonlyMapDeep<KeyType, ValueType> extends ReadonlyMap<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
 

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -4,6 +4,7 @@ import {PartialDeep} from '..';
 const foo = {
 	baz: 'fred',
 	bar: {
+		function: (_) => {},
 		object: {key: 'value'},
 		string: 'waldo',
 		number: 1,
@@ -13,13 +14,22 @@ const foo = {
 		undefined: undefined, // eslint-disable-line object-shorthand
 		map: new Map<string, string>(),
 		set: new Set<string>(),
-		array: ['foo']
+		array: ['foo'],
+		tuple: ['foo'] as ['foo'],
+		readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
+		readonlySet: new Set<string>() as ReadonlySet<string>,
+		readonlyArray: ['foo'] as readonly string[],
+		readonlyTuple: ['foo'] as const
 	}
 };
 
 const partialDeepFoo: PartialDeep<typeof foo> = foo;
 
+/**
+this negative test should pass
 expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
+ */
+expectType<Function | undefined>(partialDeepFoo.bar!.function);
 expectType<object | undefined>(partialDeepFoo.bar!.object);
 expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);
@@ -30,3 +40,8 @@ expectType<undefined>(partialDeepFoo.bar!.undefined);
 expectType<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
 expectType<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
 expectType<string[] | undefined>(partialDeepFoo.bar!.array);
+expectType<['foo'] | undefined>(partialDeepFoo.bar!.tuple);
+expectType<ReadonlyMap<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.readonlyMap);
+expectType<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
+expectType<readonly string[] | undefined>(partialDeepFoo.bar!.readonlyArray);
+expectType<readonly ['foo'] | undefined>(partialDeepFoo.bar!.readonlyTuple);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,10 +1,10 @@
-import {expectError, expectType} from 'tsd';
+import {expectType} from 'tsd';
 import {PartialDeep} from '..';
 
 const foo = {
 	baz: 'fred',
 	bar: {
-		function: (_) => {},
+		function: (_: string): void => {},
 		object: {key: 'value'},
 		string: 'waldo',
 		number: 1,
@@ -26,10 +26,10 @@ const foo = {
 const partialDeepFoo: PartialDeep<typeof foo> = foo;
 
 /**
-this negative test should pass
+This negative test should pass:
 expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
  */
-expectType<Function | undefined>(partialDeepFoo.bar!.function);
+expectType<(_: string) => void | undefined>(partialDeepFoo.bar!.function);
 expectType<object | undefined>(partialDeepFoo.bar!.object);
 expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,28 +1,32 @@
 import {expectError, expectType} from 'tsd';
 import {PartialDeep} from '..';
 
-type Foo = {
-    baz: string;
-    bar: {
-        waldo: number[];
-        fred: string;
-        qux: {
-            corge: number;
-        };
-    };
+const foo = {
+    baz: 'fred',
+	bar: {
+        object: {key: 'value'},
+        string: 'waldo',
+        number: 1,
+        boolean: false,
+        symbol: Symbol('test'),
+        null: null,
+        undefined: undefined, // eslint-disable-line object-shorthand
+        map: new Map<string, string>(),
+        set: new Set<string>(),
+        array: ['foo']
+	}
 };
 
-type PartialDeepFoo = {
-    baz?: string;
-    bar?: {
-        waldo?: number[];
-        fred?: string;
-        qux?: {
-            corge?: number;
-        };
-    };
-};
+const partialDeepFoo: PartialDeep<typeof foo> = foo;
 
-const partialDeep: PartialDeep<Foo> = {bar: {fred: 'thump'}};
-expectType<PartialDeepFoo>(partialDeep);
-expectError(expectType<Partial<Foo>>(partialDeep));
+expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
+expectType<object | undefined>(partialDeepFoo.bar!.object);
+expectType<string | undefined>(partialDeepFoo.bar!.string);
+expectType<number | undefined>(partialDeepFoo.bar!.number);
+expectType<boolean | undefined>(partialDeepFoo.bar!.boolean);
+expectType<symbol | undefined>(partialDeepFoo.bar!.symbol);
+expectType<null | undefined>(partialDeepFoo.bar!.null);
+expectType<undefined>(partialDeepFoo.bar!.undefined);
+expectType<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
+expectType<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
+expectType<string[] | undefined>(partialDeepFoo.bar!.array);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,0 +1,28 @@
+import {expectError, expectType} from 'tsd';
+import {PartialDeep} from '..';
+
+type Foo = {
+    baz: string;
+    bar: {
+        waldo: number[];
+        fred: string;
+        qux: {
+            corge: number;
+        };
+    };
+};
+
+type PartialDeepFoo = {
+    baz?: string;
+    bar?: {
+        waldo?: number[];
+        fred?: string;
+        qux?: {
+            corge?: number;
+        };
+    };
+};
+
+const partialDeep: PartialDeep<Foo> = {bar: {fred: 'thump'}};
+expectType<PartialDeepFoo>(partialDeep);
+expectError(expectType<Partial<Foo>>(partialDeep));

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectError} from 'tsd';
 import {PartialDeep} from '..';
 
 const foo = {
@@ -25,11 +25,10 @@ const foo = {
 
 const partialDeepFoo: PartialDeep<typeof foo> = foo;
 
-/**
-This negative test should pass:
 expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
- */
-expectType<(_: string) => void | undefined>(partialDeepFoo.bar!.function);
+const partialDeepBar: PartialDeep<typeof foo.bar> = foo.bar;
+expectType<typeof partialDeepBar | undefined>(partialDeepFoo.bar);
+expectType<((_: string) => void) | undefined>(partialDeepFoo.bar!.function);
 expectType<object | undefined>(partialDeepFoo.bar!.object);
 expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);
@@ -39,9 +38,9 @@ expectType<null | undefined>(partialDeepFoo.bar!.null);
 expectType<undefined>(partialDeepFoo.bar!.undefined);
 expectType<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
 expectType<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
-expectType<string[] | undefined>(partialDeepFoo.bar!.array);
-expectType<['foo'] | undefined>(partialDeepFoo.bar!.tuple);
+expectType<Array<string | undefined> | undefined>(partialDeepFoo.bar!.array);
+expectType<['foo' | undefined] | undefined>(partialDeepFoo.bar!.tuple);
 expectType<ReadonlyMap<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.readonlyMap);
 expectType<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
-expectType<readonly string[] | undefined>(partialDeepFoo.bar!.readonlyArray);
-expectType<readonly ['foo'] | undefined>(partialDeepFoo.bar!.readonlyTuple);
+expectType<ReadonlyArray<string | undefined> | undefined>(partialDeepFoo.bar!.readonlyArray);
+expectType<readonly ['foo' | undefined] | undefined>(partialDeepFoo.bar!.readonlyTuple);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -2,18 +2,18 @@ import {expectError, expectType} from 'tsd';
 import {PartialDeep} from '..';
 
 const foo = {
-    baz: 'fred',
+	baz: 'fred',
 	bar: {
-        object: {key: 'value'},
-        string: 'waldo',
-        number: 1,
-        boolean: false,
-        symbol: Symbol('test'),
-        null: null,
-        undefined: undefined, // eslint-disable-line object-shorthand
-        map: new Map<string, string>(),
-        set: new Set<string>(),
-        array: ['foo']
+		object: {key: 'value'},
+		string: 'waldo',
+		number: 1,
+		boolean: false,
+		symbol: Symbol('test'),
+		null: null,
+		undefined: undefined, // eslint-disable-line object-shorthand
+		map: new Map<string, string>(),
+		set: new Set<string>(),
+		array: ['foo']
 	}
 };
 


### PR DESCRIPTION
Fixes #18 

Create a type from another type with all properties set to optional and the nested properties of all properties set to optional, as opposed to the [`Partial<T>`](https://github.com/Microsoft/TypeScript/blob/2961bc3fc0ea1117d4e53bc8e97fa76119bc33e3/src/lib/es5.d.ts#L1401-L1406) type which constructs a type with properties of T that have a depth of 1 set to optional.

**Example**

```TypeScript
import {PartialDeep} from 'type-fest';

interface Baz {
    qux: string;
    corge: {
        waldo: number[];
        fred: string;
    };
}

function baz(bar: Partial<Baz>) { }
function foo(bar: PartialDeep<Baz>) { }

baz(({ corge: { waldo: [ 1, 2 ] } }); // Property ‘fred’ is missing in type ‘{waldo: number[]; fred: string;}’
foo({ corge: { waldo: [ 1, 2 ] } }); // Passes
```

**Use cases**

* Merging a default settings/config object with another object, the second object would be a deep partial of the default object.
* Mocking and testing complex entities, where populating an entire object with it's properties would be redundant in terms of the mock or test.
