### PR TITLE
Add `SetNonNullable` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ export {ReadonlyDeep} from './source/readonly-deep';
 export {LiteralUnion} from './source/literal-union';
 export {Promisable} from './source/promisable';
 export {Opaque} from './source/opaque';
+export {SetNonNullable} from './source/set-non-nullable';
 export {SetOptional} from './source/set-optional';
 export {SetRequired} from './source/set-required';
 export {ValueOf} from './source/value-of';

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Click the type names for complete docs.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 - [`Promisable`](source/promisable.d.ts) - Create a type that represents either the value or the value wrapped in `PromiseLike`.
 - [`Opaque`](source/opaque.d.ts) - Create an [opaque type](https://codemix.com/opaque-types-in-javascript/).
+- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, undefined and null) types from the given keys.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ Click the type names for complete docs.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 - [`Promisable`](source/promisable.d.ts) - Create a type that represents either the value or the value wrapped in `PromiseLike`.
 - [`Opaque`](source/opaque.d.ts) - Create an [opaque type](https://codemix.com/opaque-types-in-javascript/).
-- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, undefined and null) types from the given keys.
+- [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that removes nullish (optional, `undefined`, and `null`) types from the given keys.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -2,7 +2,7 @@ import {Except} from './except';
 import {Simplify} from './simplify';
 
 /**
-Create a type that makes the given keys non-nullable. The remaining keys are kept as is.
+Create a type removes nullish (optional, undefined and null) types from the given keys. The remaining keys are kept as is.
 
 Use-case: You want to define a single model where the only thing that changes is whether or not some of the keys are required.
 
@@ -21,7 +21,7 @@ type Foo = {
 type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
 // type SomeNonNullable = {
 // 	a?: number;
-// 	b: string; // Was already non-null and still is.
+// 	b: string; // Was already not nullish and still is.
 // 	c: boolean; // Is now not optional.
 //  d: number; // Is now not null
 //	e: string; // Is now not undefined

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -1,0 +1,36 @@
+import {Except} from './except';
+import {Simplify} from './simplify';
+
+/**
+Create a type that makes the given keys non-nullable. The remaining keys are kept as is.
+
+Use-case: You want to define a single model where the only thing that changes is whether or not some of the keys are required.
+
+@example
+```
+import {SetNonNullable} from 'type-fest';
+
+type Foo = {
+	a?: number;
+	b: string;
+	c?: boolean;
+	d: number | null;
+	e: string | undefined;
+}
+
+type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
+// type SomeNonNullable = {
+// 	a?: number;
+// 	b: string; // Was already non-null and still is.
+// 	c: boolean; // Is now not optional.
+//  d: number; // Is now not null
+//	e: string; // Is now not undefined
+// }
+```
+*/
+export type SetNonNullable<BaseType, Keys extends keyof BaseType> = Simplify<
+	// Pick just the keys that are optional from the base type.
+	Except<BaseType, Keys> &
+		// For each 'Key' provided, make it not optional or nullable
+		{ [Key in Keys]-?: NonNullable<BaseType[Key]> }
+>;

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -50,5 +50,5 @@ export type SetNonNullable<BaseType, Keys extends keyof BaseType> = Simplify<
 	// Pick just the keys that are optional from the base type.
 	Except<BaseType, Keys> &
 		// For each 'Key' provided, make it not optional or nullable
-		{ [Key in Keys]-?: NonNullable<BaseType[Key]> }
+		{[Key in Keys]-?: NonNullable<BaseType[Key]>}
 >;

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -2,7 +2,8 @@ import {Except} from './except';
 import {Simplify} from './simplify';
 
 /**
-Create a type removes nullish (optional, undefined and null) types from the given keys. The remaining keys are kept as is.
+Create a type that removes nullish (optional, undefined and null) types from the given keys. The remaining keys are kept as is.
+This behaves in a similar manor to `SetRequired<T,K>` by removing optionals, however also applies the `NonNullable<T>` operator to the values at the specified keys.
 
 Use-case: You want to define a single model where the only thing that changes is whether or not some of the keys are required.
 
@@ -26,7 +27,24 @@ type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
 //  d: number; // Is now not null
 //	e: string; // Is now not undefined
 // }
+
+function hasRequiredKeys(foo: Foo): foo is SomeNonNullable;
 ```
+
+This is especially useful in cases where you want to write a type-guard that asserts one or more values of an object are not null.
+
+@example
+```
+type Person {
+	firstName?: string | null;
+	lastName?: string | null;
+}
+
+function hasFirstName(person: Person) person is SetNonNullable<Person, "firstName"> {
+	return typeof person.firstName === "string";
+}
+```
+
 */
 export type SetNonNullable<BaseType, Keys extends keyof BaseType> = Simplify<
 	// Pick just the keys that are optional from the base type.

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -24,8 +24,8 @@ type SomeNonNullable = SetNonNullable<Foo, 'b' | 'c' | 'd' | 'e'>;
 // 	a?: number;
 // 	b: string; // Was already not nullish and still is.
 // 	c: boolean; // Is now not optional.
-//  d: number; // Is now not null
-//	e: string; // Is now not undefined
+//  d: number; // Is now not null.
+//	e: string; // Is now not undefined.
 // }
 
 function hasRequiredKeys(foo: Foo): foo is SomeNonNullable;

--- a/source/set-non-nullable.d.ts
+++ b/source/set-non-nullable.d.ts
@@ -41,7 +41,7 @@ type Person {
 }
 
 function hasFirstName(person: Person) person is SetNonNullable<Person, "firstName"> {
-	return typeof person.firstName === "string";
+	return person.firstName != null;
 }
 ```
 

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -1,7 +1,7 @@
 import {expectType, expectError} from 'tsd';
 import {SetNonNullable} from '..';
 
-// Update nullish fields to be non-null, leave one unchanged.
+// Update nullish fields to be non-null and leave one unchanged.
 declare const variation1: SetNonNullable<
 	{
 		a?: string;
@@ -16,7 +16,7 @@ expectType<{a?: string; b: string; c: string; d: string; e: string}>(
 	variation1,
 );
 
-// Remove optional, undefined and null, leave one unchanged.
+// Remove optional, undefined, and null. Leave one unchanged.
 declare const variation2: SetNonNullable<
 	{a?: number | null | undefined; b?: number | null | undefined},
 	'a'

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -12,20 +12,20 @@ declare const variation1: SetNonNullable<
 	},
 	'b' | 'c' | 'd' | 'e'
 >;
-expectType<{ a?: string; b: string; c: string; d: string; e: string }>(
-	variation1
+expectType<{a?: string; b: string; c: string; d: string; e: string}>(
+	variation1,
 );
 
 // Remove optional, undefined and null, leave one unchanged.
 declare const variation2: SetNonNullable<
-	{ a?: number | null | undefined; b?: number | null | undefined },
+	{a?: number | null | undefined; b?: number | null | undefined},
 	'a'
 >;
-expectType<{ a: number; b?: number | null | undefined }>(variation2);
+expectType<{a: number; b?: number | null | undefined}>(variation2);
 
 // Fail if type changes even if optional is right.
 declare const variation3: SetNonNullable<
-	{ a?: number; b: string; c?: boolean | null | undefined },
+	{a?: number; b: string; c?: boolean | null | undefined},
 	'b' | 'c'
 >;
-expectError<{ a?: boolean; b: string; c: boolean }>(variation3);
+expectError<{a?: boolean; b: string; c: boolean}>(variation3);

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -1,0 +1,31 @@
+import {expectType, expectError} from 'tsd';
+import {SetNonNullable} from '..';
+
+// Update nullish fields to be non-null, leave one unchanged.
+declare const variation1: SetNonNullable<
+	{
+		a?: string;
+		b: string;
+		c?: string;
+		d: string | null;
+		e: string | undefined;
+	},
+	'b' | 'c' | 'd' | 'e'
+>;
+expectType<{ a?: string; b: string; c: string; d: string; e: string }>(
+	variation1
+);
+
+// Remove optional, undefined and null, leave one unchanged.
+declare const variation2: SetNonNullable<
+	{ a?: number | null | undefined; b?: number | null | undefined },
+	'a'
+>;
+expectType<{ a: number; b?: number | null | undefined }>(variation2);
+
+// Fail if type changes even if optional is right.
+declare const variation3: SetNonNullable<
+	{ a?: number; b: string; c?: boolean | null | undefined },
+	'b' | 'c'
+>;
+expectError<{ a?: boolean; b: string; c: boolean }>(variation3);


### PR DESCRIPTION
Adds `SetNonNullable<Type, Keys>` which allows someone to remove nullish values at specific keys of an object. This is useful when defining type guards.

```ts
type Person {
	firstName?: string | null;
	lastName?: string | null;
}

function hasFirstName(person: Person) person is SetNonNullable<Person, "firstName"> {
	return person.firstName != null;
}
```

Continuation of https://github.com/sindresorhus/type-fest/pull/199
Addresses https://github.com/sindresorhus/type-fest/issues/228

If anything is still missing let me know, I've tried to fulfil the contributing guidelines.