### PR TITLE
Add support for ESM exports in the `PackageJson` type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -231,8 +231,8 @@ declare namespace PackageJson {
 	*/
 	export type Exports =
 	| string
-	| { [key in ExportCondition]: Exports }
-	| { [key: string]: Exports };
+	| {[key in ExportCondition]: Exports}
+	| {[key: string]: Exports};
 
 	export interface NonStandardEntryPoints {
 		/**

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -417,6 +417,8 @@ export type PackageJson = {
 
 	/**
 	Standard entry points of the package, with enhanced support for ECMAScript Modules.
+
+	[Read more.](https://nodejs.org/api/esm.html#esm_package_entry_points)
 	*/
 	exports?: PackageJson.Exports;
 

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -211,6 +211,29 @@ declare namespace PackageJson {
 		[packageName: string]: string;
 	}
 
+	/**
+	Conditions which provide a way to resolve a package entry point based on the environment.
+	*/
+	export type ExportCondition = LiteralUnion<
+		| 'import'
+		| 'require'
+		| 'node'
+		| 'deno'
+		| 'browser'
+		| 'electron'
+		| 'react-native'
+		| 'default',
+		string
+	>;
+
+	/**
+	Entry points of a module, optionally with conditions and subpath exports.
+	*/
+	export type Exports =
+	| string
+	| { [key in ExportCondition]: Exports }
+	| { [key: string]: Exports };
+
 	export interface NonStandardEntryPoints {
 		/**
 		An ECMAScript module ID that is the primary entry point to the program.
@@ -381,9 +404,21 @@ export type PackageJson = {
 	files?: string[];
 
 	/**
+	Resolution algorithm for importing ".js" files from the package's scope.
+
+	[Read more.](https://nodejs.org/api/esm.html#esm_package_json_type_field)
+	*/
+	type?: 'module' | 'commonjs';
+
+	/**
 	The module ID that is the primary entry point to the program.
 	*/
 	main?: string;
+
+	/**
+	Standard entry points of the package, with enhanced support for ECMAScript Modules.
+	*/
+	exports?: PackageJson.Exports;
 
 	/**
 	The executable files that should be installed into the `PATH`.


### PR DESCRIPTION
Please see the [ECMAScript Modules docs of Node.js](https://nodejs.org/api/esm.html) for details about the implementation.