### PR TITLE
`Opaque`: Use internal unique symbol instead of `__opaque__` property

### DIFF
--- a/source/opaque.d.ts
+++ b/source/opaque.d.ts
@@ -1,4 +1,9 @@
 /**
+ Internal unique symbol
+*/
+declare const internal: unique symbol;
+
+/**
 Create an opaque type, which hides its internal details from the public, and can only be created by being used explicitly.
 
 The generic type parameter can be anything. It doesn't have to be an object.
@@ -64,4 +69,4 @@ type Person = {
 
 @category Utilities
 */
-export type Opaque<Type, Token = unknown> = Type & {readonly __opaque__: Token};
+export type Opaque<Type, Token = unknown> = Type & {readonly [internal]: Token};

--- a/source/opaque.d.ts
+++ b/source/opaque.d.ts
@@ -1,6 +1,3 @@
-/**
- Internal unique symbol
-*/
 declare const internal: unique symbol;
 
 /**


### PR DESCRIPTION
# Purpose

Instead of returning an intersection type with a public `__opaque__` property, this PR return an intersection type with a unique symbol based property.

[TS Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8mCGBHArhAagRgDwBVwQBoocB7AawgDsoBeKZSsykgd0oD5bj8oAyKAN4AnCPAAmJSgBsQUAPpySCFBAUAuYuSoBfANwAofWIgBjKfBFQTkgM7AoAS0rAIQyvCkaGDlVBsgAWwAjEikDfVBIWGVUNAAmXHwiUgpqOgYmVg4uPCj+YVEJaVkAbScXNw8AXQ0UnXDI6ABRAPgHKUwuOCRY7DshJwBzdkNGqBa2jriumPQE-qGR-QAzBhNgB0koFztulUwACghW9o0J9swASkFtQ1XKdc3qHeA92Lijk89xr-jrgVu+mslDs8kUs3U9EYzDYXAA5HDDMDQcAhMg7AFoHQYEEAFamYAAOngNhsDkGlAOCKIAjBSh6qjkUG0l1GEF2s0OqPRwExrP0AHoBVAAALAGwAWggAA9IOspUIhCQhBF2a9OR9uRiIJcgA)