### PR TITLE
Add `string[]` to `PackageJson.Exports`

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -227,6 +227,7 @@ declare namespace PackageJson {
 	*/
 	export type Exports =
 	| string
+	| string[]
 	| {[key in ExportCondition]: Exports}
 	| {[key: string]: Exports}; // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

Per Node's [docs](https://nodejs.org/dist/latest/docs/api/all.html#packages_exports) a string[] is an allowable type for the `exports` property.
