### PR TITLE
Fix `Split` type

### DIFF
--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -8,23 +8,23 @@ declare function split<
 
 const items = 'foo,bar,baz,waldo';
 
-// General use
+// General use.
 expectType<['foo', 'bar', 'baz', 'waldo']>(split(items, ','));
 
-// Non-present character
+// Missing replacement character in original string.
 expectType<['foo,bar,baz,waldo']>(split(items, ' '));
 
-// Empty string split (every char)
+// Empty string split (every character).
 expectType<[
 	'f', 'o', 'o', ',', 'b', 'a', 'r', ',',
 	'b', 'a', 'z', ',', 'w', 'a', 'l', 'd', 'o'
 ]>(split(items, ''));
 
-// Split single-same-character
+// Split single same character.
 expectType<['', '']>(split(' ', ' '));
 
-// Split empty string by empty string
+// Split empty string by empty string.
 expectType<[]>(split('', ''));
 
-// Split empty string by any string
+// Split empty string by any string.
 expectType<['']>(split('', ' '));

--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -1,12 +1,30 @@
 import {expectType} from 'tsd';
 import {Split} from '../ts41';
 
-declare function split<S extends string, D extends string>(string: S, separator: D): Split<S, D>;
+declare function split<
+	S extends string,
+	Delimiter extends string
+>(string: S, separator: Delimiter): Split<S, Delimiter>;
 
 const items = 'foo,bar,baz,waldo';
-const array = split(items, ',');
 
-expectType<'foo'>(array[0]);
-expectType<'bar'>(array[1]);
-expectType<'baz'>(array[2]);
-expectType<'waldo'>(array[3]);
+// General use
+expectType<['foo', 'bar', 'baz', 'waldo']>(split(items, ','));
+
+// Non-present character
+expectType<['foo,bar,baz,waldo']>(split(items, ' '));
+
+// Empty string split (every char)
+expectType<[
+	'f', 'o', 'o', ',', 'b', 'a', 'r', ',',
+	'b', 'a', 'z', ',', 'w', 'a', 'l', 'd', 'o'
+]>(split(items, ''));
+
+// Split single-same-character
+expectType<['', '']>(split(' ', ' '));
+
+// Split empty string by empty string
+expectType<[]>(split('', ''));
+
+// Split empty string by any string
+expectType<['']>(split('', ' '));

--- a/ts41/split.d.ts
+++ b/ts41/split.d.ts
@@ -18,7 +18,11 @@ array = split(items, ',');
 
 @category Template Literals
 */
-export type Split<S extends string, D extends string> =
-	S extends `${infer T}${D}${infer U}`
-		? [T, ...Split<U, D>]
-		: [S];
+export type Split<
+    S extends string,
+    Delimiter extends string = ""
+> = S extends `${infer Si}${Delimiter}${infer Sj}`
+    ? [Si, ...Split<Sj, Delimiter>]
+    : S extends Delimiter
+    ? []
+    : [S];

--- a/ts41/split.d.ts
+++ b/ts41/split.d.ts
@@ -19,10 +19,10 @@ array = split(items, ',');
 @category Template Literals
 */
 export type Split<
-    S extends string,
-    Delimiter extends string = ""
-> = S extends `${infer Si}${Delimiter}${infer Sj}`
-    ? [Si, ...Split<Sj, Delimiter>]
-    : S extends Delimiter
-    ? []
-    : [S];
+	S extends string,
+	Delimiter extends string
+> = S extends `${infer Head}${Delimiter}${infer Tail}`
+	? [Head, ...Split<Tail, Delimiter>]
+	: S extends Delimiter
+	? []
+	: [S];


### PR DESCRIPTION
Consider the input:

```ts
Split<"a", "">
```

You would expect this to give the single length tuple `["a"]` , but it gives `["a", ""]`.

In addition, the default for the delimiter should be `""`, and that has been added.

This is necessary due to the statement in the doc comment about writing a signature for
String.prototype.split, which has `""` as the default delimiter.

> Use-case: Defining the return type of a method like `String.prototype.split`.
