### PR TITLE
Add `SetNonNullable` type

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -17,6 +17,7 @@ export {ReadonlyDeep} from './source/readonly-deep';
 export {LiteralUnion} from './source/literal-union';
 export {Promisable} from './source/promisable';
 export {Opaque} from './source/opaque';
+export {SetNonNullable} from './source/set-non-nullable';
 export {SetOptional} from './source/set-optional';
 export {SetRequired} from './source/set-required';
 export {ValueOf} from './source/value-of';

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Click the type names for complete docs.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 - [`Promisable`](source/promisable.d.ts) - Create a type that represents either the value or the value wrapped in `PromiseLike`.
 - [`Opaque`](source/opaque.d.ts) - Create an [opaque type](https://codemix.com/opaque-types-in-javascript/).
+- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, undefined and null) types from the given keys.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Click the type names for complete docs.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 - [`Promisable`](source/promisable.d.ts) - Create a type that represents either the value or the value wrapped in `PromiseLike`.
 - [`Opaque`](source/opaque.d.ts) - Create an [opaque type](https://codemix.com/opaque-types-in-javascript/).
-- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, undefined and null) types from the given keys.
+- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, `undefined`, and `null`) types from the given keys.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -2,7 +2,7 @@ import {Except} from './except';
 import {Simplify} from './simplify';
 
 /**
-Create a type that makes the given keys non-nullable. The remaining keys are kept as is.
+Create a type removes nullish (optional, undefined and null) types from the given keys. The remaining keys are kept as is.
 
 Use-case: You want to define a single model where the only thing that changes is whether or not some of the keys are required.
 
@@ -21,7 +21,7 @@ type Foo = {
 type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
 // type SomeNonNullable = {
 // 	a?: number;
-// 	b: string; // Was already non-null and still is.
+// 	b: string; // Was already not nullish and still is.
 // 	c: boolean; // Is now not optional.
 //  d: number; // Is now not null
 //	e: string; // Is now not undefined

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -1,0 +1,36 @@
+import {Except} from './except';
+import {Simplify} from './simplify';
+
+/**
+Create a type that makes the given keys non-nullable. The remaining keys are kept as is.
+
+Use-case: You want to define a single model where the only thing that changes is whether or not some of the keys are required.
+
+@example
+```
+import {SetNonNullable} from 'type-fest';
+
+type Foo = {
+	a?: number;
+	b: string;
+	c?: boolean;
+	d: number | null;
+	e: string | undefined;
+}
+
+type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
+// type SomeNonNullable = {
+// 	a?: number;
+// 	b: string; // Was already non-null and still is.
+// 	c: boolean; // Is now not optional.
+//  d: number; // Is now not null
+//	e: string; // Is now not undefined
+// }
+```
+*/
+export type SetNonNullable<BaseType, Keys extends keyof BaseType> = Simplify<
+	// Pick just the keys that are optional from the base type.
+	Except<BaseType, Keys> &
+		// For each 'Key' provided, make it not optional or nullable
+		{ [Key in Keys]-?: NonNullable<BaseType[Key]> }
+>;

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -23,14 +23,14 @@ type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
 // 	a?: number;
 // 	b: string; // Was already not nullish and still is.
 // 	c: boolean; // Is now not optional.
-//  d: number; // Is now not null
-//	e: string; // Is now not undefined
+// 	d: number; // Is now not null.
+// 	e: string; // Is now not undefined.
 // }
 ```
 */
 export type SetNonNullable<BaseType, Keys extends keyof BaseType> = Simplify<
 	// Pick just the keys that are optional from the base type.
 	Except<BaseType, Keys> &
-		// For each 'Key' provided, make it not optional or nullable
-		{ [Key in Keys]-?: NonNullable<BaseType[Key]> }
+		// For each 'Key' provided, make it not optional or nullable.
+		{[Key in Keys]-?: NonNullable<BaseType[Key]>}
 >;

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -1,0 +1,31 @@
+import {expectType, expectError} from 'tsd';
+import {SetNonNullable} from '..';
+
+// Update nullish fields to be non-null, leave one unchanged.
+declare const variation1: SetNonNullable<
+	{
+		a?: string;
+		b: string;
+		c?: string;
+		d: string | null;
+		e: string | undefined;
+	},
+	'b' | 'c' | 'd' | 'e'
+>;
+expectType<{ a?: string; b: string; c: string; d: string; e: string }>(
+	variation1
+);
+
+// Remove optional, undefined and null, leave one unchanged.
+declare const variation2: SetNonNullable<
+	{ a?: number | null | undefined; b?: number | null | undefined },
+	'a'
+>;
+expectType<{ a: number; b?: number | null | undefined }>(variation2);
+
+// Fail if type changes even if optional is right.
+declare const variation3: SetNonNullable<
+	{ a?: number; b: string; c?: boolean | null | undefined },
+	'b' | 'c'
+>;
+expectError<{ a?: boolean; b: string; c: boolean }>(variation3);

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -21,7 +21,7 @@ declare const variation2: SetNonNullable<
 	{a?: number | null | undefined; b?: number | null | undefined},
 	'a'
 >;
-expectType<{ a: number; b?: number | null | undefined }>(variation2);
+expectType<{a: number; b?: number | null | undefined}>(variation2);
 
 // Fail if type changes even if optional is right.
 declare const variation3: SetNonNullable<

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -1,7 +1,7 @@
 import {expectType, expectError} from 'tsd';
 import {SetNonNullable} from '..';
 
-// Update nullish fields to be non-null, leave one unchanged.
+// Update nullish fields to be non-null and leave one unchanged.
 declare const variation1: SetNonNullable<
 	{
 		a?: string;
@@ -12,20 +12,20 @@ declare const variation1: SetNonNullable<
 	},
 	'b' | 'c' | 'd' | 'e'
 >;
-expectType<{ a?: string; b: string; c: string; d: string; e: string }>(
+expectType<{a?: string; b: string; c: string; d: string; e: string}>(
 	variation1
 );
 
-// Remove optional, undefined and null, leave one unchanged.
+// Remove optional, undefined, and null. Leave one unchanged.
 declare const variation2: SetNonNullable<
-	{ a?: number | null | undefined; b?: number | null | undefined },
+	{a?: number | null | undefined; b?: number | null | undefined},
 	'a'
 >;
 expectType<{ a: number; b?: number | null | undefined }>(variation2);
 
 // Fail if type changes even if optional is right.
 declare const variation3: SetNonNullable<
-	{ a?: number; b: string; c?: boolean | null | undefined },
+	{a?: number; b: string; c?: boolean | null | undefined},
 	'b' | 'c'
 >;
-expectError<{ a?: boolean; b: string; c: boolean }>(variation3);
+expectError<{a?: boolean; b: string; c: boolean}>(variation3);


### PR DESCRIPTION
Often, you will want to extract code the checks or asserts that specific fields of an object are present, this makes typing this much easier.

```typescript
function assertHasName(person: Person): asserts person is SetNonNullable<Person, "name"> {
  if(person.name == null) throw new Error("Person has no name");
}
```

Fixes #144