### PR TITLE
Fix `TypedArray` type export

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -3,7 +3,7 @@
 
 // Basic
 export * from './source/basic';
-export * from "./source/typed-array"
+export * from './source/typed-array';
 
 // Utilities
 export {Except} from './source/except';

--- a/base.d.ts
+++ b/base.d.ts
@@ -3,6 +3,7 @@
 
 // Basic
 export * from './source/basic';
+export * from "./source/typed-array"
 
 // Utilities
 export {Except} from './source/except';


### PR DESCRIPTION
`TypedArray` was moved to a new file, but is not exported anywhere. Added it.
