### PR TITLE
Export `Simplify` type

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -35,6 +35,7 @@ export {Entry} from './source/entry';
 export {Entries} from './source/entries';
 export {SetReturnType} from './source/set-return-type';
 export {Asyncify} from './source/asyncify';
+export {Simplify} from './source/simplify';
 
 // Miscellaneous
 export {PackageJson} from './source/package-json';

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Click the type names for complete docs.
 - [`Entries`](source/entries.d.ts) - Create a type that represents the type of the entries of a collection.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Asyncify`](source/asyncify.d.ts) - Create an async version of the given function type.
+- [`Simplify`](source/simplify.d.ts) - Flatten the type output to improve type hints shown in editors.
 
 ### Template literal types
 

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -15,7 +15,7 @@ type SizeProps = {
 	height: number;
 };
 
-// In your editor, hovering over `Props` will show a flattened object with all the props.
+// In your editor, hovering over `Props` will show a flattened object with all the properties.
 type Props = Simplify<PositionProps & SizeProps>;
 ```
 

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -1,4 +1,24 @@
 /**
 Flatten the type output to improve type hints shown in editors.
+
+@example
+```
+import {Simplify} from 'type-fest';
+
+type PositionProps = {
+	top: number;
+	left: number;
+};
+
+type SizeProps = {
+	width: number;
+	height: number;
+};
+
+// In your editor, hovering over `Props` will show a flattened object with all the props.
+type Props = Simplify<PositionProps & SizeProps>;
+```
+
+@category Utilities
 */
 export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]};


### PR DESCRIPTION
Per #172, export the `Simplify` type to allow `type-fest` users to flatten object intersections.