### PR TITLE
Fix export for `Get` type

### DIFF
--- a/ts41/index.d.ts
+++ b/ts41/index.d.ts
@@ -7,3 +7,4 @@ export {KebabCase} from './kebab-case';
 export {PascalCase} from './pascal-case';
 export {SnakeCase} from './snake-case';
 export {DelimiterCase} from './delimiter-case';
+export {Get} from './get';


### PR DESCRIPTION
Looks like the `export` for `Get<>` was missing. Tests reference it using internal paths.

There's also the unexported utility `Split<>`, but that is probably intentional.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->