### PR TITLE
fix: make `TsConfigJson` a valid `JsonObject`

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -1,3 +1,5 @@
+import {JsonObject} from './basic';
+
 declare namespace TsConfigJson {
 	namespace CompilerOptions {
 		export type JSX =
@@ -147,8 +149,7 @@ declare namespace TsConfigJson {
 			| 'webworker'
 			| 'webworker.importscripts';
 
-		export interface Plugin {
-			[key: string]: unknown;
+		export interface Plugin extends JsonObject{
 			/**
 			Plugin name.
 			*/
@@ -817,7 +818,7 @@ declare namespace TsConfigJson {
 	}
 }
 
-export interface TsConfigJson {
+export interface TsConfigJson extends JsonObject {
 	/**
 	Instructs the TypeScript compiler how to compile `.ts` files.
 	*/

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import {TsConfigJson} from '..';
+import {TsConfigJson, JsonObject} from '..';
 
 const tsConfig: TsConfigJson = {};
 
@@ -11,3 +11,6 @@ expectType<string[] | undefined>(tsConfig.files);
 expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
+
+const createTsConfig = (): TsConfigJson => tsConfig;
+expectType<JsonObject>(createTsConfig());


### PR DESCRIPTION
Similar to #80 for turning the `TsConfigJson` type into a valid `JsonObject`.