### PR TITLE
Add GitHub CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Node.js ${{ matrix.node_version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - 15
+          - 14
+          - 12
+          - 10
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
+      - run: npm install
+      - run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,22 @@
 name: CI
-
 on:
   - push
   - pull_request
-
 jobs:
   test:
-    name: Node.js ${{ matrix.node_version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node_version:
+        node-version:
           - 14
           - 12
           - 10
-        os:
-          - ubuntu-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - 15
           - 14
           - 12
           - 10
@@ -25,4 +24,4 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
       - run: npm install
-      - run: npm run test
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '10'

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 <br>
 <br>
 
-[![Build Status](https://travis-ci.com/sindresorhus/type-fest.svg?branch=master)](https://travis-ci.com/sindresorhus/type-fest)
+[![Build Status](https://github.com/sindresorhus/type-fest/workflows/CI/badge.svg?branch=master)](https://github.com/sindresorhus/type-fest/actions?query=branch%3Amaster+workflow%3ACI)
 [![](https://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://giphy.com/gifs/illustration-rainbow-unicorn-26AHG5KGFxSkUWw1i)
 <!-- Commented out until they actually show anything
 [![npm dependents](https://badgen.net/npm/dependents/type-fest)](https://www.npmjs.com/package/type-fest?activeTab=dependents) [![npm downloads](https://badgen.net/npm/dt/type-fest)](https://www.npmjs.com/package/type-fest)


### PR DESCRIPTION
As Travis CI is now severely limited for OSS projects and I would say GitHub Actions are more accessible for GitHub projects.

Based on a modified copy of [the one in Unicorn](https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/master/.github/workflows/ci.yml), which we back then discussed in https://github.com/sindresorhus/eslint-plugin-unicorn/pull/504.

Added tests for Node `14` and `15` on top of the `10` and `12` that's in the Travis file.

Once https://github.com/actions/setup-node/issues/26 has been solved the version numbers can be replaced with aliases like `lts` instead, until then eg. https://github.com/dcodeIO/setup-node-nvm could be used if wanted.

Runs well: https://github.com/voxpelli/type-fest/actions?query=workflow%3ACI
