### PR TITLE
Improve readability of `Merge` result

### DIFF
--- a/source/merge.d.ts
+++ b/source/merge.d.ts
@@ -1,4 +1,7 @@
 import {Except} from './except';
+import {Simplify} from './simplify';
+
+type Merge_<FirstType, SecondType> = Except<FirstType, Extract<keyof FirstType, keyof SecondType>> & SecondType;
 
 /**
 Merge two types into a new type. Keys of the second type overrides keys of the first type.
@@ -19,4 +22,4 @@ type Bar = {
 const ab: Merge<Foo, Bar> = {a: 1, b: 2};
 ```
 */
-export type Merge<FirstType, SecondType> = Except<FirstType, Extract<keyof FirstType, keyof SecondType>> & SecondType;
+export type Merge<FirstType, SecondType> = Simplify<Merge_<FirstType, SecondType>>;


### PR DESCRIPTION
Consider this example:

```ts
type Foo = { foo: string };
type Bar = { bar: string };

type Merged = Merge<Foo, Bar>;
```

Before this PR:

![image](https://user-images.githubusercontent.com/20914054/102266543-5cd15900-3ef7-11eb-84e8-56522776ecd0.png)

After this PR:

![image](https://user-images.githubusercontent.com/20914054/102266505-504d0080-3ef7-11eb-8180-e228e5fa8c34.png)
