### PR TITLE
PackageJson types improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,5 +26,5 @@ export {Stringified} from './source/stringified';
 export {FixedLengthArray} from './source/fixed-length-array';
 
 // Miscellaneous
-export {PackageJson} from './source/package-json';
+export {PackageJson, PackageJsonStrict} from './source/package-json';
 export {TsConfigJson} from './source/tsconfig-json';

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -337,7 +337,7 @@ declare namespace PackageJson {
 		*/
 		jspm?: PackageJson;
     }
-    
+
     /**
     Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Containing standard npm properties.
     */
@@ -346,37 +346,37 @@ declare namespace PackageJson {
         The name of the package.
         */
         name?: string;
-    
+
         /**
         Package version, parseable by [`node-semver`](https://github.com/npm/node-semver).
         */
         version?: string;
-    
+
         /**
         Package description, listed in `npm search`.
         */
         description?: string;
-    
+
         /**
         Keywords associated with package, listed in `npm search`.
         */
         keywords?: string[];
-    
+
         /**
         The URL to the package's homepage.
         */
         homepage?: LiteralUnion<'.', string>;
-    
+
         /**
         The URL to the package's issue tracker and/or the email address to which issues should be reported.
         */
-        bugs?: PackageJson.BugsLocation;
-    
+        bugs?: BugsLocation;
+
         /**
         The license for the package.
         */
         license?: string;
-    
+
         /**
         The licenses for the package.
         */
@@ -384,43 +384,43 @@ declare namespace PackageJson {
             type?: string;
             url?: string;
         }>;
-    
-        author?: PackageJson.Person;
-    
+
+        author?: Person;
+
         /**
         A list of people who contributed to the package.
         */
-        contributors?: PackageJson.Person[];
-    
+        contributors?: Person[];
+
         /**
         A list of people who maintain the package.
         */
-        maintainers?: PackageJson.Person[];
-    
+        maintainers?: Person[];
+
         /**
         The files included in the package.
         */
         files?: string[];
-    
+
         /**
         Resolution algorithm for importing ".js" files from the package's scope.
-    
+
         [Read more.](https://nodejs.org/api/esm.html#esm_package_json_type_field)
         */
         type?: 'module' | 'commonjs';
-    
+
         /**
         The module ID that is the primary entry point to the program.
         */
         main?: string;
-    
+
         /**
         Standard entry points of the package, with enhanced support for ECMAScript Modules.
-    
+
         [Read more.](https://nodejs.org/api/esm.html#esm_package_entry_points)
         */
-        exports?: PackageJson.Exports;
-    
+        exports?: Exports;
+
         /**
         The executable files that should be installed into the `PATH`.
         */
@@ -429,17 +429,17 @@ declare namespace PackageJson {
         | {
             [binary: string]: string;
         };
-    
+
         /**
         Filenames to put in place for the `man` program to find.
         */
         man?: string | string[];
-    
+
         /**
         Indicates the structure of the package.
         */
-        directories?: PackageJson.DirectoryLocations;
-    
+        directories?: DirectoryLocations;
+
         /**
         Location for the code repository.
         */
@@ -448,47 +448,47 @@ declare namespace PackageJson {
         | {
             type: string;
             url: string;
-    
+
             /**
             Relative path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
-    
+
             [Read more.](https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md)
             */
             directory?: string;
         };
-    
+
         /**
         Script commands that are run at various times in the lifecycle of the package. The key is the lifecycle event, and the value is the command to run at that point.
         */
-        scripts?: PackageJson.Scripts;
-    
+        scripts?: Scripts;
+
         /**
         Is used to set configuration parameters used in package scripts that persist across upgrades.
         */
         config?: {
             [configKey: string]: unknown;
         };
-    
+
         /**
         The dependencies of the package.
         */
-        dependencies?: PackageJson.Dependency;
-    
+        dependencies?: Dependency;
+
         /**
         Additional tooling dependencies that are not required for the package to work. Usually test, build, or documentation tooling.
         */
-        devDependencies?: PackageJson.Dependency;
-    
+        devDependencies?: Dependency;
+
         /**
         Dependencies that are skipped if they fail to install.
         */
-        optionalDependencies?: PackageJson.Dependency;
-    
+        optionalDependencies?: Dependency;
+
         /**
         Dependencies that will usually be required by the package user directly or via another dependency.
         */
-        peerDependencies?: PackageJson.Dependency;
-    
+        peerDependencies?: Dependency;
+
         /**
         Indicate peer dependencies that are optional.
         */
@@ -497,29 +497,29 @@ declare namespace PackageJson {
                 optional: true;
             };
         };
-    
+
         /**
         Package names that are bundled when the package is published.
         */
         bundledDependencies?: string[];
-    
+
         /**
         Alias of `bundledDependencies`.
         */
         bundleDependencies?: string[];
-    
+
         /**
         Engines that this package runs on.
         */
         engines?: {
             [EngineName in 'npm' | 'node' | string]: string;
         };
-    
+
         /**
         @deprecated
         */
         engineStrict?: boolean;
-    
+
         /**
         Operating systems the module runs on.
         */
@@ -540,7 +540,7 @@ declare namespace PackageJson {
             | '!win32',
             string
         >>;
-    
+
         /**
         CPU architectures the module runs on.
         */
@@ -569,29 +569,29 @@ declare namespace PackageJson {
             | '!x64',
             string
         >>;
-    
+
         /**
         If set to `true`, a warning will be shown if package is installed locally. Useful if the package is primarily a command-line application that should be installed globally.
-    
+
         @deprecated
         */
         preferGlobal?: boolean;
-    
+
         /**
         If set to `true`, then npm will refuse to publish it.
         */
         private?: boolean;
-    
+
         /**
         A set of config values that will be used at publish-time. It's especially handy to set the tag, registry or access, to ensure that a given package is not tagged with 'latest', published to the global public registry or that a scoped module is private by default.
         */
         publishConfig?: {
             [config: string]: unknown;
         };
-    
+
         /**
         Describes and notifies consumers of a package's monetary support information.
-    
+
         [Read more.](https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md)
         */
         funding?: string | {
@@ -617,7 +617,7 @@ declare namespace PackageJson {
 /**
 Strict Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Also includes types for fields used by other popular projects, like TypeScript and Yarn. Dose not allow unknown keys.
  */
-export type PackageJsonStrict = 
+export type PackageJsonStrict =
 PackageJson.PackageJsonStandard &
 PackageJson.NonStandardEntryPoints &
 PackageJson.TypeScriptConfiguration &

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -336,287 +336,297 @@ declare namespace PackageJson {
 		JSPM configuration.
 		*/
 		jspm?: PackageJson;
-	}
+    }
+    
+    /**
+    Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Containing standard npm properties.
+    */
+    export interface PackageJsonStandard {
+        /**
+        The name of the package.
+        */
+        name?: string;
+    
+        /**
+        Package version, parseable by [`node-semver`](https://github.com/npm/node-semver).
+        */
+        version?: string;
+    
+        /**
+        Package description, listed in `npm search`.
+        */
+        description?: string;
+    
+        /**
+        Keywords associated with package, listed in `npm search`.
+        */
+        keywords?: string[];
+    
+        /**
+        The URL to the package's homepage.
+        */
+        homepage?: LiteralUnion<'.', string>;
+    
+        /**
+        The URL to the package's issue tracker and/or the email address to which issues should be reported.
+        */
+        bugs?: PackageJson.BugsLocation;
+    
+        /**
+        The license for the package.
+        */
+        license?: string;
+    
+        /**
+        The licenses for the package.
+        */
+        licenses?: Array<{
+            type?: string;
+            url?: string;
+        }>;
+    
+        author?: PackageJson.Person;
+    
+        /**
+        A list of people who contributed to the package.
+        */
+        contributors?: PackageJson.Person[];
+    
+        /**
+        A list of people who maintain the package.
+        */
+        maintainers?: PackageJson.Person[];
+    
+        /**
+        The files included in the package.
+        */
+        files?: string[];
+    
+        /**
+        Resolution algorithm for importing ".js" files from the package's scope.
+    
+        [Read more.](https://nodejs.org/api/esm.html#esm_package_json_type_field)
+        */
+        type?: 'module' | 'commonjs';
+    
+        /**
+        The module ID that is the primary entry point to the program.
+        */
+        main?: string;
+    
+        /**
+        Standard entry points of the package, with enhanced support for ECMAScript Modules.
+    
+        [Read more.](https://nodejs.org/api/esm.html#esm_package_entry_points)
+        */
+        exports?: PackageJson.Exports;
+    
+        /**
+        The executable files that should be installed into the `PATH`.
+        */
+        bin?:
+        | string
+        | {
+            [binary: string]: string;
+        };
+    
+        /**
+        Filenames to put in place for the `man` program to find.
+        */
+        man?: string | string[];
+    
+        /**
+        Indicates the structure of the package.
+        */
+        directories?: PackageJson.DirectoryLocations;
+    
+        /**
+        Location for the code repository.
+        */
+        repository?:
+        | string
+        | {
+            type: string;
+            url: string;
+    
+            /**
+            Relative path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
+    
+            [Read more.](https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md)
+            */
+            directory?: string;
+        };
+    
+        /**
+        Script commands that are run at various times in the lifecycle of the package. The key is the lifecycle event, and the value is the command to run at that point.
+        */
+        scripts?: PackageJson.Scripts;
+    
+        /**
+        Is used to set configuration parameters used in package scripts that persist across upgrades.
+        */
+        config?: {
+            [configKey: string]: unknown;
+        };
+    
+        /**
+        The dependencies of the package.
+        */
+        dependencies?: PackageJson.Dependency;
+    
+        /**
+        Additional tooling dependencies that are not required for the package to work. Usually test, build, or documentation tooling.
+        */
+        devDependencies?: PackageJson.Dependency;
+    
+        /**
+        Dependencies that are skipped if they fail to install.
+        */
+        optionalDependencies?: PackageJson.Dependency;
+    
+        /**
+        Dependencies that will usually be required by the package user directly or via another dependency.
+        */
+        peerDependencies?: PackageJson.Dependency;
+    
+        /**
+        Indicate peer dependencies that are optional.
+        */
+        peerDependenciesMeta?: {
+            [packageName: string]: {
+                optional: true;
+            };
+        };
+    
+        /**
+        Package names that are bundled when the package is published.
+        */
+        bundledDependencies?: string[];
+    
+        /**
+        Alias of `bundledDependencies`.
+        */
+        bundleDependencies?: string[];
+    
+        /**
+        Engines that this package runs on.
+        */
+        engines?: {
+            [EngineName in 'npm' | 'node' | string]: string;
+        };
+    
+        /**
+        @deprecated
+        */
+        engineStrict?: boolean;
+    
+        /**
+        Operating systems the module runs on.
+        */
+        os?: Array<LiteralUnion<
+            | 'aix'
+            | 'darwin'
+            | 'freebsd'
+            | 'linux'
+            | 'openbsd'
+            | 'sunos'
+            | 'win32'
+            | '!aix'
+            | '!darwin'
+            | '!freebsd'
+            | '!linux'
+            | '!openbsd'
+            | '!sunos'
+            | '!win32',
+            string
+        >>;
+    
+        /**
+        CPU architectures the module runs on.
+        */
+        cpu?: Array<LiteralUnion<
+            | 'arm'
+            | 'arm64'
+            | 'ia32'
+            | 'mips'
+            | 'mipsel'
+            | 'ppc'
+            | 'ppc64'
+            | 's390'
+            | 's390x'
+            | 'x32'
+            | 'x64'
+            | '!arm'
+            | '!arm64'
+            | '!ia32'
+            | '!mips'
+            | '!mipsel'
+            | '!ppc'
+            | '!ppc64'
+            | '!s390'
+            | '!s390x'
+            | '!x32'
+            | '!x64',
+            string
+        >>;
+    
+        /**
+        If set to `true`, a warning will be shown if package is installed locally. Useful if the package is primarily a command-line application that should be installed globally.
+    
+        @deprecated
+        */
+        preferGlobal?: boolean;
+    
+        /**
+        If set to `true`, then npm will refuse to publish it.
+        */
+        private?: boolean;
+    
+        /**
+        A set of config values that will be used at publish-time. It's especially handy to set the tag, registry or access, to ensure that a given package is not tagged with 'latest', published to the global public registry or that a scoped module is private by default.
+        */
+        publishConfig?: {
+            [config: string]: unknown;
+        };
+    
+        /**
+        Describes and notifies consumers of a package's monetary support information.
+    
+        [Read more.](https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md)
+        */
+        funding?: string | {
+            /**
+            The type of funding.
+            */
+            type?: LiteralUnion<
+                | 'github'
+                | 'opencollective'
+                | 'patreon'
+                | 'individual'
+                | 'foundation'
+                | 'corporation',
+                string
+            >;
+            /**
+            The URL to the funding page.
+            */
+            url: string;
+        };
+    }
 }
+/**
+Strict Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Also includes types for fields used by other popular projects, like TypeScript and Yarn. Dose not allow unknown keys.
+ */
+export type PackageJsonStrict = 
+PackageJson.PackageJsonStandard &
+PackageJson.NonStandardEntryPoints &
+PackageJson.TypeScriptConfiguration &
+PackageJson.YarnConfiguration &
+PackageJson.JSPMConfiguration;
 
 /**
 Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Also includes types for fields used by other popular projects, like TypeScript and Yarn.
 */
-export type PackageJson = {
-	/**
-	The name of the package.
-	*/
-	name?: string;
-
-	/**
-	Package version, parseable by [`node-semver`](https://github.com/npm/node-semver).
-	*/
-	version?: string;
-
-	/**
-	Package description, listed in `npm search`.
-	*/
-	description?: string;
-
-	/**
-	Keywords associated with package, listed in `npm search`.
-	*/
-	keywords?: string[];
-
-	/**
-	The URL to the package's homepage.
-	*/
-	homepage?: LiteralUnion<'.', string>;
-
-	/**
-	The URL to the package's issue tracker and/or the email address to which issues should be reported.
-	*/
-	bugs?: PackageJson.BugsLocation;
-
-	/**
-	The license for the package.
-	*/
-	license?: string;
-
-	/**
-	The licenses for the package.
-	*/
-	licenses?: Array<{
-		type?: string;
-		url?: string;
-	}>;
-
-	author?: PackageJson.Person;
-
-	/**
-	A list of people who contributed to the package.
-	*/
-	contributors?: PackageJson.Person[];
-
-	/**
-	A list of people who maintain the package.
-	*/
-	maintainers?: PackageJson.Person[];
-
-	/**
-	The files included in the package.
-	*/
-	files?: string[];
-
-	/**
-	Resolution algorithm for importing ".js" files from the package's scope.
-
-	[Read more.](https://nodejs.org/api/esm.html#esm_package_json_type_field)
-	*/
-	type?: 'module' | 'commonjs';
-
-	/**
-	The module ID that is the primary entry point to the program.
-	*/
-	main?: string;
-
-	/**
-	Standard entry points of the package, with enhanced support for ECMAScript Modules.
-
-	[Read more.](https://nodejs.org/api/esm.html#esm_package_entry_points)
-	*/
-	exports?: PackageJson.Exports;
-
-	/**
-	The executable files that should be installed into the `PATH`.
-	*/
-	bin?:
-	| string
-	| {
-		[binary: string]: string;
-	};
-
-	/**
-	Filenames to put in place for the `man` program to find.
-	*/
-	man?: string | string[];
-
-	/**
-	Indicates the structure of the package.
-	*/
-	directories?: PackageJson.DirectoryLocations;
-
-	/**
-	Location for the code repository.
-	*/
-	repository?:
-	| string
-	| {
-		type: string;
-		url: string;
-
-		/**
-		Relative path to package.json if it is placed in non-root directory (for example if it is part of a monorepo).
-
-		[Read more.](https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md)
-		*/
-		directory?: string;
-	};
-
-	/**
-	Script commands that are run at various times in the lifecycle of the package. The key is the lifecycle event, and the value is the command to run at that point.
-	*/
-	scripts?: PackageJson.Scripts;
-
-	/**
-	Is used to set configuration parameters used in package scripts that persist across upgrades.
-	*/
-	config?: {
-		[configKey: string]: unknown;
-	};
-
-	/**
-	The dependencies of the package.
-	*/
-	dependencies?: PackageJson.Dependency;
-
-	/**
-	Additional tooling dependencies that are not required for the package to work. Usually test, build, or documentation tooling.
-	*/
-	devDependencies?: PackageJson.Dependency;
-
-	/**
-	Dependencies that are skipped if they fail to install.
-	*/
-	optionalDependencies?: PackageJson.Dependency;
-
-	/**
-	Dependencies that will usually be required by the package user directly or via another dependency.
-	*/
-	peerDependencies?: PackageJson.Dependency;
-
-	/**
-	Indicate peer dependencies that are optional.
-	*/
-	peerDependenciesMeta?: {
-		[packageName: string]: {
-			optional: true;
-		};
-	};
-
-	/**
-	Package names that are bundled when the package is published.
-	*/
-	bundledDependencies?: string[];
-
-	/**
-	Alias of `bundledDependencies`.
-	*/
-	bundleDependencies?: string[];
-
-	/**
-	Engines that this package runs on.
-	*/
-	engines?: {
-		[EngineName in 'npm' | 'node' | string]: string;
-	};
-
-	/**
-	@deprecated
-	*/
-	engineStrict?: boolean;
-
-	/**
-	Operating systems the module runs on.
-	*/
-	os?: Array<LiteralUnion<
-		| 'aix'
-		| 'darwin'
-		| 'freebsd'
-		| 'linux'
-		| 'openbsd'
-		| 'sunos'
-		| 'win32'
-		| '!aix'
-		| '!darwin'
-		| '!freebsd'
-		| '!linux'
-		| '!openbsd'
-		| '!sunos'
-		| '!win32',
-		string
-	>>;
-
-	/**
-	CPU architectures the module runs on.
-	*/
-	cpu?: Array<LiteralUnion<
-		| 'arm'
-		| 'arm64'
-		| 'ia32'
-		| 'mips'
-		| 'mipsel'
-		| 'ppc'
-		| 'ppc64'
-		| 's390'
-		| 's390x'
-		| 'x32'
-		| 'x64'
-		| '!arm'
-		| '!arm64'
-		| '!ia32'
-		| '!mips'
-		| '!mipsel'
-		| '!ppc'
-		| '!ppc64'
-		| '!s390'
-		| '!s390x'
-		| '!x32'
-		| '!x64',
-		string
-	>>;
-
-	/**
-	If set to `true`, a warning will be shown if package is installed locally. Useful if the package is primarily a command-line application that should be installed globally.
-
-	@deprecated
-	*/
-	preferGlobal?: boolean;
-
-	/**
-	If set to `true`, then npm will refuse to publish it.
-	*/
-	private?: boolean;
-
-	/**
-	A set of config values that will be used at publish-time. It's especially handy to set the tag, registry or access, to ensure that a given package is not tagged with 'latest', published to the global public registry or that a scoped module is private by default.
-	*/
-	publishConfig?: {
-		[config: string]: unknown;
-	};
-
-	/**
-	Describes and notifies consumers of a package's monetary support information.
-
-	[Read more.](https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md)
-	*/
-	funding?: string | {
-		/**
-		The type of funding.
-		*/
-		type?: LiteralUnion<
-			| 'github'
-			| 'opencollective'
-			| 'patreon'
-			| 'individual'
-			| 'foundation'
-			| 'corporation',
-			string
-		>;
-		/**
-		The URL to the funding page.
-		*/
-		url: string;
-	};
-} &
-PackageJson.NonStandardEntryPoints &
-PackageJson.TypeScriptConfiguration &
-PackageJson.YarnConfiguration &
-PackageJson.JSPMConfiguration & {
+export type PackageJson = PackageJsonStrict & {
 	[key: string]: unknown;
 };

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -1,7 +1,8 @@
-import {expectType, expectAssignable} from 'tsd';
-import {PackageJson, LiteralUnion} from '..';
+import {expectType, expectAssignable, expectNotAssignable} from 'tsd';
+import {PackageJson, PackageJsonStrict, LiteralUnion} from '..';
 
 const packageJson: PackageJson = {};
+const packageJsonStrict: PackageJsonStrict = {};
 
 expectType<string | undefined>(packageJson.name);
 expectType<string | undefined>(packageJson.version);
@@ -67,3 +68,6 @@ expectType<
 >(packageJson.esnext);
 expectType<PackageJson | undefined>(packageJson.jspm);
 expectType<unknown>(packageJson.foo);
+
+expectAssignable<PackageJsonStrict>(packageJson);
+expectNotAssignable<PackageJson>(packageJsonStrict);


### PR DESCRIPTION
This PR should not break existing code.

1. Refactor `PackageJsonStandard` type into the `PackageJson` namespace.
2. Add and export `PackageJsonStrict` type without unknown keys.

* When the time comes to release a major version it's possible to replace the `PackageJson` type with the strict one.