### PR TITLE
Add `ExactMatch` type

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -35,6 +35,7 @@ export {Entry} from './source/entry';
 export {Entries} from './source/entries';
 export {SetReturnType} from './source/set-return-type';
 export {Asyncify} from './source/asyncify';
+export {ExactMatch} from './source/exact-match';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Click the type names for complete docs.
 - [`Entries`](source/entries.d.ts) - Create a type that represents the type of the entries of a collection.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
+- [`ExactMatch`](source/exact-match.d.ts) - Returns a `boolean` type to determine if the two types match exactly.
 
 ### Template literal types
 

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ Click the type names for complete docs.
 - [`Entries`](source/entries.d.ts) - Create a type that represents the type of the entries of a collection.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
-- [`ExactMatch`](source/exact-match.d.ts) - Returns a `boolean` type to determine if the two types match exactly.
+- [`ExactMatch`](source/exact-match.d.ts) - Returns a boolean for whether the given two types match exactly.
 
 ### Template literal types
 

--- a/source/exact-match.d.ts
+++ b/source/exact-match.d.ts
@@ -1,0 +1,55 @@
+/**
+Returns a `boolean` type to determine if the two types match exactly.
+
+This can be useful if another type wants to make a decision based on whether one type is exactly the same as the other, with the same keys of the same types.
+
+If you just use the `extends` expression as equality, the result will be `true` even if one of the types has extra keys.
+
+@example
+```
+import {ExactMatch} from 'type-fest';
+
+interface Foo {
+  a: number;
+  b: string;
+}
+
+interface Bar extends Foo {
+  c: number;
+}
+
+type TestOptions<FooLike> = ExactMatch<FooLike, Foo> extends true ? { foo?: FooLike } : { foo: FooLike }
+
+class Test<FooLike extends Foo = Foo> {
+  private foo: FooLike = { a: 1, b: 'a' } as FooLike;
+
+  constructor(options: TestOptions<FooLike>) {
+    if (options.foo) {
+      this.foo = options.foo;
+    }
+  }
+}
+
+// With the default type it is not necessary to specify the options.
+const a = new Test({})
+
+// With a custom type you need to pass the options to the constructor
+// because the new type has the extra key `c`.
+const b = new Test<Bar>({
+  foo: {
+    a: 1,
+    b: 'a',
+    c: 2
+  }
+})
+```
+
+@category Utilities
+*/
+export type ExactMatch<FirstType, SecondType> =
+  FirstType extends SecondType ?
+    Exclude<keyof FirstType, keyof SecondType> extends never ?
+      Exclude<keyof SecondType, keyof FirstType> extends never ? true
+      : false
+    : false
+  : false;

--- a/source/exact-match.d.ts
+++ b/source/exact-match.d.ts
@@ -18,7 +18,7 @@ interface Bar extends Foo {
   c: number;
 }
 
-type TestOptions<FooLike> = ExactMatch<FooLike, Foo> extends true ? { foo?: FooLike } : { foo: FooLike }
+type TestOptions<FooLike> = ExactMatch<FooLike, Foo> extends true ? {foo?: FooLike} : {foo: FooLike}
 
 class Test<FooLike extends Foo = Foo> {
   private foo: FooLike = { a: 1, b: 'a' } as FooLike;

--- a/test-d/exact-match.ts
+++ b/test-d/exact-match.ts
@@ -26,7 +26,7 @@ expectType<false>(exampleTypeWithFewerKeys);
 declare const exampleTypeWithFewerKeysReverse: ExactMatch<Baz, Foo>;
 expectType<false>(exampleTypeWithFewerKeysReverse);
 
-declare const exampleTypeExactMatch: ExactMatch<Foo & { c: boolean }, Bar>;
+declare const exampleTypeExactMatch: ExactMatch<Foo & {c: boolean}, Bar>;
 expectType<true>(exampleTypeExactMatch);
 
 declare const exampleTypeExactMatchReverse: ExactMatch<Bar, Foo & { c: boolean }>;

--- a/test-d/exact-match.ts
+++ b/test-d/exact-match.ts
@@ -1,0 +1,39 @@
+import {expectType} from 'tsd';
+import {ExactMatch} from '..';
+
+interface Foo {
+  a: number;
+  b: string;
+}
+
+interface Bar extends Foo {
+  c: boolean;
+}
+
+interface Baz {
+  a: number;
+}
+
+declare const exampleTypeWithMoreKeys: ExactMatch<Foo, Bar>;
+expectType<false>(exampleTypeWithMoreKeys);
+
+declare const exampleTypeWithMoreKeysReverse: ExactMatch<Bar, Foo>;
+expectType<false>(exampleTypeWithMoreKeysReverse);
+
+declare const exampleTypeWithFewerKeys: ExactMatch<Foo, Baz>;
+expectType<false>(exampleTypeWithFewerKeys);
+
+declare const exampleTypeWithFewerKeysReverse: ExactMatch<Baz, Foo>;
+expectType<false>(exampleTypeWithFewerKeysReverse);
+
+declare const exampleTypeExactMatch: ExactMatch<Foo & { c: boolean }, Bar>;
+expectType<true>(exampleTypeExactMatch);
+
+declare const exampleTypeExactMatchReverse: ExactMatch<Bar, Foo & { c: boolean }>;
+expectType<true>(exampleTypeExactMatchReverse);
+
+declare const exampleOmitKey: ExactMatch<Omit<Foo, 'b'>, Baz>;
+expectType<true>(exampleOmitKey);
+
+declare const exampleOmitKeyReverse: ExactMatch<Baz, Omit<Foo, 'b'>>;
+expectType<true>(exampleOmitKeyReverse);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->
This type can be useful if another type wants to make a decision based on whether one type is exactly the same as the other, with the same keys of the same types.
If you just use the `extends` expression as equality, the result will be `true` even if one of the types has extra keys.

I needed this type to do something like the example below:
```ts
import {ExactMatch} from 'type-fest';

interface Foo {
  a: number;
  b: string;
}

interface Bar extends Foo {
  c: number;
}

type TestOptions<FooLike> = ExactMatch<FooLike, Foo> extends true ? { foo?: FooLike } : { foo: FooLike }

class Test<FooLike extends Foo = Foo> {
  private foo: FooLike = { a: 1, b: 'a' } as FooLike;

  constructor(options: TestOptions<FooLike>) {
    if (options.foo) {
      this.foo = options.foo;
    }
  }
}

// With the default type it is not necessary to specify the options.
const a = new Test({})

// With a custom type you need to pass the options to the constructor
// because the new type has the extra key `c`.
const b = new Test<Bar>({
  foo: {
    a: 1,
    b: 'a',
    c: 2
  }
})
```