### PR TITLE
Add `workspaces` to `PackageJson` type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -265,37 +265,40 @@ declare namespace PackageJson {
 		An array of workspace pattern strings which contain the workspace packages.
 		*/
 		packages?: WorkspacePattern[];
-		/**
-		`nohoist` is designed to solve the problem of packages which break when their node_modules are moved to the root workspace directory - a process known as hoisting. For these packages both within your workspace and also some that have been installed via node_modules it is important to have a mechanism for preventing the default Yarn workspace behavior. By adding workspace pattern strings here, Yarn will resume non-workspace behavior for any package which matches the patterns defined.
 
-		More information can be found via this blog posthttps://classic.yarnpkg.com/blog/2018/02/15/nohoist/
+		/**
+		Designed to solve the problem of packages which break when their `node_modules` are moved to the root workspace directory - a process known as hoisting. For these packages, both within your workspace, and also some that have been installed via `node_modules`, it is important to have a mechanism for preventing the default Yarn workspace behavior. By adding workspace pattern strings here, Yarn will resume non-workspace behavior for any package which matches the defined patterns.
+
+		[Read more](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)
 		*/
 		nohoist?: WorkspacePattern[];
 	}
 
 	/**
-	A workspace pattern points to a folder or group of folders which contain packages that should be included in the workspace installation process. The patterns are handled with minimatch https://github.com/isaacs/minimatch
+	A workspace pattern points to a directory or group of directories which contain packages that should be included in the workspace installation process.
+	
+	The patterns are handled with [minimatch](https://github.com/isaacs/minimatch).
 
 	@example
-	`docs` -> Include the docs folder and install it's dependencies.
-	`packages/*` -> Include all nested folders within the packages folder like `packages/cli` and `packages/core`.
+	`docs` → Include the docs directory and install its dependencies.
+	`packages/*` → Include all nested directories within the packages directory, like `packages/cli` and `packages/core`.
 	*/
 	type WorkspacePattern = string;
 
 	export interface YarnConfiguration {
 		/**
-		Used to configure Yarn workspaces (https://classic.yarnpkg.com/docs/workspaces/).
+		Used to configure [Yarn workspaces](https://classic.yarnpkg.com/docs/workspaces/).
 
 		Workspaces allow you to manage multiple packages within the same repository in such a way that you only need to run `yarn install` once to install all of them in a single pass.
 
-		Please note the top level `private` property of the `package.json` **must** be set to true in order to use workspaces.
+		Please note that the top-level `private` property of `package.json` **must** be set to `true` in order to use workspaces.
 		*/
 		workspaces?: WorkspacePattern[] | WorkspaceConfig;
 
 		/**
-		If your package only allows one version of a given dependency, and you’d like to enforce the same behavior as `yarn install --flat` on the command line, set this to `true`.
+		If your package only allows one version of a given dependency, and you’d like to enforce the same behavior as `yarn install --flat` on the command-line, set this to `true`.
 
-		Note that if your `package.json` contains `"flat": true` and other packages depend on yours (e.g. you are building a library rather than an application), those other packages will also need `"flat": true` in their `package.json` or be installed with `yarn install --flat` on the command-line.
+		Note that if your `package.json` contains `"flat": true` and other packages depend on yours (e.g. you are building a library rather than an app), those other packages will also need `"flat": true` in their `package.json` or be installed with `yarn install --flat` on the command-line.
 		*/
 		flat?: boolean;
 

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -257,7 +257,41 @@ declare namespace PackageJson {
 		typings?: string;
 	}
 
+	/**
+	An alternative configuration for Yarn workspaces.
+	*/
+	export interface WorkspaceConfig {
+		/**
+		An array of workspace pattern strings which contain the workspace packages.
+		*/
+		packages?: WorkspacePattern[];
+		/**
+		`nohoist` is designed to solve the problem of packages which break when their node_modules are moved to the root workspace directory - a process known as hoisting. For these packages both within your workspace and also some that have been installed via node_modules it is important to have a mechanism for preventing the default Yarn workspace behavior. By adding workspace pattern strings here, Yarn will resume non-workspace behavior for any package which matches the patterns defined.
+
+		More information can be found via this blog posthttps://classic.yarnpkg.com/blog/2018/02/15/nohoist/
+		*/
+		nohoist?: WorkspacePattern[];
+	}
+
+	/**
+	A workspace pattern points to a folder or group of folders which contain packages that should be included in the workspace installation process. The patterns are handled with minimatch https://github.com/isaacs/minimatch
+
+	@example
+	`docs` -> Include the docs folder and install it's dependencies.
+	`packages/*` -> Include all nested folders within the packages folder like `packages/cli` and `packages/core`.
+	*/
+	type WorkspacePattern = string;
+
 	export interface YarnConfiguration {
+		/**
+		Used to configure Yarn workspaces (https://classic.yarnpkg.com/docs/workspaces/).
+
+		Workspaces allow you to manage multiple packages within the same repository in such a way that you only need to run `yarn install` once to install all of them in a single pass.
+
+		Please note the top level `private` property of the `package.json` **must** be set to true in order to use workspaces.
+		*/
+		workspaces?: WorkspacePattern[] | WorkspaceConfig;
+
 		/**
 		If your package only allows one version of a given dependency, and you’d like to enforce the same behavior as `yarn install --flat` on the command line, set this to `true`.
 

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -35,6 +35,7 @@ expectType<PackageJson.Dependency | undefined>(packageJson.peerDependencies);
 expectType<string[] | undefined>(packageJson.bundleDependencies);
 expectType<string[] | undefined>(packageJson.bundledDependencies);
 expectType<PackageJson.Dependency | undefined>(packageJson.resolutions);
+expectType<PackageJson.WorkspaceConfig | string[] | undefined>(packageJson.workspaces);
 expectType<{[engineName: string]: string} | undefined>(packageJson.engines);
 expectType<boolean | undefined>(packageJson.engineStrict);
 expectType<


### PR DESCRIPTION
### Description

Yarn workspaces are becoming a more prominent feature of the `package.json` file.