### PR TITLE
Add `ConditionalKeys`, `ConditionalPick` and `ConditionalExcept` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,9 @@ export {Opaque} from './source/opaque';
 export {SetOptional} from './source/set-optional';
 export {SetRequired} from './source/set-required';
 export {PromiseValue} from './source/promise-value';
+export {ConditionalExcept} from './source/conditional-except';
+export {ConditionalKeys} from './source/conditional-keys';
+export {ConditionalPick} from './source/conditional-pick';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -76,8 +76,8 @@ Click the type names for complete docs.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`PromiseValue`](source/promise-value.d.ts) - Returns the type that is wrapped inside a `Promise` type.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
-- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape when the values extend the given `Condition` type.
-- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape when the values extend the given `Condition` type.
+- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
+- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -76,8 +76,8 @@ Click the type names for complete docs.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`PromiseValue`](source/promise-value.d.ts) - Returns the type that is wrapped inside a `Promise` type.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
-- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a given shape when the values extend the given `Condition` type.
-- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a given shape when the values extend the given `Condition` type.
+- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape when the values extend the given `Condition` type.
+- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape when the values extend the given `Condition` type.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,9 @@ Click the type names for complete docs.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`PromiseValue`](source/promise-value.d.ts) - Returns the type that is wrapped inside a `Promise` type.
+- [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract all keys from a shape where values extend the provided `Condition` type.
+- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except select properties from a given shape when the values extend the provided `Condition` type.
+- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except remove properties from a given shape only when the values extend the provided `Condition` type.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -75,9 +75,9 @@ Click the type names for complete docs.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`PromiseValue`](source/promise-value.d.ts) - Returns the type that is wrapped inside a `Promise` type.
-- [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract all keys from a shape where values extend the provided `Condition` type.
-- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except select properties from a given shape when the values extend the provided `Condition` type.
-- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except remove properties from a given shape only when the values extend the provided `Condition` type.
+- [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
+- [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a given shape when the values extend the given `Condition` type.
+- [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a given shape when the values extend the given `Condition` type.
 
 ### Miscellaneous
 

--- a/source/conditional-except.d.ts
+++ b/source/conditional-except.d.ts
@@ -1,0 +1,45 @@
+import {Except} from './except';
+import {ConditionalKeys} from './conditional-keys';
+
+/**
+Exclude the keys from any shape which matches the provided `Condition`.
+
+This is useful when you want to create a new type with a specific set of keys from a shape. For example, you might want to exclude all the primitive properties from a class and form a new shape containing everything but the primitive properties.
+
+@example
+```
+import {Primitive, ConditionalExcept} from 'type-fest';
+
+class Awesome {
+	name: string;
+	successes: number;
+	failures: bigint;
+
+	run() {}
+}
+
+type ExceptPrimitivesFromAwesome = ConditionalExcept<Awesome, Primitive>;
+// => { run: () => void; }
+```
+
+A simpler and more contrived example is below.
+
+@example
+```
+import {ConditionalExcept} from 'type-fest';
+
+interface Example {
+	a: string;
+	b: string | number;
+	c: () => void;
+	d: {}
+}
+
+type NonStringKeysOnly = ConditionalExcept<Example, string>;
+// => { b: string | number; c: () => void; d: {}; }
+```
+*/
+export type ConditionalExcept<Base, Condition> = Except<
+	Base,
+	ConditionalKeys<Base, Condition>
+>;

--- a/source/conditional-except.d.ts
+++ b/source/conditional-except.d.ts
@@ -2,7 +2,7 @@ import {Except} from './except';
 import {ConditionalKeys} from './conditional-keys';
 
 /**
-Exclude the keys from any shape which matches the provided `Condition`.
+Exclude keys from a shape that matches the given `Condition`.
 
 This is useful when you want to create a new type with a specific set of keys from a shape. For example, you might want to exclude all the primitive properties from a class and form a new shape containing everything but the primitive properties.
 
@@ -19,10 +19,8 @@ class Awesome {
 }
 
 type ExceptPrimitivesFromAwesome = ConditionalExcept<Awesome, Primitive>;
-// => { run: () => void; }
+//=> {run: () => void}
 ```
-
-A simpler and more contrived example is below.
 
 @example
 ```
@@ -32,11 +30,11 @@ interface Example {
 	a: string;
 	b: string | number;
 	c: () => void;
-	d: {}
+	d: {};
 }
 
 type NonStringKeysOnly = ConditionalExcept<Example, string>;
-// => { b: string | number; c: () => void; d: {}; }
+//=> {b: string | number; c: () => void; d: {}}
 ```
 */
 export type ConditionalExcept<Base, Condition> = Except<

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -1,0 +1,43 @@
+/**
+Extract the keys from a type where the value type of the key extends the provided condition.
+
+Internally this is used for the `ConditionalPick` and `ConditionalExcept` types.
+
+@example
+```
+import {ConditionalKeys} from 'type-fest';
+
+interface Example {
+	a: string;
+	b: string | number;
+	c?: string;
+	d: {}
+}
+
+type StringKeysOnly = ConditionalKeys<Example, string>;
+// => 'a'
+```
+
+To support partial types make sure your `Condition` is a union of undefined `string | undefined` as demonstrated below.
+
+@example
+```
+type StringKeysAndUndefined = ConditionalKeys<Example, string | undefined>;
+// => 'a' | 'c'
+```
+*/
+export type ConditionalKeys<Base, Condition> = NonNullable<
+	// Wrap in NonNullable to strip away the `undefined` type from the produced union.
+	{
+		// Map through all the keys of the provided base type.
+		[Key in keyof Base]:
+			// Pick only keys with types extending the `Condition` type provided.
+			Base[Key] extends Condition
+				// Retain this key since the condition passes.
+				? Key
+				// Discard this key since the condition fails.
+				: never;
+
+	// Convert the produced object into a union type of the keys which pass the conditional test.
+	}[keyof Base]
+>;

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -1,5 +1,5 @@
 /**
-Extract the keys from a type where the value type of the key extends the provided condition.
+Extract the keys from a type where the value type of the key extends the given `Condition`.
 
 Internally this is used for the `ConditionalPick` and `ConditionalExcept` types.
 
@@ -11,33 +11,33 @@ interface Example {
 	a: string;
 	b: string | number;
 	c?: string;
-	d: {}
+	d: {};
 }
 
 type StringKeysOnly = ConditionalKeys<Example, string>;
-// => 'a'
+//=> 'a'
 ```
 
-To support partial types make sure your `Condition` is a union of undefined `string | undefined` as demonstrated below.
+To support partial types, make sure your `Condition` is a union of undefined (for example, `string | undefined`) as demonstrated below.
 
 @example
 ```
 type StringKeysAndUndefined = ConditionalKeys<Example, string | undefined>;
-// => 'a' | 'c'
+//=> 'a' | 'c'
 ```
 */
 export type ConditionalKeys<Base, Condition> = NonNullable<
-	// Wrap in NonNullable to strip away the `undefined` type from the produced union.
+	// Wrap in `NonNullable` to strip away the `undefined` type from the produced union.
 	{
-		// Map through all the keys of the provided base type.
+		// Map through all the keys of the given base type.
 		[Key in keyof Base]:
-			// Pick only keys with types extending the `Condition` type provided.
+			// Pick only keys with types extending the given `Condition` type.
 			Base[Key] extends Condition
 				// Retain this key since the condition passes.
 				? Key
 				// Discard this key since the condition fails.
 				: never;
 
-	// Convert the produced object into a union type of the keys which pass the conditional test.
+	// Convert the produced object into a union type of the keys which passed the conditional test.
 	}[keyof Base]
 >;

--- a/source/conditional-pick.d.ts
+++ b/source/conditional-pick.d.ts
@@ -1,9 +1,9 @@
 import {ConditionalKeys} from './conditional-keys';
 
 /**
-Pick all keys from them shape which match the provided `Condition`.
+Pick keys from the shape that matches the given `Condition`.
 
-This is useful when you want to create a new type from a specific subset from an already created type. For example you might want to pick all the primitive properties from a class and form a new automatically derived type.
+This is useful when you want to create a new type from a specific subset of an existing type. For example, you might want to pick all the primitive properties from a class and form a new automatically derived type.
 
 @example
 ```
@@ -18,10 +18,8 @@ class Awesome {
 }
 
 type PickPrimitivesFromAwesome = ConditionalPick<Awesome, Primitive>;
-// => { name: string; successes: number; failures: bigint; }
+//=> {name: string; successes: number; failures: bigint}
 ```
-
-A simpler and more contrived example is below.
 
 @example
 ```
@@ -31,11 +29,11 @@ interface Example {
 	a: string;
 	b: string | number;
 	c: () => void;
-	d: {}
+	d: {};
 }
 
 type StringKeysOnly = ConditionalPick<Example, string>;
-// => { a: string; }
+//=> {a: string}
 ```
 */
 export type ConditionalPick<Base, Condition> = Pick<

--- a/source/conditional-pick.d.ts
+++ b/source/conditional-pick.d.ts
@@ -1,0 +1,44 @@
+import {ConditionalKeys} from './conditional-keys';
+
+/**
+Pick all keys from them shape which match the provided `Condition`.
+
+This is useful when you want to create a new type from a specific subset from an already created type. For example you might want to pick all the primitive properties from a class and form a new automatically derived type.
+
+@example
+```
+import {Primitive, ConditionalPick} from 'type-fest';
+
+class Awesome {
+	name: string;
+	successes: number;
+	failures: bigint;
+
+	run() {}
+}
+
+type PickPrimitivesFromAwesome = ConditionalPick<Awesome, Primitive>;
+// => { name: string; successes: number; failures: bigint; }
+```
+
+A simpler and more contrived example is below.
+
+@example
+```
+import {ConditionalPick} from 'type-fest';
+
+interface Example {
+	a: string;
+	b: string | number;
+	c: () => void;
+	d: {}
+}
+
+type StringKeysOnly = ConditionalPick<Example, string>;
+// => { a: string; }
+```
+*/
+export type ConditionalPick<Base, Condition> = Pick<
+	Base,
+	ConditionalKeys<Base, Condition>
+>;

--- a/test-d/conditional-except.ts
+++ b/test-d/conditional-except.ts
@@ -19,10 +19,10 @@ interface Example {
 }
 
 declare const exampleConditionalExcept: ConditionalExcept<Example, string>;
-expectType<{ b?: string | number; c?: string; d: Record<string, unknown> }>(exampleConditionalExcept);
+expectType<{b?: string | number; c?: string; d: Record<string, unknown>}>(exampleConditionalExcept);
 
 declare const awesomeConditionalExcept: ConditionalExcept<Awesome, Primitive>;
-expectType<{ run: () => void }>(awesomeConditionalExcept);
+expectType<{run: () => void}>(awesomeConditionalExcept);
 
 declare const exampleConditionalExceptWithUndefined: ConditionalExcept<Example, string | undefined>;
-expectType<{ b?: string | number; d: Record<string, unknown> }>(exampleConditionalExceptWithUndefined);
+expectType<{b?: string | number; d: Record<string, unknown>}>(exampleConditionalExceptWithUndefined);

--- a/test-d/conditional-except.ts
+++ b/test-d/conditional-except.ts
@@ -1,0 +1,28 @@
+import {expectType} from 'tsd';
+import {ConditionalExcept, Primitive} from '..';
+
+class Awesome {
+	name!: string;
+	successes!: number;
+	failures!: bigint;
+
+	run(): void {
+		// Empty
+	}
+}
+
+interface Example {
+	a: string;
+	b?: string | number;
+	c?: string;
+	d: Record<string, unknown>;
+}
+
+declare const exampleConditionalExcept: ConditionalExcept<Example, string>;
+expectType<{ b?: string | number; c?: string; d: Record<string, unknown> }>(exampleConditionalExcept);
+
+declare const awesomeConditionalExcept: ConditionalExcept<Awesome, Primitive>;
+expectType<{ run: () => void }>(awesomeConditionalExcept);
+
+declare const exampleConditionalExceptWithUndefined: ConditionalExcept<Example, string | undefined>;
+expectType<{ b?: string | number; d: Record<string, unknown> }>(exampleConditionalExceptWithUndefined);

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -1,0 +1,15 @@
+import {expectType} from 'tsd';
+import {ConditionalKeys} from '..';
+
+interface Example {
+	a: string;
+	b?: string | number;
+	c?: string;
+	d: Record<string, unknown>;
+}
+
+declare const exampleConditionalKeys: ConditionalKeys<Example, string>;
+expectType<'a'>(exampleConditionalKeys);
+
+declare const exampleConditionalKeysWithUndefined: ConditionalKeys<Example, string | undefined>;
+expectType<'a' | 'c'>(exampleConditionalKeysWithUndefined);

--- a/test-d/conditional-pick.ts
+++ b/test-d/conditional-pick.ts
@@ -1,0 +1,28 @@
+import {expectType} from 'tsd';
+import {ConditionalPick, Primitive} from '..';
+
+class Awesome {
+	name!: string;
+	successes!: number;
+	failures!: bigint;
+
+	run(): void {
+		// Empty
+	}
+}
+
+interface Example {
+	a: string;
+	b?: string | number;
+	c?: string;
+	d: Record<string, unknown>;
+}
+
+declare const exampleConditionalPick: ConditionalPick<Example, string>;
+expectType< { a: string }>(exampleConditionalPick);
+
+declare const awesomeConditionalPick: ConditionalPick<Awesome, Primitive>;
+expectType<{ name: string; successes: number; failures: bigint }>(awesomeConditionalPick);
+
+declare const exampleConditionalPickWithUndefined: ConditionalPick<Example, string | undefined>;
+expectType<{ a: string; c?: string }>(exampleConditionalPickWithUndefined);

--- a/test-d/conditional-pick.ts
+++ b/test-d/conditional-pick.ts
@@ -19,10 +19,10 @@ interface Example {
 }
 
 declare const exampleConditionalPick: ConditionalPick<Example, string>;
-expectType< { a: string }>(exampleConditionalPick);
+expectType< {a: string}>(exampleConditionalPick);
 
 declare const awesomeConditionalPick: ConditionalPick<Awesome, Primitive>;
-expectType<{ name: string; successes: number; failures: bigint }>(awesomeConditionalPick);
+expectType<{name: string; successes: number; failures: bigint}>(awesomeConditionalPick);
 
 declare const exampleConditionalPickWithUndefined: ConditionalPick<Example, string | undefined>;
-expectType<{ a: string; c?: string }>(exampleConditionalPickWithUndefined);
+expectType<{a: string; c?: string}>(exampleConditionalPickWithUndefined);


### PR DESCRIPTION
### Description

Add types to conditionally pick and exclude properties from any shape based on the provided `Condition`. 

This type comes in handy quite a lot in my library code bases where transforming types or picking properties based on conditions helps dynamically drive automatic inference. 

Any suggestions for better names is welcome. Since this code base provides the `Except` type I've used the name `ConditionalExcept`. However, it might be more understandable to use `ConditionalOmit`.
