### PR TITLE
Add `FixedLengthArray` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export {ConditionalKeys} from './source/conditional-keys';
 export {ConditionalPick} from './source/conditional-pick';
 export {UnionToIntersection} from './source/union-to-intersection';
 export {Stringified} from './source/stringified';
+export {FixedLengthArray} from './source/fixed-length-array';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Click the type names for complete docs.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
-- [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of a provided type and of a provided fixed length.
+- [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of the given type and length.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Click the type names for complete docs.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
+- [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of provided types and of a provided fixed length.
 
 ### Miscellaneous
 

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Click the type names for complete docs.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
-- [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of provided types and of a provided fixed length.
+- [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of a provided type and of a provided fixed length.
 
 ### Miscellaneous
 

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -20,7 +20,7 @@ export type FixedLengthArray<T, Length extends number, ArrayPrototype = [T, ...T
 	ArrayPrototype,
 	Exclude<keyof ArrayPrototype, ArrayLengthMutationKeys>
 > & {
-	[I: number]: T;
+	[index: number]: T;
 	[Symbol.iterator]: () => IterableIterator<T>;
 	readonly length: Length;
 };

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -4,7 +4,7 @@ Methods to exclude.
 type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';
 
 /**
-Create a type that represents an array of the given type and length. The arrays length and the `Array` prototype methods that manipulate its length are excluded in the resulting type.
+Create a type that represents an array of the given type and length. The array's length and the `Array` prototype methods that manipulate its length are excluded in the resulting type.
 
 Please participate in [this issue](https://github.com/microsoft/TypeScript/issues/26223) if you want to have a similiar type built into TypeScript.
 

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,6 +1,13 @@
 /**
 Create a type that represents an array of a provided type and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.
 
+Please participate in [this issue](https://github.com/microsoft/TypeScript/issues/26223) if you want to have a similiar type built-in in TypeScript.
+
+Use-cases:
+- Declaring fixed-length tuples or arrays with a large number of items
+- Creating a Range union (e.g. `0 | 1 | 2 | 3 | 4` from the keys of such a type) without having to resort to recursive types
+- Creating an array of coordinates with a static length, of for example 3 for a 3D vector
+
 @example
 ```
 import {FixedLengthArray} from 'type-fest';

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -16,12 +16,12 @@ guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
 ```
 */
-export type FixedLengthArray<T, Length extends number, ArrayPrototype = [T, ...T[]]> = Pick<
+export type FixedLengthArray<Element, Length extends number, ArrayPrototype = [Element, ...Element[]]> = Pick<
 	ArrayPrototype,
 	Exclude<keyof ArrayPrototype, ArrayLengthMutationKeys>
 > & {
-	[index: number]: T;
-	[Symbol.iterator]: () => IterableIterator<T>;
+	[index: number]: Element;
+	[Symbol.iterator]: () => IterableIterator<Element>;
 	readonly length: Length;
 };
 

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -8,8 +8,10 @@ import {FixedLengthArray} from 'type-fest';
 type FencingTeam = FixedLengthArray<string, 3>;
 
 const guestFencingTeam: FencingTeam = ['Josh', 'Michael', 'Robert'];
+
 const homeFencingTeam: FencingTeam = ['George', 'John'];
 //=> error TS2322: Type string[] is not assignable to type 'FencingTeam'
+
 guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
 ```

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,5 +1,5 @@
 /**
-Create a type that represents an array of provided types and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.
+Create a type that represents an array of a provided type and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.
 
 @example
 ```

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,0 +1,29 @@
+/**
+Create a type that represents an array of provided types and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.
+
+@example
+```
+import {FixedLengthArray} from 'type-fest';
+
+type FencingTeam = FixedLengthArray<string, 3>;
+
+const guestFencingTeam = ['Josh', 'Michael', 'Robert'];
+const homeFencingTeam = ['George', 'John'];
+//=> error TS2322: Type string[] is not assignable to type 'FencingTeam'
+guestFencingTeam.push('Sam');
+//=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
+```
+*/
+export type FixedLengthArray<T, Length extends number, ArrayPrototype = [T, ...T[]]> = Pick<
+	ArrayPrototype,
+	Exclude<keyof ArrayPrototype, ArrayLengthMutationKeys>
+> & {
+	[I: number]: T;
+	[Symbol.iterator]: () => IterableIterator<T>;
+	readonly length: Length;
+};
+
+/**
+Provides the Array object methods to exclude from a Fixed Length Array. Internal helper for Fixed Length Array.
+*/
+type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -7,8 +7,8 @@ import {FixedLengthArray} from 'type-fest';
 
 type FencingTeam = FixedLengthArray<string, 3>;
 
-const guestFencingTeam = ['Josh', 'Michael', 'Robert'];
-const homeFencingTeam = ['George', 'John'];
+const guestFencingTeam: FencingTeam = ['Josh', 'Michael', 'Robert'];
+const homeFencingTeam: FencingTeam = ['George', 'John'];
 //=> error TS2322: Type string[] is not assignable to type 'FencingTeam'
 guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,12 +1,17 @@
 /**
-Create a type that represents an array of a provided type and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.
+Methods to exclude.
+*/
+type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';
 
-Please participate in [this issue](https://github.com/microsoft/TypeScript/issues/26223) if you want to have a similiar type built-in in TypeScript.
+/**
+Create a type that represents an array of the given type and length. The arrays length and the `Array` prototype methods that manipulate its length are excluded in the resulting type.
+
+Please participate in [this issue](https://github.com/microsoft/TypeScript/issues/26223) if you want to have a similiar type built into TypeScript.
 
 Use-cases:
-- Declaring fixed-length tuples or arrays with a large number of items
-- Creating a Range union (e.g. `0 | 1 | 2 | 3 | 4` from the keys of such a type) without having to resort to recursive types
-- Creating an array of coordinates with a static length, of for example 3 for a 3D vector
+- Declaring fixed-length tuples or arrays with a large number of items.
+- Creating a range union (for example, `0 | 1 | 2 | 3 | 4` from the keys of such a type) without having to resort to recursive types.
+- Creating an array of coordinates with a static length, for example, length of 3 for a 3D vector.
 
 @example
 ```
@@ -31,8 +36,3 @@ export type FixedLengthArray<Element, Length extends number, ArrayPrototype = [E
 	[Symbol.iterator]: () => IterableIterator<Element>;
 	readonly length: Length;
 };
-
-/**
-Provides the Array object methods to exclude from a Fixed Length Array. Internal helper for Fixed Length Array.
-*/
-type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';

--- a/test-d/fixed-length-array.ts
+++ b/test-d/fixed-length-array.ts
@@ -1,0 +1,11 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import {FixedLengthArray} from '..';
+
+type FixedToThreeStrings = FixedLengthArray<string, 3>;
+
+expectAssignable<FixedToThreeStrings>(['a', 'b', 'c']);
+
+expectNotAssignable<FixedToThreeStrings>(['a', 'b', 123]);
+expectNotAssignable<FixedToThreeStrings>(['a']);
+expectNotAssignable<FixedToThreeStrings>(['a', 'b']);
+expectNotAssignable<FixedToThreeStrings>(['a', 'b', 'c', 'd']);


### PR DESCRIPTION
Fixes #102 

Create a type that represents an array of provided types and of a provided fixed length. The arrays length and Array prototype mutations that manipulate its length are excluded in the resulting type.

**Use-cases:**

- Declaring fixed-length tuples or arrays with a large number of items
- Creating a Range union (e.g. `0 | 1 | 2 | 3 | 4` from the keys of such a type) without having to resort to recursive types
- Creating an array of coordinates with a static length, of for example 3 for a 3D vector

**Example:**

```TS
import {FixedLengthArray} from 'type-fest';

type FencingTeam = FixedLengthArray<string, 3>;

const guestFencingTeam: FencingTeam = ['Josh', 'Michael', 'Robert'];
const homeFencingTeam: FencingTeam = ['George', 'John'];
//=> error TS2322: Type string[] is not assignable to type 'FencingTeam'
guestFencingTeam.push('Sam');
//=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
```

**Caveats:**

I'm not *quite* sure how to test for the absence of Array.prototype methods that manipulate the arrays length without importing a testing framework. Would love to hear a suggestion if this test case is deemed necessary.