### PR TITLE
Upgrade `tsd` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"json"
 	],
 	"devDependencies": {
-		"tsd": "^0.7.3",
+		"tsd": "^0.11.0",
 		"xo": "^0.27.2"
 	},
 	"types": "index.d.ts",

--- a/test-d/merge-exclusive.ts
+++ b/test-d/merge-exclusive.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectError, expectAssignable} from 'tsd';
 import {MergeExclusive} from '..';
 
 interface BaseOptions {
@@ -18,10 +18,10 @@ type Options = MergeExclusive<ExclusiveVariation1, ExclusiveVariation2>;
 const exclusiveVariation1: Options = {exclusive1: true};
 const exclusiveVariation2: Options = {exclusive2: 1};
 
-expectType<{option?: string; exclusive1: boolean; exclusive2?: string}>(
+expectAssignable<{option?: string; exclusive1: boolean; exclusive2?: string}>(
 	exclusiveVariation1
 );
-expectType<{option?: string; exclusive1?: string; exclusive2: number}>(
+expectAssignable<{option?: string; exclusive1?: string; exclusive2: number}>(
 	exclusiveVariation2
 );
 

--- a/test-d/merge.ts
+++ b/test-d/merge.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectAssignable} from 'tsd';
 import {Merge} from '..';
 
 type Foo = {
@@ -11,4 +11,4 @@ type Bar = {
 };
 
 const ab: Merge<Foo, Bar> = {a: 1, b: 2};
-expectType<{a: number; b: number}>(ab);
+expectAssignable<{a: number; b: number}>(ab);

--- a/test-d/opaque.ts
+++ b/test-d/opaque.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectAssignable, expectError} from 'tsd';
 import {Opaque} from '..';
 
 type Value = Opaque<number, 'Value'>;
@@ -7,10 +7,10 @@ type Value = Opaque<number, 'Value'>;
 const value: Value = 2 as Value;
 
 // Every opaque type should have a private member with a type of the Token parameter, so the compiler can differentiate separate opaque types.
-expectType<unknown>(value.__opaque__);
+expectAssignable<unknown>(value.__opaque__);
 
 // The underlying type of the value is still a number.
-expectType<number>(value);
+expectAssignable<number>(value);
 
 // You cannot modify an opaque value.
 expectError<Value>(value + 2); // eslint-disable-line @typescript-eslint/restrict-plus-operands

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectAssignable} from 'tsd';
 import {PackageJson, LiteralUnion} from '..';
 
 const packageJson: PackageJson = {};
@@ -38,14 +38,14 @@ expectType<PackageJson.Dependency | undefined>(packageJson.resolutions);
 expectType<PackageJson.WorkspaceConfig | string[] | undefined>(packageJson.workspaces);
 expectType<{[engineName: string]: string} | undefined>(packageJson.engines);
 expectType<boolean | undefined>(packageJson.engineStrict);
-expectType<
+expectAssignable<
 	| undefined
 	| Array<LiteralUnion<
 			'darwin' | 'linux' | 'win32' | '!darwin' | '!linux' | '!win32',
 			string
 	>>
 >(packageJson.os);
-expectType<
+expectAssignable<
 	| undefined
 	| Array<LiteralUnion<
 			'x64' | 'ia32' | 'arm' | 'mips' | '!x64' | '!ia32' | '!arm' | '!mips',

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectType, expectError, expectAssignable} from 'tsd';
 import {PartialDeep} from '..';
 
 const foo = {
@@ -29,19 +29,19 @@ expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
 const partialDeepBar: PartialDeep<typeof foo.bar> = foo.bar;
 expectType<typeof partialDeepBar | undefined>(partialDeepFoo.bar);
 expectType<((_: string) => void) | undefined>(partialDeepFoo.bar!.function);
-expectType<object | undefined>(partialDeepFoo.bar!.object);
+expectAssignable<object | undefined>(partialDeepFoo.bar!.object);
 expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);
 expectType<boolean | undefined>(partialDeepFoo.bar!.boolean);
 expectType<symbol | undefined>(partialDeepFoo.bar!.symbol);
 expectType<null | undefined>(partialDeepFoo.bar!.null);
 expectType<undefined>(partialDeepFoo.bar!.undefined);
