### PR TITLE
Fix `CamelCase` behavior when value is in uppercase

### DIFF
--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -37,6 +37,12 @@ expectType<'veryPrefixed'>(camelFromDoublePrefixedKebab);
 const camelFromRepeatedSeparators: CamelCase<'foo____bar'> = 'fooBar';
 expectType<'fooBar'>(camelFromRepeatedSeparators);
 
+const camelFromUppercase: CamelCase<'FOO'> = 'foo';
+expectType<'foo'>(camelFromUppercase);
+
+const camelFromLowercase: CamelCase<'foo'> = 'foo';
+expectType<'foo'>(camelFromLowercase);
+
 // Verifying example
 type CamelCasedProperties<T> = {
 	[K in keyof T as CamelCase<K>]: T[K]
@@ -46,10 +52,12 @@ interface RawOptions {
 	'dry-run': boolean;
 	'full_family_name': string;
 	foo: number;
+	BAR: string;
 }
 
 expectAssignable<CamelCasedProperties<RawOptions>>({
 	dryRun: true,
 	fullFamilyName: 'bar.js',
-	foo: 123
+	foo: 123,
+	bar: 'foo'
 });

--- a/ts41/camel-case.d.ts
+++ b/ts41/camel-case.d.ts
@@ -63,4 +63,4 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 
 @category Template Literals
 */
-export type CamelCase<K> = K extends string ? CamelCaseStringArray<Split<K, WordSeparators>> : K;
+export type CamelCase<K> = K extends string ? K extends Uppercase<K> ? Lowercase<K> : CamelCaseStringArray<Split<K, WordSeparators>> : K;


### PR DESCRIPTION
When using `CamelCase` with uppercase value the behavior is incorrect

# Current Behavior

```javascript
const camelFromUppercase: CamelCase<'FOO'> = 'fOO';
```

# Expected Behavior (like [lodash](https://www.npmjs.com/package/lodash) or [camelcase](https://www.npmjs.com/package/camelcase))
```javascript
const camelFromUppercase: CamelCase<'FOO'> = 'foo';
```
