### PR TITLE
Add `Includes` type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Click the type names for complete docs.
 - [`Entries`](source/entries.d.ts) - Create a type that represents the type of the entries of a collection.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
+- [`Includes`](ts41/includes.ts) - Returns a boolean for whether the given array includes the given item.
 
 ### Template literal types
 

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -8,14 +8,14 @@ const includesSingleItemArray: Includes<['colors'], 'colors'> = true;
 expectType<true>(includesSingleItemArray);
 
 const includesComplexMultiTypeArray: Includes<[
-  {
-    prop: 'value';
-    num: 5;
-    anotherArr: [1, '5', false];
-  },
-  true,
-  null,
-  'abcd'
+	{
+		prop: 'value';
+		num: 5;
+		anotherArr: [1, '5', false];
+	},
+	true,
+	null,
+	'abcd'
 ], 'abc'> = false;
 expectType<false>(includesComplexMultiTypeArray);
 

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -22,6 +22,12 @@ expectType<false>(includesComplexMultiTypeArray);
 const noExtendsProblem: Includes<[boolean], true> = false;
 expectType<false>(noExtendsProblem);
 
+const objectIncludes: Includes<[{}], { a: 1 }> = false;
+expectType<false>(objectIncludes);
+
+const objectIncludesPass: Includes<[{ a: 1 }], { a: 1 }> = true;
+expectType<true>(objectIncludesPass);
+
 // @ts-expect-error
 const noArgsIncludes: Includes<> = false;
 

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -1,5 +1,5 @@
-import {Includes} from '..';
 import {expectType} from 'tsd';
+import {Includes} from '..';
 
 const includesEmptyArray: Includes<[], 'abc'> = false;
 expectType<false>(includesEmptyArray);

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -25,7 +25,7 @@ expectType<false>(noExtendsProblem);
 const objectIncludes: Includes<[{}], { a: 1 }> = false;
 expectType<false>(objectIncludes);
 
-const objectIncludesPass: Includes<[{ a: 1 }], { a: 1 }> = true;
+const objectIncludesPass: Includes<[{a: 1}], {a: 1}> = true;
 expectType<true>(objectIncludesPass);
 
 // @ts-expect-error

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import {Includes} from '..';
 
 const includesEmptyArray: Includes<[], 'abc'> = false;
@@ -28,14 +28,12 @@ expectType<false>(objectIncludes);
 const objectIncludesPass: Includes<[{a: 1}], {a: 1}> = true;
 expectType<true>(objectIncludesPass);
 
-// @ts-expect-error
-const noArgsIncludes: Includes<> = false;
+declare const anything: any;
 
-// @ts-expect-error
-const oneArgIncludes: Includes<['my', 'array', 'has', 'stuff']> = false;
+expectError<Includes>(anything);
 
-// @ts-expect-error
-const nonArrayPassed: Includes<'why a string?', 5> = false;
+expectError<Includes<['my', 'array', 'has', 'stuff']>>(anything);
 
-// @ts-expect-error
-const objectPassed: Includes<{ key: 'value' }, 7> = false;
+expectError<Includes<'why a string?', 5>>(anything);
+
+expectError<Includes<{ key: 'value' }, 7>>(anything);

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -1,0 +1,35 @@
+import {Includes} from '..';
+import {expectType} from 'tsd';
+
+const includesEmptyArray: Includes<[], 'abc'> = false;
+expectType<false>(includesEmptyArray);
+
+const includesSingleItemArray: Includes<['colors'], 'colors'> = true;
+expectType<true>(includesSingleItemArray);
+
+const includesComplexMultiTypeArray: Includes<[
+  {
+    prop: 'value';
+    num: 5;
+    anotherArr: [1, '5', false];
+  },
+  true,
+  null,
+  'abcd'
+], 'abc'> = false;
+expectType<false>(includesComplexMultiTypeArray);
+
+const noExtendsProblem: Includes<[boolean], true> = false;
+expectType<false>(noExtendsProblem);
+
+// @ts-expect-error
+const noArgsIncludes: Includes<> = false;
+
+// @ts-expect-error
+const oneArgIncludes: Includes<['my', 'array', 'has', 'stuff']> = false;
+
+// @ts-expect-error
+const nonArrayPassed: Includes<'why a string?', 5> = false;
+
+// @ts-expect-error
+const objectPassed: Includes<{ key: 'value' }, 7> = false;

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -22,7 +22,7 @@ expectType<false>(includesComplexMultiTypeArray);
 const noExtendsProblem: Includes<[boolean], true> = false;
 expectType<false>(noExtendsProblem);
 
-const objectIncludes: Includes<[{}], { a: 1 }> = false;
+const objectIncludes: Includes<[{}], {a: 1}> = false;
 expectType<false>(objectIncludes);
 
 const objectIncludesPass: Includes<[{a: 1}], {a: 1}> = true;
