### PR TITLE
Support numbers in `Join` type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Click the type names for complete docs.
 - [`DelimiterCase`](source/delimiter-case.d.ts) – Convert a string literal to a custom string delimiter casing.
 - [`DelimiterCasedProperties`](source/delimiter-cased-properties.d.ts) – Convert object properties to a custom string delimiter casing.
 - [`DelimiterCasedPropertiesDeep`](source/delimiter-cased-properties-deep.d.ts) – Convert object properties to a custom string delimiter casing recursively.
-- [`Join`](source/join.d.ts) - Join an array of strings using the given string as delimiter.
+- [`Join`](source/join.d.ts) - Join an array of strings and/or numbers using the given string as a delimiter.
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
 - [`Trim`](source/trim.d.ts) - Remove leading and trailing spaces from a string.
 - [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -20,7 +20,7 @@ const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 @category Template Literals
 */
 export type Join<
-	Strings extends (string | number)[],
+	Strings extends Array<string | number>,
 	Delimiter extends string,
 > = Strings extends [] ? '' :
 	Strings extends [string | number] ? `${Strings[0]}` :

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -13,10 +13,10 @@ const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
 @category Template Literals
 */
 export type Join<
-	Strings extends string[],
+	Strings extends (string | number)[],
 	Delimiter extends string,
 > = Strings extends [] ? '' :
-	Strings extends [string] ? `${Strings[0]}` :
+	Strings extends [string | number] ? `${Strings[0]}` :
 	// @ts-expect-error `Rest` is inferred as `unknown` here: https://github.com/microsoft/TypeScript/issues/45281
-	Strings extends [string, ...infer Rest] ? `${Strings[0]}${Delimiter}${Join<Rest, Delimiter>}` :
-	string;
+	Strings extends [string | number, ...infer Rest] ? `${Strings[0]}${Delimiter}${Join<Rest, Delimiter>}` :
+	string | number;

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -1,5 +1,5 @@
 /**
-Join an array of strings and/or numbers using the given string as delimiter.
+Join an array of strings and/or numbers using the given string as a delimiter.
 
 Use-case: Defining key paths in a nested object. For example, for dot-notation fields in MongoDB queries.
 
@@ -7,7 +7,14 @@ Use-case: Defining key paths in a nested object. For example, for dot-notation f
 ```
 import {Join} from 'type-fest';
 
-const path: Join<['foo', '0', 'baz'], '.'> = ['foo', '0', 'baz'].join('.');
+// mixed (strings & numbers) items: 'foo.0.baz'
+const path: Join<['foo', 0, 'baz'], '.'> = ['foo', 0, 'baz'].join('.');
+
+// only string items: 'foo.bar.baz'
+const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
+
+// only number items: 1.2.3
+const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 ```
 
 @category Template Literals

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -1,5 +1,5 @@
 /**
-Join an array of strings using the given string as delimiter.
+Join an array of strings and/or numbers using the given string as delimiter.
 
 Use-case: Defining key paths in a nested object. For example, for dot-notation fields in MongoDB queries.
 
@@ -7,7 +7,7 @@ Use-case: Defining key paths in a nested object. For example, for dot-notation f
 ```
 import {Join} from 'type-fest';
 
-const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
+const path: Join<['foo', '0', 'baz'], '.'> = ['foo', '0', 'baz'].join('.');
 ```
 
 @category Template Literals

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -7,13 +7,13 @@ Use-case: Defining key paths in a nested object. For example, for dot-notation f
 ```
 import {Join} from 'type-fest';
 
-// mixed (strings & numbers) items; result is: 'foo.0.baz'
+// Mixed (strings & numbers) items; result is: 'foo.0.baz'
 const path: Join<['foo', 0, 'baz'], '.'> = ['foo', 0, 'baz'].join('.');
 
-// only string items; result is: 'foo.bar.baz'
+// Only string items; result is: 'foo.bar.baz'
 const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
 
-// only number items; result is: '1.2.3'
+// Only number items; result is: '1.2.3'
 const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 ```
 

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -7,13 +7,13 @@ Use-case: Defining key paths in a nested object. For example, for dot-notation f
 ```
 import {Join} from 'type-fest';
 
-// mixed (strings & numbers) items: 'foo.0.baz'
+// mixed (strings & numbers) items; result is: 'foo.0.baz'
 const path: Join<['foo', 0, 'baz'], '.'> = ['foo', 0, 'baz'].join('.');
 
-// only string items: 'foo.bar.baz'
+// only string items; result is: 'foo.bar.baz'
 const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
 
-// only number items: 1.2.3
+// only number items; result is: '1.2.3'
 const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 ```
 

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -3,7 +3,9 @@ import {Join} from '../index';
 
 // General use.
 const generalTest: Join<['foo', 'bar', 'baz'], '.'> = 'foo.bar.baz';
+const generalTestVariantWithNumbers: Join<['foo', 0, 'baz'], '.'> = 'foo.0.baz';
 expectType<'foo.bar.baz'>(generalTest);
+expectType<'foo.0.baz'>(generalTestVariantWithNumbers);
 expectError<'foo'>(generalTest);
 expectError<'foo.bar'>(generalTest);
 expectError<'foo.bar.ham'>(generalTest);

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -2,13 +2,15 @@ import {expectError, expectType} from 'tsd';
 import {Join} from '../index';
 
 // General use.
-const generalTest: Join<['foo', 'bar', 'baz'], '.'> = 'foo.bar.baz';
-const generalTestVariantWithNumbers: Join<['foo', 0, 'baz'], '.'> = 'foo.0.baz';
-expectType<'foo.bar.baz'>(generalTest);
-expectType<'foo.0.baz'>(generalTestVariantWithNumbers);
-expectError<'foo'>(generalTest);
-expectError<'foo.bar'>(generalTest);
-expectError<'foo.bar.ham'>(generalTest);
+const generalTestVariantMixed: Join<['foo', 0, 'baz'], '.'> = 'foo.0.baz';
+const generalTestVariantOnlyStrings: Join<['foo', 'bar', 'baz'], '.'> = 'foo.bar.baz';
+const generalTestVariantOnlyNumbers: Join<[1, 2, 3], '.'> = '1.2.3';
+expectType<'foo.0.baz'>(generalTestVariantMixed);
+expectType<'1.2.3'>(generalTestVariantOnlyNumbers);
+expectType<'foo.bar.baz'>(generalTestVariantOnlyStrings);
+expectError<'foo'>(generalTestVariantOnlyStrings);
+expectError<'foo.bar'>(generalTestVariantOnlyStrings);
+expectError<'foo.bar.ham'>(generalTestVariantOnlyStrings);
 
 // Empty string delimiter.
 const emptyDelimiter: Join<['foo', 'bar', 'baz'], ''> = 'foobarbaz';


### PR DESCRIPTION
Thank you for the `Join` type, really helpful.
Let's please support `number` parameters as well, so we could create results like the one below:
- `foo.0.bar`

On a side note, I'm using `Join` type to cast type override on `Array.join()` and this native JavaScript function supports `number` parameters, which leads to believe this `Join` type should support it too.
