### PR TITLE
internal.d.ts: BuildTuple should preserve type.  

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -24,7 +24,7 @@ Create a tuple type of the given length `<L>`.
 */
 type BuildTuple<L extends number, T extends readonly unknown[] = []> = T extends {readonly length: L}
 	? T
-	: BuildTuple<L, [...T, unknown]>;
+	: BuildTuple<L, [...T, T[any]]>;
 
 /**
 Create a tuple of length `A` and a tuple composed of two other tuples,


### PR DESCRIPTION
Although it is just an internal util, and only length is extracted, it could be exported one day.

@Menecats and @sindresorhus: I missed mentioning this in https://github.com/sindresorhus/type-fest/pull/277

In the recursion step, the appended item is not `unknown`, but rather `T[any]`.  Do you agree?

It is not a big deal because only the length is extracted in `Subtract`.  But one day `BuildTuple` could be exported. So it is probably good to capture this now.