@@ -36,4 +36,4 @@ expectError<Includes<['my', 'array', 'has', 'stuff']>>(anything);
 
 expectError<Includes<'why a string?', 5>>(anything);
 
-expectError<Includes<{ key: 'value' }, 7>>(anything);
+expectError<Includes<{key: 'value'}, 7>>(anything);

--- a/ts41/includes.d.ts
+++ b/ts41/includes.d.ts
@@ -5,7 +5,7 @@ Returns a boolean on whether two types are equal
 */
 type IsEqual<T, U> =
 	(<G>() => G extends T ? 1 : 2) extends
-  (<G>() => G extends U ? 1 : 2)
+	(<G>() => G extends U ? 1 : 2)
 		? true
 		: false;
 

--- a/ts41/includes.d.ts
+++ b/ts41/includes.d.ts
@@ -1,0 +1,19 @@
+/**
+Returns a boolean for whether the given array includes the given item.
+
+This can be useful if another type wants to make a decision based on whether the array includes that item.
+
+@example
+```
+import {Includes} from 'type-fest';
+
+type hasRed<arr extends any[]> = Includes<arr, 'red'>;
+```
+
+@category Utilities
+*/
+export type Includes<Value extends any[], Item> = {
+	[P in keyof Value & number as Value[P]]: true;
+}[Item] extends true
+	? true
+	: false;

--- a/ts41/includes.d.ts
+++ b/ts41/includes.d.ts
@@ -7,7 +7,7 @@ This can be useful if another type wants to make a decision based on whether the
 ```
 import {Includes} from 'type-fest';
 
-type hasRed<arr extends any[]> = Includes<arr, 'red'>;
+type hasRed<array extends any[]> = Includes<array, 'red'>;
 ```
 
 @category Utilities

--- a/ts41/includes.d.ts
+++ b/ts41/includes.d.ts
@@ -1,4 +1,15 @@
 /**
+Returns a boolean on whether two types are equal
+
+@link https://github.com/microsoft/TypeScript/issues/27024#issuecomment-421529650
+*/
+type IsEqual<T, U> =
+	(<G>() => G extends T ? 1 : 2) extends
+  (<G>() => G extends U ? 1 : 2)
+		? true
+		: false;
+
+/**
 Returns a boolean for whether the given array includes the given item.
 
 This can be useful if another type wants to make a decision based on whether the array includes that item.
@@ -12,8 +23,9 @@ type hasRed<array extends any[]> = Includes<array, 'red'>;
 
 @category Utilities
 */
-export type Includes<Value extends any[], Item> = {
-	[P in keyof Value & number as Value[P]]: true;
-}[Item] extends true
-	? true
-	: false;
+export type Includes<Value extends any[], Item> =
+	IsEqual<Value[0], Item> extends true
+		? true
+		: Value extends [Value[0], ...infer rest]
+			? Includes<rest, Item>
+			: false;

--- a/ts41/includes.d.ts
+++ b/ts41/includes.d.ts
@@ -1,5 +1,5 @@
 /**
-Returns a boolean on whether two types are equal
+Returns a boolean for whether given two types are equal.
 
 @link https://github.com/microsoft/TypeScript/issues/27024#issuecomment-421529650
 */

--- a/ts41/index.d.ts
+++ b/ts41/index.d.ts
@@ -20,5 +20,6 @@ export {DelimiterCasedProperties} from './delimiter-cased-properties';
 export {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';
 export {Split} from './split';
 export {Trim} from './trim';
+export {Includes} from './includes';
 export {Get} from './get';
 export {LastArrayElement} from './last-array-element';

--- a/ts41/screaming-snake-case.d.ts
+++ b/ts41/screaming-snake-case.d.ts
@@ -1,14 +1,6 @@
 import {SplitIncludingDelimiters} from './delimiter-case';
 import {SnakeCase} from './snake-case';
-
-/**
-Returns a boolean for whether the given array includes the given item.
-*/
-type Includes<Value extends any[], Item> = {
-	[P in keyof Value & number as Value[P]]: true;
-}[Item] extends true
-	? true
-	: false;
+import {Includes} from './includes';
 
 /**
 Returns a boolean for whether the string is screaming snake case.


### PR DESCRIPTION
Resolves #216

The problem is that my solution to `Includes` works only with the `PropertyKey` type for `Item`, because it makes the values the key and the value a boolean, then checks if the value is true for the property with the key of `Item`. The other solution is:

```ts
type Includes<T extends readonly any[], U> = U extends T[number] ? true : false;
```

However as shown in type-challenges/type-challenges#1432, this solution does not work, because it uses `extends` allowing `[{a: 5}]` to include `{}`. Any ideas on supporting `Item` for types other than `PropertyKey` and at the same time not running into the `extends` problem (https://github.com/Yash-Singh1/type-fest/blob/main/test-d/includes.ts#L22)?