### PR TITLE
Add `repository.directory` to `PackageJson` type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -375,6 +375,7 @@ export type PackageJson = {
 	| {
 		type: string;
 		url: string;
+		directory?: string;
 	};
 
 	/**

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -375,6 +375,11 @@ export type PackageJson = {
 	| {
 		type: string;
 		url: string;
+		/**
+		Path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
+
+		[Read more.](https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md)
+		*/
 		directory?: string;
 	};
 

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -376,7 +376,7 @@ export type PackageJson = {
 		type: string;
 		url: string;
 		/**
-		Path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
+		Relative path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
 
 		[Read more.](https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md)
 		*/

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -375,6 +375,7 @@ export type PackageJson = {
 	| {
 		type: string;
 		url: string;
+
 		/**
 		Relative path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
 

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -21,7 +21,7 @@ expectType<string | undefined>(packageJson.types);
 expectType<string | undefined>(packageJson.typings);
 expectType<string | string[] | undefined>(packageJson.man);
 expectType<PackageJson.DirectoryLocations | undefined>(packageJson.directories);
-expectType<{type: string; url: string} | string | undefined>(
+expectType<{type: string; url: string; directory?: string} | string | undefined>(
 	packageJson.repository
 );
 expectType<PackageJson.Scripts | undefined>(packageJson.scripts);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

It's common for packages coming from monorepos to have additional `directory` field to `repository` object.

Few examples:
- [jest-cli/package.json](https://github.com/facebook/jest/blob/823677901b9632dbfb9397bf5eef2d32b78527a4/packages/jest-cli/package.json#L37)
- [react/package.json](https://github.com/facebook/react/blob/9fd760ce75fd76716888997852ca85394eeab49a/packages/react/package.json#L23)
- [@vue/cli/package.json](https://github.com/vuejs/vue-cli/blob/8fcea225b7b4406ff7c03e34d4e962b45d78ef9f/packages/%40vue/cli/package.json#L11)
