### PR TITLE
Add `UnionToIntersection` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export {AsyncReturnType} from './source/async-return-type';
 export {ConditionalExcept} from './source/conditional-except';
 export {ConditionalKeys} from './source/conditional-keys';
 export {ConditionalPick} from './source/conditional-pick';
+export {UnionToIntersection} from './source/union-to-intersection';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Click the type names for complete docs.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
+- [`UnionToIntersection`](source/union-to-intersection.d.ts) - Converts a union type to an intersection type.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Click the type names for complete docs.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
-- [`UnionToIntersection`](source/union-to-intersection.d.ts) - Converts a union type to an intersection type.
+- [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 
 ### Miscellaneous
 

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -1,3 +1,5 @@
+import {Except} from './except';
+
 /**
 Create a type that makes the given keys optional. The remaining keys are kept as is. The sister of the `SetRequired` type.
 
@@ -23,7 +25,7 @@ type SomeOptional = SetOptional<Foo, 'b' | 'c'>;
 */
 export type SetOptional<BaseType, Keys extends keyof BaseType = keyof BaseType> =
 	// Pick just the keys that are not optional from the base type.
-	Pick<BaseType, Exclude<keyof BaseType, Keys>> &
+	Except<BaseType, Keys> &
 	// Pick the keys that should be optional from the base type and make them optional.
 	Partial<Pick<BaseType, Keys>> extends
 	// If `InferredType` extends the previous, then for each key, use the inferred type key.

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -1,3 +1,5 @@
+import {Except} from './except';
+
 /**
 Create a type that makes the given keys required. The remaining keys are kept as is. The sister of the `SetOptional` type.
 
@@ -23,7 +25,7 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType = keyof BaseType> =
 	// Pick just the keys that are not required from the base type.
-	Pick<BaseType, Exclude<keyof BaseType, Keys>> &
+	Except<BaseType, Keys> &
 	// Pick the keys that should be required from the base type and make them required.
 	Required<Pick<BaseType, Keys>> extends
 	// If `InferredType` extends the previous, then for each key, use the inferred type key.

--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -1,23 +1,22 @@
 /**
-A helpful utility which maps a union type to an intersection type using [distributive conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+Convert a union type to an intersection type using [distributive conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
 
-Inspired by a [stack overflow answer](https://stackoverflow.com/a/50375286/2172153).
+Inspired by [this Stack Overflow answer](https://stackoverflow.com/a/50375286/2172153).
 
 @example
-
-```ts
+```
 import {UnionToIntersection} from 'type-fest';
 
 type Union = {the(): void} | {great(arg: string): void} | {escape: boolean};
+
 type Intersection = UnionToIntersection<Union>;
 //=> {the(): void; great(arg: string): void; escape: boolean};
 ```
 
-A more applicable example which could make it's way into your library code follows.
+A more applicable example which could make its way into your library code follows.
 
 @example
-
-```ts
+```
 import {UnionToIntersection} from 'type-fest';
 
 class CommandOne {
@@ -34,7 +33,7 @@ class CommandTwo {
   }
 }
 
-const union = [new CommandOne(), new CommandTwo()].map(instance => instance.commands)
+const union = [new CommandOne(), new CommandTwo()].map(instance => instance.commands);
 type Union = typeof union;
 //=> {a1(): void; b1(): void} | {a2(argA: string): void; b2(argB: string): void}
 

--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -20,17 +20,17 @@ A more applicable example which could make its way into your library code follow
 import {UnionToIntersection} from 'type-fest';
 
 class CommandOne {
-  commands: {
-    a1: () => undefined,
-    b1: () => undefined,
-  }
+	commands: {
+		a1: () => undefined,
+		b1: () => undefined,
+	}
 }
 
 class CommandTwo {
-  commands: {
-    a2: (argA: string) => undefined,
-    b2: (argB: string) => undefined,
-  }
+	commands: {
+		a2: (argA: string) => undefined,
+		b2: (argB: string) => undefined,
+	}
 }
 
 const union = [new CommandOne(), new CommandTwo()].map(instance => instance.commands);
@@ -42,17 +42,17 @@ type Intersection = UnionToIntersection<Union>;
 ```
 */
 export type UnionToIntersection<Union> = (
-  // `extends any` is always going to be the case and is used to convert the
-  // `Union` into a [distributive conditional
-  // type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
-  Union extends any
-    // The union type is used as the only argument to a function since the union
-    // of function arguments is an intersection.
-    ? (distributedUnion: Union) => void
-    // This won't happen.
-    : never
-    // Infer the `Intersection` type since TypeScript represents the positional
-    // arguments of unions of functions as an intersection of the union.
-  ) extends ((mergedIntersection: infer Intersection) => void)
-    ? Intersection
-    : never;
+	// `extends any` is always going to be the case and is used to convert the
+	// `Union` into a [distributive conditional
+	// type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+	Union extends unknown
+		// The union type is used as the only argument to a function since the union
+		// of function arguments is an intersection.
+		? (distributedUnion: Union) => void
+		// This won't happen.
+		: never
+		// Infer the `Intersection` type since TypeScript represents the positional
+		// arguments of unions of functions as an intersection of the union.
+	) extends ((mergedIntersection: infer Intersection) => void)
+		? Intersection
+		: never;

