### PR TITLE
Allow all keys to be optional in the `JsonObject` type

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -40,7 +40,7 @@ Matches a JSON object.
 
 This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.
 */
-export type JsonObject = {[key: string]: JsonValue};
+export type JsonObject = {[key: string]?: JsonValue};
 
 /**
 Matches a JSON array.

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -40,7 +40,7 @@ Matches a JSON object.
 
 This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.
 */
-export type JsonObject = {[key: string]?: JsonValue};
+export type JsonObject = {[key in string]?: JsonValue};
 
 /**
 Matches a JSON array.

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -40,7 +40,7 @@ Matches a JSON object.
 
 This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.
 */
-export type JsonObject = {[key in string]?: JsonValue};
+export type JsonObject = {[Key in string]?: JsonValue};
 
 /**
 Matches a JSON array.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

By right, when an object has certain keys optional, the object is still a valid `JsonObject`. So, it makes more sense to allow all keys to be optional. Indeed, an `JsonObject` doesn't always have values for all string indexes.

This resolves https://github.com/sindresorhus/type-fest/issues/64 .