### PR TITLE
add aliases for template literal case types

### DIFF
--- a/ts41/index.d.ts
+++ b/ts41/index.d.ts
@@ -2,19 +2,68 @@
 export * from '../base';
 
 // These are special types that require at least TypeScript 4.1.
-export {CamelCase} from './camel-case';
-export {CamelCasedProperties} from './camel-cased-properties';
-export {CamelCasedPropertiesDeep} from './camel-cased-properties-deep';
-export {KebabCase} from './kebab-case';
-export {KebabCasedProperties} from './kebab-cased-properties';
-export {KebabCasedPropertiesDeep} from './kebab-cased-properties-deep';
-export {PascalCase} from './pascal-case';
-export {PascalCasedProperties} from './pascal-cased-properties';
-export {PascalCasedPropertiesDeep} from './pascal-cased-properties-deep';
-export {SnakeCase} from './snake-case';
-export {SnakeCasedProperties} from './snake-cased-properties';
-export {SnakeCasedPropertiesDeep} from './snake-cased-properties-deep';
-export {ScreamingSnakeCase} from './screaming-snake-case';
+export {
+	CamelCase,
+	CamelCase as DromedaryCase,
+} from './camel-case';
+export {
+	CamelCasedProperties,
+	CamelCasedProperties as DromedaryCasedProperties,
+} from './camel-cased-properties';
+export {
+	CamelCasedPropertiesDeep,
+	CamelCasedPropertiesDeep as DromedaryCasedPropertiesDeep,
+} from './camel-cased-properties-deep';
+export {
+	KebabCase,
+	KebabCase as DashCase,
+	KebabCase as LispCase,
+	KebabCase as ParamCase,
+} from './kebab-case';
+export {
+	KebabCasedProperties,
+	KebabCasedProperties as DashCasedProperties,
+	KebabCasedProperties as LispCasedProperties,
+	KebabCasedProperties as ParamCasedProperties,
+} from './kebab-cased-properties';
+export {
+	KebabCasedPropertiesDeep,
+	KebabCasedPropertiesDeep as DashCasedPropertiesDeep,
+	KebabCasedPropertiesDeep as LispCasedPropertiesDeep,
+	KebabCasedPropertiesDeep as ParamCasedPropertiesDeep,
+} from './kebab-cased-properties-deep';
+export {
+	PascalCase,
+	PascalCase as StudlyCase,
+	PascalCase as UpperCamelCase,
+} from './pascal-case';
+export {
+	PascalCasedProperties,
+	PascalCasedProperties as StudlyCasedProperties,
+	PascalCasedProperties as UpperCamelCasedProperties,
+} from './pascal-cased-properties';
+export {
+	PascalCasedPropertiesDeep,
+	PascalCasedPropertiesDeep as StudlyCasedPropertiesDeep,
+	PascalCasedPropertiesDeep as UpperCamelCasedPropertiesDeep,
+} from './pascal-cased-properties-deep';
+export {
+	SnakeCase,
+	SnakeCase as PotholeCase,
+} from './snake-case';
+export {
+	SnakeCasedProperties,
+	SnakeCasedProperties as PotholeCasedProperties,
+} from './snake-cased-properties';
+export {
+	SnakeCasedPropertiesDeep,
+	SnakeCasedPropertiesDeep as PotholeCasedPropertiesDeep
+} from './snake-cased-properties-deep';
+export {
+	ScreamingSnakeCase,
+	ScreamingSnakeCase as ConstantCase,
+	ScreamingSnakeCase as MacroCase
+} from './screaming-snake-case';
 export {DelimiterCase} from './delimiter-case';
 export {DelimiterCasedProperties} from './delimiter-cased-properties';
 export {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';


### PR DESCRIPTION
aliases exports of template literal types for identifier formats (`FooCase` types) with other common names of those wrd cases

#### Why would we care about the identifier name?
- **Familiarity:** I'm never going to remember that "screaming snake case" is a real thing
- **Avoiding frivolous or offensive language:** Kebabs... camels... the community is moving away from this type of labeling
- **Using terms for naming conventions that relate to their primary use case:** For example, it's much easier for some to remember that "param case" is used for params as opposed to "kebab case" (kebabs even aren't always on sticks)
- A team is likely to have a common, domain-agnostic language for naming conventions, that may be influenced by any of the above concerns