### PR TITLE
Fix TS type reference

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -1,4 +1,4 @@
-/// <reference lib="esnext"/>
+/// <reference lib="es2020.bigint"/>
 
 // TODO: This can just be `export type Primitive = not object` when the `not` keyword is out.
 /**


### PR DESCRIPTION
I'm targeting Node.js 12.x, which means that I shouldn't be able to compile e.g. `"foo".replaceAll("a", "b")`. But if I import anything from type-fest, from anywhere in my code, then suddenly that code compiles across my entire code base. This is a well-known issue, see e.g. https://github.com/microsoft/TypeScript/issues/33901

The culprit was introduced in https://github.com/sindresorhus/type-fest/pull/37.

As a partial solution, I would recommend replacing the reference to `esnext` with a reference to `es2020.bigint`. Perhaps it would also be worth adding a caveat to the README to the effect that this library is only fully compatible with environments that support `es2020.bigint`.