### PR TITLE
Add `ExtendsOr`, `ExtendsAnd`, and `ExtendsThenElse` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,11 @@ export {SetReturnType} from './source/set-return-type';
 export {Asyncify} from './source/asyncify';
 export {Simplify} from './source/simplify';
 export {Jsonify} from './source/jsonify';
+export {
+    ExtendsOr,
+    ExtendsAnd,
+    ExtendsThenElse,
+} from './source/extends-or-and-then-else';
 
 // Template literal types
 export {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ Click the type names for complete docs.
 - [`Includes`](source/includes.ts) - Returns a boolean for whether the given array includes the given item.
 - [`Simplify`](source/simplify.d.ts) - Flatten the type output to improve type hints shown in editors.
 - [`Jsonify`](source/jsonify.d.ts) - Transform a type to one that is assignable to the `JsonValue` type.
+- [`ExtendsOr, ExtendsAnd, ExtendsThenElse`](source/extends-or-and-then-else.d.ts) - `A extends B ? A : C`, `A extends B ? C : A,` `A extends B ? C : D` respectively. A small collection of short-circuit and other conditional shorthands (e.g. || and && type utilities).
 
 ### Template literal types
 

--- a/source/extends-or-and-then-else.d.ts
+++ b/source/extends-or-and-then-else.d.ts
@@ -1,0 +1,129 @@
+/**
+Can be used as a short-circuit-esque/fallback-esque operator.
+Probably most useful when the underlying type of the 1st passed
+parameter is unknown or a union of sorts (such as in Object[key]
+or Array[key] situations), but can be used anywhere a shorthand
+for `A extends B ? A : C` seems useful.
+
+@example
+```
+import {ExtendsOr} from 'type-fest';
+
+// Say we are trying to convert an async api that uses callbacks
+// as the last param to use native promises instead, resolving the
+// last param the callback is called with (e.g. npm request package).
+// We don't want Functions that don't take a Function as their last
+// param to be promise-wrapped, nor do we want to alter the types of
+// non-Function properties.
+
+type PromiseApi = {
+    [key in keyof Api]: LastTupleElement<
+        Parameters<
+            ExtendsOr<
+                Api[key], // <--unsure if Function,
+                // outer Parameters<> would err without ExtendsOr<> here
+                Function, // <--if Function, passthru type
+                (a: 0) => void // <--else fallback to this
+            >
+        >
+    > extends Function
+        ? (
+              ...args: RemoveLastParam<Api[key]>
+          ) => Promise<
+              LastTupleElement<
+                  Parameters<LastTupleElement<Parameters<Api[key]>>>
+              >
+          >
+        : Api[key]; // passthru everything else untouched, including:
+                    // non-Function types, Functions with no params,
+                    // and Functions whose last param isn't Function
+};
+```
+
+@category Utilities
+*/
+export type ExtendsOr<SomeType, Test, OrType> = SomeType extends Test
+    ? SomeType
+    : OrType;
+
+/**
+The inverse of ExtendsOr<>.
+
+Probably most useful when the underlying type of the 1st passed
+parameter is unknown or a union of sorts (such as in Object[key]
+or Array[key] situations), but can be used anywhere a shorthand
+for `A extends B ? C : A` seems useful. @see ExtendsOr
+
+@example
+```
+import {ExtendsAnd} from 'type-fest';
+
+type TruthyObject<Obj> = {
+    [key in keyof Obj]: ExtendsAnd<Obj[k], boolean, true>;
+};
+
+// TruthyObject<{ notBool: string; bool1: boolean; bool2: boolean }>
+
+// becomes...
+
+// {
+//     notBool: string;
+//     bool1: true;
+//     bool2: true;
+// }
+```
+
+@category Utilities
+*/
+export type ExtendsAnd<SomeType, Test, AndType> = SomeType extends Test
+    ? AndType
+    : SomeType;
+
+/**
+Conditional shorthand.
+
+Can be used anywhere a conditional expression could,
+but otherwise cannot be used to "infer" types.
+
+@example
+```
+import {ExtendsThenElse, ExtendsAnd} from 'type-fest';
+
+type TruthyObjectWithDates<Obj> = {
+    [key in keyof Obj]: ExtendsThenElse<
+        Obj[key],
+        boolean,
+        true,
+        ExtendsAnd<
+            Obj[key],
+            string,
+            `${number}${number}${number}${number}-${number}${number}-${number}${number}`
+        >
+    >;
+};
+
+// TruthyObjectWithDates<{
+//     date1: string;
+//     bool1: boolean;
+//     bool2: boolean;
+//     leftAlone: Function
+// }>
+
+// becomes...
+
+// {
+//     date1: `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
+//     bool1: true;
+//     bool2: true;
+//     leftAlone: Function
+// }
+```
+
+@category Utilities
+*/
+export type ExtendsThenElse<
+    SomeType,
+    Test,
+    ThenValue,
+    ElseValue,
+> = SomeType extends Test ? ThenValue : ElseValue;

--- a/test-d/extends-or-and-then-else.ts
+++ b/test-d/extends-or-and-then-else.ts
@@ -1,0 +1,14 @@
+import {expectType} from 'tsd';
+import {ExtendsOr, ExtendsAnd, ExtendsThenElse} from '../index';
+
+declare const bool: boolean;
+declare const string: string;
+
+expectType<ExtendsOr<typeof bool, boolean, string>>(bool); // Passthru match
+expectType<ExtendsOr<typeof bool, Function, string>>(string); // Fallback/short-circuit non-match
+
+expectType<ExtendsAnd<typeof bool, boolean, string>>(string); // Coerce match
+expectType<ExtendsAnd<typeof bool, Function, string>>(bool); // Passthru non-match
+
+expectType<ExtendsThenElse<typeof bool, boolean, string, never>>(string); // Then
+expectType<ExtendsThenElse<typeof bool, Function, never, string>>(string); // Else


### PR DESCRIPTION
A few basic utility types that act as `||` and `&&` shorthands. 

The third type is simply an if/then/else conditional which simply mirrors the behavior of typescript's `extends` ternary conditional expression (yeah I know not very useful but it allows for alternative syntax/style).

These utilities could also have other names such as:
`ExtendsOr` -> `Or`
`ExtendsAnd` -> `And`
`ExtendsThenElse` -> `Cond` or `Condition` or `Conditional` or `Ternary` etc.
...but I thought these names were ok.

These are all simple utilities, so how they work should be rather easy to figure out, although I did try to provide some examples (including an example that reflects a problem that originally inspired this idea having to do with Parameters<> erroring if it is not sure that it is receiving a Function).