-expectType<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
-expectType<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
+expectAssignable<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
+expectAssignable<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
 expectType<Array<string | undefined> | undefined>(partialDeepFoo.bar!.array);
 expectType<['foo'?] | undefined>(partialDeepFoo.bar!.tuple);
-expectType<ReadonlyMap<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.readonlyMap);
-expectType<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
+expectAssignable<ReadonlyMap<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.readonlyMap);
+expectAssignable<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
 expectType<ReadonlyArray<string | undefined> | undefined>(partialDeepFoo.bar!.readonlyArray);
 expectType<readonly ['foo'?] | undefined>(partialDeepFoo.bar!.readonlyTuple);
 // Check for compiling with omitting partial keys

--- a/test-d/promise-value.ts
+++ b/test-d/promise-value.ts
@@ -1,14 +1,14 @@
-import {expectType} from 'tsd';
+import {expectAssignable} from 'tsd';
 import {PromiseValue} from '..';
 
 type NumberPromise = Promise<number>;
 type Otherwise = object;
 
 // Test the normal behaviour.
-expectType<PromiseValue<NumberPromise>>(2);
+expectAssignable<PromiseValue<NumberPromise>>(2);
 
 // Test what happens when the `PromiseValue` type is not handed a `Promise` type.
-expectType<PromiseValue<number>>(2);
+expectAssignable<PromiseValue<number>>(2);
 
 // Test the `Otherwise` generic parameter.
-expectType<PromiseValue<number, Otherwise>>({});
+expectAssignable<PromiseValue<number, Otherwise>>({});

--- a/test-d/require-at-least-one.ts
+++ b/test-d/require-at-least-one.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectError, expectAssignable} from 'tsd';
 import {RequireAtLeastOne} from '..';
 
 type SystemMessages = {
@@ -23,4 +23,4 @@ expectError(test({macos: 'hey'}));
 expectError(test({default: 'hello'}));
 
 declare const atLeastOneWithoutKeys: RequireAtLeastOne<{a: number; b: number}>;
-expectType<{a: number; b?: number} | {a?: number; b: number}>(atLeastOneWithoutKeys);
+expectAssignable<{a: number; b?: number} | {a?: number; b: number}>(atLeastOneWithoutKeys);

--- a/test-d/require-exactly-one.ts
+++ b/test-d/require-exactly-one.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectError, expectAssignable} from 'tsd';
 import {RequireExactlyOne} from '..';
 
 type SystemMessages = {
@@ -20,5 +20,5 @@ expectError(test({}));
 expectError(test({macos: 'hey', linux: 'sup', default: 'hello'}));
 
 declare const oneWithoutKeys: RequireExactlyOne<{a: number; b: number}>;
-expectType<{a: number} | {b: number}>(oneWithoutKeys);
-expectError(expectType<{a: number; b: number}>(oneWithoutKeys));
+expectAssignable<{a: number} | {b: number}>(oneWithoutKeys);
+expectError(expectAssignable<{a: number; b: number}>(oneWithoutKeys));

--- a/test-d/union-to-intersection.ts
+++ b/test-d/union-to-intersection.ts
@@ -1,9 +1,9 @@
-import {expectType} from 'tsd';
+import {expectAssignable} from 'tsd';
 import {UnionToIntersection} from '..';
 
 declare const intersection1: UnionToIntersection<{a: string} | {b: number}>;
-expectType<{a: string; b: number}>(intersection1);
+expectAssignable<{a: string; b: number}>(intersection1);
 
 // Creates a union of matching properties.
 declare const intersection2: UnionToIntersection<{a: string} | {b: number} | {a: () => void}>;
-expectType<{a: string | (() => void); b: number}>(intersection2);
+expectAssignable<{a: string | (() => void); b: number}>(intersection2);


### PR DESCRIPTION
I do get these `warnings` and `errors`. But I get the same errors when removing the new `tsd` version. Any ideas ? I guess the `todo` warnings are just todo's.

```
  source/require-exactly-one.d.ts:1:1
  ⚠   1:1    Unexpected todo comment.                                                         no-warning-comments

  source/basic.d.ts:20:126
  ⚠   3:1    Unexpected todo comment.                                                         no-warning-comments
  ⚠  16:1    Unexpected todo comment.                                                         no-warning-comments
  ✖  20:126  @typescript-eslint/type-annotation-spacing rule is disabled but never reported.  eslint-comments/no-unused-disable

```

Fixes #91