### PR TITLE
Add `PackageJson.PublishConfig` type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -601,20 +601,25 @@ declare namespace PackageJson {
 
 	export interface PublishConfig {
 		/**
+		Additional, less common properties from the [npm docs on publishConfig](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig)
+		*/
+		[additionalProp: string]: unknown;
+
+		/**
 		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set `--access=public`. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.
 		*/
 		access?: 'public' | 'restricted';
 
 		/**
 		The base URL of the npm registry.
-		
+
 		Default: `'https://registry.npmjs.org/'`
 		*/
 		registry?: string;
 
 		/**
 		The tag to publish the package under.
-		
+
 		Default: `'latest'`
 		*/
 		tag?: string;
@@ -629,5 +634,4 @@ PackageJson.PackageJsonStandard &
 PackageJson.NonStandardEntryPoints &
 PackageJson.TypeScriptConfiguration &
 PackageJson.YarnConfiguration &
-PackageJson.JSPMConfiguration &
-PackageJson.PublishConfig;
+PackageJson.JSPMConfiguration;

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -601,15 +601,21 @@ declare namespace PackageJson {
 
 	export interface PublishConfig {
 		/**
-		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set --access=public. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.
+		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set `--access=public`. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.
 		*/
 		access?: 'public' | 'restricted';
+
 		/**
-		The base URL of the npm registry. Defaults to "https://registry.npmjs.org/"
+		The base URL of the npm registry.
+		
+		Default: `'https://registry.npmjs.org/'`
 		*/
 		registry?: string;
+
 		/**
-		The tag to publish the package under. Defaults to "latest"
+		The tag to publish the package under.
+		
+		Default: `'latest'`
 		*/
 		tag?: string;
 	}

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -601,9 +601,9 @@ declare namespace PackageJson {
 
 	export interface PublishConfig {
 		/**
-		Additional, less common properties from the [npm docs on publishConfig](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig).
+		Additional, less common properties from the [npm docs on `publishConfig`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig).
 		*/
-		[additionalProp: string]: unknown;
+		[additionalProperties: string]: unknown;
 
 		/**
 		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set `--access=public`. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -601,7 +601,7 @@ declare namespace PackageJson {
 
 	export interface PublishConfig {
 		/**
-		Additional, less common properties from the [npm docs on publishConfig](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig)
+		Additional, less common properties from the [npm docs on publishConfig](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig).
 		*/
 		[additionalProp: string]: unknown;
 

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -571,7 +571,7 @@ declare namespace PackageJson {
 		/**
 		A set of config values that will be used at publish-time. It's especially handy to set the tag, registry or access, to ensure that a given package is not tagged with 'latest', published to the global public registry or that a scoped module is private by default.
 		*/
-		publishConfig?: Record<string, unknown>;
+		publishConfig?: PublishConfig;
 
 		/**
 		Describes and notifies consumers of a package's monetary support information.
@@ -598,6 +598,21 @@ declare namespace PackageJson {
 			url: string;
 		};
 	}
+
+	export interface PublishConfig {
+		/**
+		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set --access=public. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.
+		*/
+		access?: 'public' | 'restricted';
+		/**
+		The base URL of the npm registry. Defaults to "https://registry.npmjs.org/"
+		*/
+		registry?: string;
+		/**
+		The tag to publish the package under. Defaults to "latest"
+		*/
+		tag?: string;
+	}
 }
 
 /**
@@ -608,4 +623,5 @@ PackageJson.PackageJsonStandard &
 PackageJson.NonStandardEntryPoints &
 PackageJson.TypeScriptConfiguration &
 PackageJson.YarnConfiguration &
-PackageJson.JSPMConfiguration;
+PackageJson.JSPMConfiguration &
+PackageJson.PublishConfig;

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -54,7 +54,7 @@ expectAssignable<
 >(packageJson.cpu);
 expectType<boolean | undefined>(packageJson.preferGlobal);
 expectType<boolean | undefined>(packageJson.private);
-expectType<Record<string, unknown> | undefined>(packageJson.publishConfig);
+expectType<PackageJson.PublishConfig | undefined>(packageJson.publishConfig);
 expectType<string | undefined>(packageJson.module);
 expectType<
 	| string


### PR DESCRIPTION
This change adds the interface for the PackageJson.PublishConfig.

Closes #204

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->