--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -1,0 +1,59 @@
+/**
+A helpful utility which maps a union type to an intersection type using [distributive conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+
+Inspired by a [stack overflow answer](https://stackoverflow.com/a/50375286/2172153).
+
+@example
+
+```ts
+import {UnionToIntersection} from 'type-fest';
+
+type Union = {the(): void} | {great(arg: string): void} | {escape: boolean};
+type Intersection = UnionToIntersection<Union>;
+//=> {the(): void; great(arg: string): void; escape: boolean};
+```
+
+A more applicable example which could make it's way into your library code follows.
+
+@example
+
+```ts
+import {UnionToIntersection} from 'type-fest';
+
+class CommandOne {
+  commands: {
+    a1: () => undefined,
+    b1: () => undefined,
+  }
+}
+
+class CommandTwo {
+  commands: {
+    a2: (argA: string) => undefined,
+    b2: (argB: string) => undefined,
+  }
+}
+
+const union = [new CommandOne(), new CommandTwo()].map(instance => instance.commands)
+type Union = typeof union;
+//=> {a1(): void; b1(): void} | {a2(argA: string): void; b2(argB: string): void}
+
+type Intersection = UnionToIntersection<Union>;
+//=> {a1(): void; b1(): void; a2(argA: string): void; b2(argB: string): void}
+```
+*/
+export type UnionToIntersection<Union> = (
+  // `extends any` is always going to be the case and is used to convert the
+  // `Union` into a [distributive conditional
+  // type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+  Union extends any
+    // The union type is used as the only argument to a function since the union
+    // of function arguments is an intersection.
+    ? (distributedUnion: Union) => void
+    // This won't happen.
+    : never
+    // Infer the `Intersection` type since TypeScript represents the positional
+    // arguments of unions of functions as an intersection of the union.
+  ) extends ((mergedIntersection: infer Intersection) => void)
+    ? Intersection
+    : never;

--- a/test-d/union-to-intersection.ts
+++ b/test-d/union-to-intersection.ts
@@ -1,0 +1,9 @@
+import {expectType} from 'tsd';
+import {UnionToIntersection} from '..';
+
+declare const intersection1: UnionToIntersection<{a: string} | {b: number}>;
+expectType<{a: string; b: number}>(intersection1);
+
+// Creates a union of matching properties.
+declare const intersection2: UnionToIntersection<{a: string} | {b: number} | {a: () => void}>;
+expectType<{a: string | (() => void); b: number}>(intersection2);


### PR DESCRIPTION
## Description

Creates an intersection type from a union type. This has been useful for me in [library](https://github.com/remirror/remirror/blob/b096ed1dd300d682e28f9a7721ad9debbe1c1eb3/%40remirror/core/src/extension-types.ts#L181-L186) code.