### PR TITLE
Add `UnionToTuple` type

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -25,6 +25,7 @@ export {ConditionalExcept} from './source/conditional-except';
 export {ConditionalKeys} from './source/conditional-keys';
 export {ConditionalPick} from './source/conditional-pick';
 export {UnionToIntersection} from './source/union-to-intersection';
+export {UnionToTuple} from './source/union-to-tuple';
 export {Stringified} from './source/stringified';
 export {FixedLengthArray} from './source/fixed-length-array';
 export {IterableElement} from './source/iterable-element';

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Click the type names for complete docs.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
-- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert an explicit union type to a tuple.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a user defined union type to a tuple type. Order can not be guaranteed on computed union types.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
 - [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of the given type and length.
 - [`IterableElement`](source/iterable-element.d.ts) - Get the element type of an `Iterable`/`AsyncIterable`. For example, an array or a generator.

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Click the type names for complete docs.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
-- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert an explicit union type to an tuple.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert an explicit union type to a tuple.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
 - [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of the given type and length.
 - [`IterableElement`](source/iterable-element.d.ts) - Get the element type of an `Iterable`/`AsyncIterable`. For example, an array or a generator.

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Click the type names for complete docs.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert an explicit union type to an tuple.
 - [`Stringified`](source/stringified.d.ts) - Create a type with the keys of the given type changed to `string` type.
 - [`FixedLengthArray`](source/fixed-length-array.d.ts) - Create a type that represents an array of the given type and length.
 - [`IterableElement`](source/iterable-element.d.ts) - Get the element type of an `Iterable`/`AsyncIterable`. For example, an array or a generator.

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -1,13 +1,13 @@
 import {UnionToIntersection} from './union-to-intersection';
 
 /**
-Convert an explicit union type to an tuple.
+Convert an explicit union type to a tuple.
 
-The elements order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee that the order of the union elements will always be the same.
+The element order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee that the order of such union elements in that case.
 
 Inspired by [this issue in the TypeScript repo](https://github.com/microsoft/TypeScript/issues/13298).
 
-Use-case: You need to do validation but you don't have an enum, only an union type. Similar to the [`Extract` example in the readme](https://typescript-play.js.org/?target=6#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXzSwEdkQBJYACgEoAueVZAWwCMQYBuAKDDwGcM8MgBF4AXngBlAJ6scESgHIRi6ty5ZUGdoihgEABXZ888AN5d48ANoiAuvUat23K6ihMQ9ATE0BzV3goPy8GZjZOLgBfLi4Aejj4AEEICBwAdz54MAALKFQQ+BxEeAAHY1NgKAwoIKy0grr4DByEUpgccpgMaXgAaxBerCzi+B9-ZulygDouFHRsU1z8kKMYE1RhaqgAHkt4AHkWACt4EAAPbVRgLLWNgBp9gGlBs8uQa6yAUUuYPQwdgNpKM7nh7mMML4CgA+R5WABqUAgpDeVxuhxO1he0jsXGh8EoOBO9COx3BQPo2PBADckaR6IjkSA6PBqTgsMBzPsicdrEC7OJWXSQNwYvFEgAVTS9JLXODpeDpKBZFg4GCoWa8VACIJykAKiQWKy2YQOAioYikCg0OEMDyhRSy4DyxS24KhAAMjyi6gS8AAwjh5OD0iBFHAkJoEOksC1mnkMJq8gUQKDNttKPlnfrwYp3J5XfBHXqoKpfYkAOI4ansTxaeDADmoRSCCBYAbxhC6TDx6rwYHIRX5bScjA4bLJwoDmDwDkfbA9JMrVMVdM1TN69LgkTgwgkchUahqIA), but in that case the `changePersonData` function does not validate the `key` parameter at runtime, making it only safe inside TypeScript. Using a tuple and `includes` for validation gives us runtime safety for that kind of function.
+Use-case: You need to do validation but you don't have an enum, only an union type. Similar to the [`Extract` example in the readme](https://typescript-play.js.org/?target=6#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXzSwEdkQBJYACgEoAueVZAWwCMQYBuAKDDwGcM8MgBF4AXngBlAJ6scESgHIRi6ty5ZUGdoihgEABXZ888AN5d48ANoiAuvUat23K6ihMQ9ATE0BzV3goPy8GZjZOLgBfLi4Aejj4AEEICBwAdz54MAALKFQQ+BxEeAAHY1NgKAwoIKy0grr4DByEUpgccpgMaXgAaxBerCzi+B9-ZulygDouFHRsU1z8kKMYE1RhaqgAHkt4AHkWACt4EAAPbVRgLLWNgBp9gGlBs8uQa6yAUUuYPQwdgNpKM7nh7mMML4CgA+R5WABqUAgpDeVxuhxO1he0jsXGh8EoOBO9COx3BQPo2PBADckaR6IjkSA6PBqTgsMBzPsicdrEC7OJWXSQNwYvFEgAVTS9JLXODpeDpKBZFg4GCoWa8VACIJykAKiQWKy2YQOAioYikCg0OEMDyhRSy4DyxS24KhAAMjyi6gS8AAwjh5OD0iBFHAkJoEOksC1mnkMJq8gUQKDNttKPlnfrwYp3J5XfBHXqoKpfYkAOI4ansTxaeDADmoRSCCBYAbxhC6TDx6rwYHIRX5bScjA4bLJwoDmDwDkfbA9JMrVMVdM1TN69LgkTgwgkchUahqIA), but in that case the `changePersonData` function does not validate the `key` parameter at runtime, making it only safe inside TypeScript. Using a tuple and `Array#includes` for validation gives us runtime safety for that kind of function.
 
 @example
 ```
@@ -18,7 +18,7 @@ const tuple: UnionToTuple<Union> = ['A', 'B'];
 
 @example
 ```
-// This type may come from a library that you are using
+// This type may come from a library that you are using.
 type ActionsInSomeLibrary = 'create' | 'read' | 'update' | 'delete' | 'aggregate';
 
 type AllowedActions = Exclude<ActionsInSomeLibrary, 'aggregate'>;

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -3,7 +3,7 @@ import {UnionToIntersection} from './union-to-intersection';
 /**
 Convert an explicit union type to a tuple.
 
-The element order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee that the order of such union elements in that case.
+The element order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee the order of such union elements in that case.
 
 Inspired by [this issue in the TypeScript repo](https://github.com/microsoft/TypeScript/issues/13298).
 

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -11,6 +11,8 @@ Use-case: You need to do validation but you don't have an enum, only an union ty
 
 @example
 ```
+import {UnionToTuple} from 'type-fest';
+
 type Union = 'A' | 'B';
 
 const tuple: UnionToTuple<Union> = ['A', 'B'];
@@ -18,12 +20,17 @@ const tuple: UnionToTuple<Union> = ['A', 'B'];
 
 @example
 ```
+import {UnionToTuple} from 'type-fest';
+
 // This type may come from a library that you are using.
 type ActionsInSomeLibrary = 'create' | 'read' | 'update' | 'delete' | 'aggregate';
 
 type AllowedActions = Exclude<ActionsInSomeLibrary, 'aggregate'>;
 
 const actions: UnionToTuple<AllowedActions> = ['create', 'read', 'update', 'delete'];
+
+// Represents an parameter of the API.
+const requestedAction = 'create';
 
 actions.includes(requestedAction) // Validate
 ```

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -1,0 +1,41 @@
+import {UnionToIntersection} from './union-to-intersection';
+
+/**
+Convert an explicit union type to an tuple.
+
+The elements order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee that the order of the union elements will always be the same.
+
+Inspired by [this issue in the TypeScript repo](https://github.com/microsoft/TypeScript/issues/13298).
+
+Use-case: You need to do validation but you don't have an enum, only an union type. Similar to the [`Extract` example in the readme](https://typescript-play.js.org/?target=6#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXzSwEdkQBJYACgEoAueVZAWwCMQYBuAKDDwGcM8MgBF4AXngBlAJ6scESgHIRi6ty5ZUGdoihgEABXZ888AN5d48ANoiAuvUat23K6ihMQ9ATE0BzV3goPy8GZjZOLgBfLi4Aejj4AEEICBwAdz54MAALKFQQ+BxEeAAHY1NgKAwoIKy0grr4DByEUpgccpgMaXgAaxBerCzi+B9-ZulygDouFHRsU1z8kKMYE1RhaqgAHkt4AHkWACt4EAAPbVRgLLWNgBp9gGlBs8uQa6yAUUuYPQwdgNpKM7nh7mMML4CgA+R5WABqUAgpDeVxuhxO1he0jsXGh8EoOBO9COx3BQPo2PBADckaR6IjkSA6PBqTgsMBzPsicdrEC7OJWXSQNwYvFEgAVTS9JLXODpeDpKBZFg4GCoWa8VACIJykAKiQWKy2YQOAioYikCg0OEMDyhRSy4DyxS24KhAAMjyi6gS8AAwjh5OD0iBFHAkJoEOksC1mnkMJq8gUQKDNttKPlnfrwYp3J5XfBHXqoKpfYkAOI4ansTxaeDADmoRSCCBYAbxhC6TDx6rwYHIRX5bScjA4bLJwoDmDwDkfbA9JMrVMVdM1TN69LgkTgwgkchUahqIA), but in that case the `changePersonData` function does not validate the `key` parameter at runtime, making it only safe inside TypeScript. Using a tuple and `includes` for validation gives us runtime safety for that kind of function.
+
+@example
+```
+type Union = 'A' | 'B';
+
+const tuple: UnionToTuple<Union> = ['A', 'B'];
+```
+
+@example
+```
+// This type may come from a library that you are using
+type ActionsInSomeLibrary = 'create' | 'read' | 'update' | 'delete' | 'aggregate';
+
+type AllowedActions = Exclude<ActionsInSomeLibrary, 'aggregate'>;
+
+const actions: UnionToTuple<AllowedActions> = ['create', 'read', 'update', 'delete'];
+
+actions.includes(requestedAction) // Validate
+```
+*/
+export type UnionToTuple<Union> =
+    UnionToIntersection<
+        // Distributive conditional trick.
+        // See the source for the `UnionToIntersection` type for more details.
+        Union extends unknown
+        ? (distributed: Union) => void
+        : never
+    > extends ((merged: infer Intersection) => void)
+        // Transforms ('A' | 'B') into [[[], "A"], "B"], but destructures the arrays
+        ? readonly [...UnionToTuple<Exclude<Union, Intersection>>, Intersection]
+        : [];

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -1,7 +1,7 @@
 import {UnionToIntersection} from './union-to-intersection';
 
 /**
-Convert an explicit union type to a tuple.
+Convert a user defined union type to a tuple type.
 
 The element order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee the order of such union elements in that case.
 

--- a/test-d/union-to-tuple.ts
+++ b/test-d/union-to-tuple.ts
@@ -1,0 +1,6 @@
+import {expectAssignable} from 'tsd';
+import {UnionToTuple} from '..';
+
+declare type Union = 'A' | 'B';
+declare const tuple: UnionToTuple<Union>;
+expectAssignable<readonly ['A', 'B']>(tuple);


### PR DESCRIPTION
_This one is controversial, but I and a lot of other people have run into this..._

Convert an explicit union type to an tuple.

The elements order of the tuple and of the union will be the same. Because of that, you should not use this if the union is computed instead of manually declared, because the TypeScript compiler does not guarantee that the order of the union elements will always be the same.

Inspired by [this issue in the TypeScript repo](https://github.com/microsoft/TypeScript/issues/13298).

Use-case: You need to do validation but you don't have an enum, only an union type. Similar to the [`Extract` example in the readme](https://typescript-play.js.org/?target=6#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXzSwEdkQBJYACgEoAueVZAWwCMQYBuAKDDwGcM8MgBF4AXngBlAJ6scESgHIRi6ty5ZUGdoihgEABXZ888AN5d48ANoiAuvUat23K6ihMQ9ATE0BzV3goPy8GZjZOLgBfLi4Aejj4AEEICBwAdz54MAALKFQQ+BxEeAAHY1NgKAwoIKy0grr4DByEUpgccpgMaXgAaxBerCzi+B9-ZulygDouFHRsU1z8kKMYE1RhaqgAHkt4AHkWACt4EAAPbVRgLLWNgBp9gGlBs8uQa6yAUUuYPQwdgNpKM7nh7mMML4CgA+R5WABqUAgpDeVxuhxO1he0jsXGh8EoOBO9COx3BQPo2PBADckaR6IjkSA6PBqTgsMBzPsicdrEC7OJWXSQNwYvFEgAVTS9JLXODpeDpKBZFg4GCoWa8VACIJykAKiQWKy2YQOAioYikCg0OEMDyhRSy4DyxS24KhAAMjyi6gS8AAwjh5OD0iBFHAkJoEOksC1mnkMJq8gUQKDNttKPlnfrwYp3J5XfBHXqoKpfYkAOI4ansTxaeDADmoRSCCBYAbxhC6TDx6rwYHIRX5bScjA4bLJwoDmDwDkfbA9JMrVMVdM1TN69LgkTgwgkchUahqIA), but in that case the `changePersonData` function does not validate the `key` parameter at runtime, making it only safe inside TypeScript. Using a tuple and `includes` for validation gives us runtime safety for that kind of function.

```ts
type Union = 'A' | 'B';

const tuple: UnionToTuple<Union> = ['A', 'B'];
```

```ts
// This type may come from a library that you are using
type ActionsInSomeLibrary = 'create' | 'read' | 'update' | 'delete' | 'aggregate';

type AllowedActions = Exclude<ActionsInSomeLibrary, 'aggregate'>;

const actions: UnionToTuple<AllowedActions> = ['create', 'read', 'update', 'delete'];

actions.includes(requestedAction) // Validate
```