### PR TITLE
Improve the doc comment for the Except type

### DIFF
--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -5,6 +5,8 @@ This type is a stricter version of [`Omit`](https://www.typescriptlang.org/docs/
 
 Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/30825) if you want to have the stricter version as a built-in in TypeScript.
 
+Typescript prefers libraries to implement stricter versions of the build-in types ([microsoft/TypeScript#30825](https://github.com/microsoft/TypeScript/issues/30825#issuecomment-523668235)).
+
 @example
 ```
 import {Except} from 'type-fest';

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -3,9 +3,7 @@ Create a type from an object type without certain keys.
 
 This type is a stricter version of [`Omit`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-5.html#the-omit-helper-type). The `Omit` type does not restrict the omitted keys to be keys present on the given type, while `Except` does. The benefits of a stricter type are avoiding typos and allowing the compiler to pick up on rename refactors automatically.
 
-Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/30825) if you want to have the stricter version as a built-in in TypeScript.
-
-Typescript prefers libraries to implement stricter versions of the build-in types ([microsoft/TypeScript#30825](https://github.com/microsoft/TypeScript/issues/30825#issuecomment-523668235)).
+This type was proposed to the TypeScript team, which declined it, saying they prefer that libraries implement stricter versions of the built-in types ([microsoft/TypeScript#30825](https://github.com/microsoft/TypeScript/issues/30825#issuecomment-523668235)).
 
 @example
 ```


### PR DESCRIPTION
> After much discussion, we think libraries providing their own "stricter" versions of Omit (as well as `Exclude` and other friends) is preferable.

https://github.com/microsoft/TypeScript/issues/30825#issuecomment-523668235

Since the question is decided and the issue closed, the comment may be removed.