### PR TITLE
Add `SetReturnType` and `Asyncify` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ export {ConditionalPick} from './source/conditional-pick';
 export {UnionToIntersection} from './source/union-to-intersection';
 export {Stringified} from './source/stringified';
 export {FixedLengthArray} from './source/fixed-length-array';
+export {SetReturnType} from './source/set-return-type';
+export {Asyncify} from './source/asyncify';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Click the type names for complete docs.
 - [`IterableElement`](source/iterable-element.d.ts) - Get the element type of an `Iterable`/`AsyncIterable`. For example, an array or a generator.
 - [`Entry`](source/entry.d.ts) - Create a type that represents the type of an entry of a collection.
 - [`Entries`](source/entries.d.ts) - Create a type that represents the type of the entries of a collection.
-- [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters of a given function type.
+- [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
 
 ### Miscellaneous

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,8 @@ Click the type names for complete docs.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
 - [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of the given type and length.
+- [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters of a given function type.
+- [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
 
 ### Miscellaneous
 

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -2,8 +2,9 @@ import {PromiseValue} from './promise-value';
 import {SetReturnType} from './set-return-type';
 
 /**
-Create an async version of the given function type.
+Create an async version of the given function type, by boxing the return type in `Promise`, while keeping the same parameter types.
 
+Use-case: you have two functions, one synchronous and one asynchronous, that do the same thing. Instead of having to duplicate the type specification, you can use `Asyncify` to reuse the synchronous type.
 @example
 ```
 import {Asyncify} from 'type-fest';

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -27,4 +27,4 @@ const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 }
 ```
 */
-export type Asyncify<Fn extends (...args: any[]) => unknown> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;
+export type Asyncify<Fn extends (...args: any[]) => any> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -8,13 +8,15 @@ Create an async version of the given function type.
 ```
 import {Asyncify} from 'type-fest';
 
+// Synchronous function.
 function getFooSync(someArg: SomeType): Foo {
-	// ...
+	// …
 }
 
 type AsyncifiedFooGetter = Asyncify<typeof getFooSync>;
-// type AsyncifiedFooGetter = (someArg: SomeType) => Promise<Foo>;
+//=> type AsyncifiedFooGetter = (someArg: SomeType) => Promise<Foo>;
 
+// Same as `getFooSync` but asynchronous.
 const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 	// TypeScript now knows that `someArg` is `SomeType` automatically.
 	// It also knows that this function must return `Promise<Foo>`.

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -2,9 +2,10 @@ import {PromiseValue} from './promise-value';
 import {SetReturnType} from './set-return-type';
 
 /**
-Create an async version of the given function type, by boxing the return type in `Promise`, while keeping the same parameter types.
+Create an async version of the given function type, by boxing the return type in `Promise` while keeping the same parameter types.
 
-Use-case: you have two functions, one synchronous and one asynchronous, that do the same thing. Instead of having to duplicate the type specification, you can use `Asyncify` to reuse the synchronous type.
+Use-case: You have two functions, one synchronous and one asynchronous that do the same thing. Instead of having to duplicate the type definition, you can use `Asyncify` to reuse the synchronous type.
+
 @example
 ```
 import {Asyncify} from 'type-fest';
@@ -21,9 +22,9 @@ type AsyncifiedFooGetter = Asyncify<typeof getFooSync>;
 const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 	// TypeScript now knows that `someArg` is `SomeType` automatically.
 	// It also knows that this function must return `Promise<Foo>`.
-	// If you have `@typescript-eslint/promise-function-async` linter rule enabled, it will even report that "Functions that return promises must be async."
+	// If you have `@typescript-eslint/promise-function-async` linter rule enabled, it will even report that "Functions that return promises must be async.".
 
-	// ...
+	// …
 }
 ```
 */

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -24,4 +24,4 @@ const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 }
 ```
 */
-export type Asyncify<Fn extends (...args: any[]) => any> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;
+export type Asyncify<Fn extends (...args: any[]) => unknown> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -1,0 +1,27 @@
+import {PromiseValue} from './promise-value';
+import {SetReturnType} from './set-return-type';
+
+/**
+Create an async version of the given function type.
+
+@example
+```ts
+import {Asyncify} from 'type-fest';
+
+function getFooSync(someArg: SomeType): Foo {
+	// ...
+}
+
+type AsyncifiedFooGetter = Asyncify<typeof getFooSync>;
+// type AsyncifiedFooGetter = (someArg: SomeType) => Promise<Foo>;
+
+const getFooAsync: AsyncifiedFooGetter = (someArg) => {
+	// TypeScript now knows that `someArg` is `SomeType` automatically.
+	// It also knows that this function must return `Promise<Foo>`.
+	// If you have `@typescript-eslint/promise-function-async` linter rule enabled, it will even report that "Functions that return promises must be async."
+
+	// ...
+}
+```
+*/
+export type Asyncify<Fn extends (...args: any[]) => any> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -5,7 +5,7 @@ import {SetReturnType} from './set-return-type';
 Create an async version of the given function type.
 
 @example
-```ts
+```
 import {Asyncify} from 'type-fest';
 
 function getFooSync(someArg: SomeType): Foo {

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -14,7 +14,7 @@ import {SetReturnType} from 'type-fest';
 type MyFunction = (foo: SomeType, bar: unknown) => SomeOtherType;
 
 type MyWrappedFunction = SetReturnType<MyFunction, boolean>;
-// type MyWrappedFunction = (foo: SomeType, bar: unknown) => boolean;
+//=> type MyWrappedFunction = (foo: SomeType, bar: unknown) => boolean;
 ```
 */
 export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =
@@ -24,6 +24,6 @@ export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =
 		// We want to detect this situation just to display a friendlier type upon hovering on an IntelliSense-powered IDE.
 		IsUnknown<ThisArg> extends true ? (...args: Arguments) => TypeToReturn : (this: ThisArg, ...args: Arguments) => TypeToReturn
 	) : (
-		// This part should be unreachable, but we make it meaningful just in case...
+		// This part should be unreachable, but we make it meaningful just in case…
 		(...args: Parameters<Fn>) => TypeToReturn
 	);

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -3,7 +3,7 @@ type IsNever<T> = [T] extends [never] ? true : false;
 type IsUnknown<T> = IsNever<T> extends false ? T extends unknown ? unknown extends T ? IsAny<T> extends false ? true : false : false : false : false;
 
 /**
-Create a function type by modifying the return type of the given function type.
+Create a function type with a return type of your choice and the same parameters as the given function type.
 
 Use-case: You want to define a wrapped function that returns something different while receiving the same parameters. For example, you might want to wrap a function that can throw an error into one that will return `undefined` instead.
 

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -1,0 +1,29 @@
+type IsAny<T> = 0 extends (1 & T) ? true : false; // https://stackoverflow.com/a/49928360/3406963
+type IsNever<T> = [T] extends [never] ? true : false;
+type IsUnknown<T> = IsNever<T> extends false ? T extends unknown ? unknown extends T ? IsAny<T> extends false ? true : false : false : false : false;
+
+/**
+Get a function type based on another, changing the return type to one of your choice.
+
+Use-case: You want to define a wrapped function that returns something different while receiving the same parameters.
+
+@example
+```
+import {SetReturnType} from 'type-fest';
+
+type MyFunction = (foo: SomeType, bar: unknown) => SomeOtherType;
+
+type MyWrappedFunction = SetReturnType<MyFunction, boolean>;
+// type MyWrappedFunction = (foo: SomeType, bar: unknown) => boolean;
+```
+*/
+export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =
+	// Just using `Parameters<Fn>` isn't ideal because it doesn't handle the `this` fake parameter
+	Fn extends (this: infer ThisArg, ...args: infer Arguments) => any ? (
+		// If a function did not specify the `this` fake parameter, it will be inferred to `unknown`
+		// We want to detect this situation just to display a friendlier type upon hovering on an IntelliSense-powered IDE.
+		IsUnknown<ThisArg> extends true ? (...args: Arguments) => TypeToReturn : (this: ThisArg, ...args: Arguments) => TypeToReturn
+	) : (
+		// This part should be unreachable, but we make it meaningful just in case...
+		(...args: Parameters<Fn>) => TypeToReturn
+	);

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -3,18 +3,18 @@ type IsNever<T> = [T] extends [never] ? true : false;
 type IsUnknown<T> = IsNever<T> extends false ? T extends unknown ? unknown extends T ? IsAny<T> extends false ? true : false : false : false : false;
 
 /**
-Get a function type based on another, changing the return type to one of your choice.
+Create a function type by modifying the return type of the given function type.
 
-Use-case: You want to define a wrapped function that returns something different while receiving the same parameters.
+Use-case: You want to define a wrapped function that returns something different while receiving the same parameters. For example, you might want to wrap a function that can throw an error into one that will return `undefined` instead.
 
 @example
 ```
 import {SetReturnType} from 'type-fest';
 
-type MyFunction = (foo: SomeType, bar: unknown) => SomeOtherType;
+type MyFunctionThatCanThrow = (foo: SomeType, bar: unknown) => SomeOtherType;
 
-type MyWrappedFunction = SetReturnType<MyFunction, boolean>;
-//=> type MyWrappedFunction = (foo: SomeType, bar: unknown) => boolean;
+type MyWrappedFunction = SetReturnType<MyFunctionThatCanThrow, SomeOtherType | undefined>;
+//=> type MyWrappedFunction = (foo: SomeType, bar: unknown) => SomeOtherType | undefined;
 ```
 */
 export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =

--- a/test-d/asyncify.ts
+++ b/test-d/asyncify.ts
@@ -4,15 +4,15 @@ import {Asyncify} from '..';
 declare function getFooSync(name: string): RegExp;
 declare function getFooWithThisArgSync(this: Date, name: string): RegExp;
 
-// Basic usage
+// Basic usage.
 declare const getFooAsync1: Asyncify<typeof getFooSync>;
 expectType<(name: string) => Promise<RegExp>>(getFooAsync1);
 
-// Noops with async functions
+// Noops with async functions.
 declare const getFooAsync2: Asyncify<typeof getFooAsync1>;
 expectType<typeof getFooAsync1>(getFooAsync2);
 
-// Respects thisArg
+// Respects `thisArg`.
 declare const getFooWithThisArgAsync1: Asyncify<typeof getFooWithThisArgSync>;
 const callResult = getFooWithThisArgAsync1.call(new Date(), 'foo');
 expectType<Promise<RegExp>>(callResult);

--- a/test-d/asyncify.ts
+++ b/test-d/asyncify.ts
@@ -1,0 +1,19 @@
+import {expectType, expectError} from 'tsd';
+import {Asyncify} from '..';
+
+declare function getFooSync(name: string): RegExp;
+declare function getFooWithThisArgSync(this: Date, name: string): RegExp;
+
+// Basic usage
+declare const getFooAsync1: Asyncify<typeof getFooSync>;
+expectType<(name: string) => Promise<RegExp>>(getFooAsync1);
+
+// Noops with async functions
+declare const getFooAsync2: Asyncify<typeof getFooAsync1>;
+expectType<typeof getFooAsync1>(getFooAsync2);
+
+// Respects thisArg
+declare const getFooWithThisArgAsync1: Asyncify<typeof getFooWithThisArgSync>;
+const callResult = getFooWithThisArgAsync1.call(new Date(), 'foo');
+expectType<Promise<RegExp>>(callResult);
+expectError(getFooWithThisArgAsync1.call('not-date', 'foo'));

--- a/test-d/set-return-type.ts
+++ b/test-d/set-return-type.ts
@@ -3,7 +3,7 @@ import {SetReturnType} from '..';
 
 declare const anything: unknown;
 
-// Without thisArg and without parameters
+// Without `thisArg` and without parameters
 declare const variation1: SetReturnType<() => void, number>;
 expectType<() => number>(variation1);
 variation1.call(anything);

--- a/test-d/set-return-type.ts
+++ b/test-d/set-return-type.ts
@@ -1,0 +1,34 @@
+import {expectType, expectError} from 'tsd';
+import {SetReturnType} from '..';
+
+declare const anything: unknown;
+
+// Without thisArg and without parameters
+declare const variation1: SetReturnType<() => void, number>;
+expectType<() => number>(variation1);
+variation1.call(anything);
+
+// Without thisArg and with parameters
+declare const variation2: SetReturnType<(foo: string, bar: boolean) => number, void>;
+expectType<(foo: string, bar: boolean) => void>(variation2);
+variation2.call(anything, 'foo', true);
+
+// With thisArg and without parameters
+function fn1(this: Date): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+declare const variation3: SetReturnType<typeof fn1, string[]>;
+expectType<(this: Date) => string[]>(variation3);
+variation3.call(new Date());
+expectError(variation3.call('not-a-date'));
+
+// With thisArg and with parameters
+declare function fn2(this: Date, foo: any, bar: Array<[number]>): any;
+declare const variation4: SetReturnType<typeof fn2, never>;
+expectType<(this: Date, foo: any, bar: Array<[number]>) => never>(variation4);
+variation4.call(new Date(), anything, [[4], [7]]);
+expectError(variation4.call('not-a-date', anything, [[4], [7]]));
+
+// Sanity check to the fact that omitting `this: unknown` from the argument list has no effect other than in readability
+declare function withExplicitThis(this: unknown, foo: string): number;
+declare function withImplicitThis(foo: string): number;
+expectType<typeof withExplicitThis>(withImplicitThis);
+expectType<typeof withImplicitThis>(withExplicitThis);

--- a/test-d/set-return-type.ts
+++ b/test-d/set-return-type.ts
@@ -3,31 +3,31 @@ import {SetReturnType} from '..';
 
 declare const anything: unknown;
 
-// Without `thisArg` and without parameters
+// Without `thisArg` and without parameters.
 declare const variation1: SetReturnType<() => void, number>;
 expectType<() => number>(variation1);
 variation1.call(anything);
 
-// Without thisArg and with parameters
+// Without `thisArg` and with parameters.
 declare const variation2: SetReturnType<(foo: string, bar: boolean) => number, void>;
 expectType<(foo: string, bar: boolean) => void>(variation2);
 variation2.call(anything, 'foo', true);
 
-// With thisArg and without parameters
+// With `thisArg` and without parameters.
 function fn1(this: Date): void {} // eslint-disable-line @typescript-eslint/no-empty-function
 declare const variation3: SetReturnType<typeof fn1, string[]>;
 expectType<(this: Date) => string[]>(variation3);
 variation3.call(new Date());
 expectError(variation3.call('not-a-date'));
 
-// With thisArg and with parameters
+// With `thisArg` and with parameters.
 declare function fn2(this: Date, foo: any, bar: Array<[number]>): any;
 declare const variation4: SetReturnType<typeof fn2, never>;
 expectType<(this: Date, foo: any, bar: Array<[number]>) => never>(variation4);
 variation4.call(new Date(), anything, [[4], [7]]);
 expectError(variation4.call('not-a-date', anything, [[4], [7]]));
 
-// Sanity check to the fact that omitting `this: unknown` from the argument list has no effect other than in readability
+// Sanity check to the fact that omitting `this: unknown` from the argument list has no effect other than in readability.
 declare function withExplicitThis(this: unknown, foo: string): number;
 declare function withImplicitThis(foo: string): number;
 expectType<typeof withExplicitThis>(withImplicitThis);


### PR DESCRIPTION
This PR adds two types:

* `SetReturnType`
* `Asyncify`

I decided to add the two in a single PR because the second depends directly on the first. I will be happy to separate into two PRs upon request (but the second would have to wait for the first to be merged first).

I can also change the name of the first to `WithReturnType` or `ReplaceReturnType` upon request; I don't have a *strong* preference but I slightly prefer `SetReturnType`.

Closes #88
Closes #125
Closes #126
