### PR TITLE
Fix support for readonly and generic arrays in the `LastArrayElement` type

### DIFF
--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -21,5 +21,7 @@ export type LastArrayElement<ValueType extends readonly unknown[]> =
 	ValueType extends [infer ElementType]
 		? ElementType
 		: ValueType extends [infer _, ...infer Tail]
-			? LastArrayElement<Tail>
-			: never;
+		? LastArrayElement<Tail>
+		: ValueType extends Array<infer ElementType>
+		? ElementType
+		: never;

--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -18,10 +18,10 @@ typeof lastOf(array);
 @category Template Literals
 */
 export type LastArrayElement<ValueType extends readonly unknown[]> =
-	ValueType extends [infer ElementType]
+	ValueType extends readonly [infer ElementType]
 		? ElementType
-		: ValueType extends [infer _, ...infer Tail]
+		: ValueType extends readonly [infer _, ...infer Tail]
 		? LastArrayElement<Tail>
-		: ValueType extends Array<infer ElementType>
+		: ValueType extends ReadonlyArray<infer ElementType>
 		? ElementType
 		: never;

--- a/test-d/last-array-element.ts
+++ b/test-d/last-array-element.ts
@@ -9,4 +9,4 @@ expectType<'bar'>(lastOf(array));
 expectType<2>(lastOf(mixedArray));
 expectType<string>(lastOf(['a', 'b', 'c']));
 expectType<string | number>(lastOf(['a', 'b', 1]));
-expectType<number>(lastOf(['a', 'b', 1] as const));
+expectType<1>(lastOf(['a', 'b', 1] as const));

--- a/test-d/last-array-element.ts
+++ b/test-d/last-array-element.ts
@@ -1,9 +1,12 @@
 import {expectType} from 'tsd';
 import {LastArrayElement} from '../index';
 
-declare function lastOf<V extends [any, ...any]>(array: V): LastArrayElement<V>;
+declare function lastOf<V extends readonly unknown[]>(array: V): LastArrayElement<V>;
 const array: ['foo', 2, 'bar'] = ['foo', 2, 'bar'];
 const mixedArray: ['bar', 'foo', 2] = ['bar', 'foo', 2];
 
 expectType<'bar'>(lastOf(array));
 expectType<2>(lastOf(mixedArray));
+expectType<string>(lastOf(['a', 'b', 'c']));
+expectType<string | number>(lastOf(['a', 'b', 1]));
+expectType<number>(lastOf(['a', 'b', 1] as const));


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

Fixes #265 
