### PR TITLE
Add typescript as dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 	],
 	"devDependencies": {
 		"tsd": "^0.13.1",
+		"typescript": "^4.0.5",
 		"xo": "^0.28.2"
 	},
 	"types": "index.d.ts",


### PR DESCRIPTION
Shows that `xo` fails when a local typescript is added, which explains why #138 fails, as it adds the `4.1.x` prerelease version of Typescript.

The errors:

```
  test-d/set-return-type.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  test-d/readonly-deep.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  test-d/partial-deep.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  test-d/entries.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  test-d/class.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  source/set-return-type.d.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  source/fixed-length-array.d.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  

  source/entry.d.ts:undefined:undefined
  ✖   0:0  Parsing error: Cannot read property map of undefined  
```

I'm not sure why it fails, but probably something with [eslint-config-xo-typescript](https://github.com/xojs/eslint-config-xo-typescript) that picks up the added `typescript` dependency and fails when using that?