### PR TITLE
Add an optional “Argument” type to the “Class” type

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -17,7 +17,7 @@ export type Primitive =
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 */
-export type Class<T = unknown, Arguments extends any[] = []> = new(...arguments_: Arguments) => T;
+export type Class<T = unknown, Arguments extends any[] = any[]> = new(...arguments_: Arguments) => T;
 
 /**
 Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -17,7 +17,7 @@ export type Primitive =
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 */
-export type Class<T = unknown> = new(...arguments_: any[]) => T;
+export type Class<T = unknown, Arguments extends any[] = []> = new(...arguments_: Arguments) => T;
 
 /**
 Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -1,0 +1,22 @@
+import {expectError} from 'tsd';
+import {Class} from '..';
+
+class Foo {
+	constructor(x: number, y: any) {
+		console.log(x, y);
+	}
+
+	method(): void {}
+}
+
+function fn(Cls: Class<Foo>): Foo {
+	return new Cls(1, '', 123);
+}
+
+function fn2(Cls: Class<Foo, [number, number]>): Foo {
+	expectError(new Cls(1, ''));
+	return new Cls(1, 2);
+}
+
+fn(Foo);
+fn2(Foo);


### PR DESCRIPTION
I've made sure the `Class` type can be used to more strictly type classes that take some arguments in their constructors, as discussed [here](https://github.com/sindresorhus/type-fest/issues/51)