### PR TITLE
Make `LiteralUnion` type  work for more types

### DIFF
--- a/source/literal-union.d.ts
+++ b/source/literal-union.d.ts
@@ -28,6 +28,6 @@ const pet: Pet2 = '';
 ```
  */
 export type LiteralUnion<
-	LiteralType extends BaseType,
+	LiteralType,
 	BaseType extends Primitive
 > = LiteralType | (BaseType & {_?: never});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

While [experimenting](https://github.com/kripod/glaze/blob/57b85375da31008cc2736d1c4c3c7db4e877a050/packages/glaze/src/useStyling.ts#L32-L46) with automatic prop completion for an upcoming CSS-in-JS library, I wanted to use `LiteralUnion` as follows:

```ts
import { CSSProperties } from 'react';

enum Duration {
  SHORT = 1, // Gets resolved to a string somewhere else in the code
  LONG,
}

type AnimationDurationValue = LiteralUnion<
  Duration,
  CSSProperties['animationDuration']
>;
```

`LiteralUnion` works perfectly when `LiteralType` doesn't extend `BaseType`.