### PR TITLE
Accept non-JSON types with `.toJSON()` method in `Jsonify` type

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -4,10 +4,11 @@ import {JsonPrimitive, JsonValue} from './basic';
 type NotJsonable = ((...args: any[]) => any) | undefined;
 
 /**
-Transform a type to one that is assignable to the `JsonValue` type. This includes:
+Transform a type to one that is assignable to the `JsonValue` type.
 
-1. Transforming JSON `interface` to a `type` that is assignable to `JsonValue`
-2. Transforming non JSON that is **Jsonable**, to a type that is assignable to JsonValue. Where **Jsonable** means the non JSON value implements `.toJSON()` method that returns a value that is assignable to `JsonValue`.
+This includes:
+1. Transforming JSON `interface` to a `type` that is assignable to `JsonValue`.
+2. Transforming non-JSON value that is *jsonable* to a type that is assignable to `JsonValue`, where *jsonable* means the non-JSON value implements the `.toJSON()` method that returns a value that is assignable to `JsonValue`.
 
 @remarks
 
@@ -39,15 +40,16 @@ fixedFn(point); // Good: point is assignable. Jsonify<T> transforms Geometry int
 fixedFn(new Date()); // Error: As expected, Date is not assignable. Jsonify<T> cannot transforms Date into value assignable to JsonValue
 ```
 
-Non-JSON values such as `Date` implement `.toJSON()`, so they can be transformed to a value assignable to `JsonValue`.
+Non-JSON values such as `Date` implement `.toJSON()`, so they can be transformed to a value assignable to `JsonValue`:
 
 @example
 ```
-const a = {
+const time = {
 	timeValue: new Date()
 };
-//Below, `Jsonify<typeof a>` is equivalent to `{timeValue: string}`
-const aJson = JSON.parse(JSON.stringify(a)) as Jsonify<typeof a>;
+
+// `Jsonify<typeof time>` is equivalent to `{timeValue: string}`
+const timeJson = JSON.parse(JSON.stringify(time)) as Jsonify<typeof time>;
 ```
 
 @link https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -4,7 +4,10 @@ import {JsonPrimitive, JsonValue} from './basic';
 type NotJsonable = ((...args: any[]) => any) | undefined;
 
 /**
-Transform a type to one that is assignable to the `JsonValue` type.
+Transform a type to one that is assignable to the `JsonValue` type. This includes:
+
+1. Transforming JSON `interface` to a `type` that is assignable to `JsonValue`
+2. Transforming non JSON that is **Jsonable**, to a type that is assignable to JsonValue. Where **Jsonable** means the non JSON value implements `.toJSON()` method that returns a value that is assignable to `JsonValue`.
 
 @remarks
 
@@ -34,6 +37,17 @@ const fixedFn = <T>(data: Jsonify<T>) => {
 
 fixedFn(point); // Good: point is assignable. Jsonify<T> transforms Geometry into value assignable to JsonValue
 fixedFn(new Date()); // Error: As expected, Date is not assignable. Jsonify<T> cannot transforms Date into value assignable to JsonValue
+```
+
+Non-JSON values such as `Date` implement `.toJSON()`, so they can be transformed to a value assignable to `JsonValue`.
+
+@example
+```
+const a = {
+	timeValue: new Date()
+};
+//Below, `Jsonify<typeof a>` is equivalent to `{timeValue: string}`
+const aJson = JSON.parse(JSON.stringify(a)) as Jsonify<typeof a>;
 ```
 
 @link https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -84,7 +84,7 @@ expectAssignable<string>(dateToJSON);
 expectAssignable<JsonValue>(dateToJSON);
 
 // The following commented `= JSON.parse(JSON.stringify(x))` is an example of how `parsedStringifiedX` could be created.
-// * Note that this would be an unsafe assignment that needs because `JSON.parse()` returns type `any`.
+// * Note that this would be an unsafe assignment because `JSON.parse()` returns type `any`.
 //   But by inspection `JSON.stringify(x)` will use `x.a.toJSON()`. So the JSON.parse() result can be
 //   assigned to Jsonify<X> if the `@typescript-eslint/no-unsafe-assignment` eslint rule is ignored
 //   or an `as Jsonify<X>` is added.

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -77,7 +77,7 @@ const point: Geometry = {
 expectNotAssignable<JsonValue>(point);
 expectAssignable<Jsonify<Geometry>>(point);
 
-// The following const values are examples of values `v` that are not JSON, but are Jsonable using
+// The following const values are examples of values `v` that are not JSON, but are *jsonable* using
 // `v.toJSON()` or `JSON.parse(JSON.stringify(v))`
 declare const dateToJSON: Jsonify<Date>;
 expectAssignable<string>(dateToJSON);
@@ -85,20 +85,20 @@ expectAssignable<JsonValue>(dateToJSON);
 
 // The following commented `= JSON.parse(JSON.stringify(x))` is an example of how `parsedStringifiedX` could be created.
 // * Note that this would be an unsafe assignment because `JSON.parse()` returns type `any`.
-//   But by inspection `JSON.stringify(x)` will use `x.a.toJSON()`. So the JSON.parse() result can be
-//   assigned to Jsonify<X> if the `@typescript-eslint/no-unsafe-assignment` eslint rule is ignored
+//   But by inspection `JSON.stringify(x)` will use `x.a.toJSON()`. So the `JSON.parse()` result can be
+//   assigned to `Jsonify<X>` if the `@typescript-eslint/no-unsafe-assignment` ESLint rule is ignored
 //   or an `as Jsonify<X>` is added.
-// * This test is not about how `parsedStringifiedX` is created, but about its type, so the `const` value is declared
+// * This test is not about how `parsedStringifiedX` is created, but about its type, so the `const` value is declared.
 declare const parsedStringifiedX: Jsonify<X>; // = JSON.parse(JSON.stringify(x));
 expectAssignable<JsonValue>(parsedStringifiedX);
 expectAssignable<string>(parsedStringifiedX.a);
 
 class NonJsonWithToJSON {
-	public m: Map<string, number> = new Map([['a', 1], ['b', 2]]);
+	public fixture: Map<string, number> = new Map([['a', 1], ['b', 2]]);
 
-	public toJSON(): {m: Array<[string, number]>} {
+	public toJSON(): {fixture: Array<[string, number]>} {
 		return {
-			m: [...this.m.entries()],
+			fixture: [...this.fixture.entries()],
 		};
 	}
 }
@@ -108,13 +108,13 @@ expectAssignable<JsonValue>(nonJsonWithToJSON.toJSON());
 expectAssignable<Jsonify<NonJsonWithToJSON>>(nonJsonWithToJSON.toJSON());
 
 class NonJsonWithInvalidToJSON {
-	public m: Map<string, number> = new Map([['a', 1], ['b', 2]]);
+	public fixture: Map<string, number> = new Map([['a', 1], ['b', 2]]);
 
-	// This is intentionally invalid toJSON()
-	// It is invalid because the result is not assignable to JsonValue
-	public toJSON(): {m: Map<string, number>} {
+	// This is intentionally invalid `.toJSON()`.
+	// It is invalid because the result is not assignable to `JsonValue`.
+	public toJSON(): {fixture: Map<string, number>} {
 		return {
-			m: this.m,
+			fixture: this.fixture,
 		};
 	}
 }

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -105,6 +105,7 @@ class NonJsonWithToJSON {
 const nonJsonWithToJSON = new NonJsonWithToJSON();
 expectNotAssignable<JsonValue>(nonJsonWithToJSON);
 expectAssignable<JsonValue>(nonJsonWithToJSON.toJSON());
+expectAssignable<Jsonify<NonJsonWithToJSON>>(nonJsonWithToJSON.toJSON());
 
 class NonJsonWithInvalidToJSON {
 	public m: Map<string, number> = new Map([['a', 1], ['b', 2]]);


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/256

@leosuncin pointed out the desire to `Jsonify` non-JSON that is Jsonable via `JSON.parse(JSON.stringify(v))`.  The example provided was an interface `Product` that was clearly not assignable to `JsonValue` because it contains `Date` values.  But `Date` implements a `toJSON()` method so the non-JSON value can be converted to JSON in a predictable way.

This pull request updates `Jsonify` to also transform non-JSON values that are Jsonable.  Where Jsonable means the non-JSON value implements  `.toJSON()` method that returns a value that is assignable to `JsonValue`.

In the tests, `parsedStringifiedX` uses a non-JSON type that currently exists in the tests and is similar to the example @leosuncin provided.  As well, I added a couple of classes of non-JSON objects. (One of the non JSON objects is Jsonable and the other is not)

Some items to reflect on and possibly discuss in this review:
* Should `Jsonify` strictly apply to JSON values only?  Or is it acceptable to include non-JSON values that are Jsonable with `toJSON()`?  
    * This pull request takes the view that it is acceptable to be more flexible and allow non-JSON values that are Jsonable.
       * I reflected on this after #256 was raised.  `Jsonify` was originally designed to transform a `JSON` `interface` to a `type` that is assignable to `JsonValue`.  It was not designed to transform non-JSON.  So my initial feeling was that #256 was not a bug.  But the idea of using `JSON.stringify()`, which leverages the inner object's `.toJSON()` methods, raises a compelling use case.
   * Another choice is to keep `Jsonify` as is... and have a new `JsonifyJsonable` type to handle non-JSON that is Jsonable.
      * But I think having 2 types would be confusing... and I can't think of a use case where it would be necessary to have 2 types.
      * Can others think of a use case where it is helpful to have a separate `JsonifyJsonable` type?  (This is my only doubt because as I approached thinking about #256 my initial feeling was that it should be a separate type... I can't create a strong argument for it though. And I am leaning towards relaxing `Jsonify` to also support non-Json but Jsonable input.)
