### PR TITLE
Add `ExtractStrict` and `ExcludeStrict` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ export * from './source/observable-like';
 
 // Utilities
 export {Except} from './source/except';
+export {ExcludeStrict} from './source/exclude-strict';
+export {ExtractStrict} from './source/extract-strict';
 export {Mutable} from './source/mutable';
 export {Merge} from './source/merge';
 export {MergeExclusive} from './source/merge-exclusive';

--- a/source/exclude-strict.d.ts
+++ b/source/exclude-strict.d.ts
@@ -1,0 +1,18 @@
+/**
+Constructs a type by excluding from Type all union members that are assignable to ExcludedUnion.
+
+This type is a stricter version of [`Exclude`](https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion). The `Exclude` type does not restrict the omitted keys to be keys present on the given type, while `ExcludeStrict` does. The benefits of a stricter type are avoiding typos and allowing the compiler to pick up on rename refactors automatically.
+
+@example
+```
+import {ExcludeStrict} from 'type-fest';
+
+type ShirtSizes = 'xxxl' | 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs';
+
+type OnlyLargeShirts = ExcludeStrict<ShirtSizes, 'm' | 's' | 'xs' | 'xxs'>;
+//=> 'xxxl' | 'xxl' | 'xl' | 'l';
+```
+
+@category Utilities
+*/
+export type ExcludeStrict<Type, ExcludedUnion extends Type> = Exclude<Type, ExcludedUnion>;

--- a/source/extract-strict.d.ts
+++ b/source/extract-strict.d.ts
@@ -1,0 +1,19 @@
+/**
+Constructs a type by extracting from Type all union members that are assignable to Union.
+
+This type is a stricter version of [`Extract`](https://www.typescriptlang.org/docs/handbook/utility-types.html#extracttype-union). The `Extract` type does not restrict the omitted keys to be keys present on the given type, while `ExtractStrict` does. The benefits of a stricter type are avoiding typos and allowing the compiler to pick up on rename refactors automatically.
+
+This type has been proposed to the TypeScript team ([microsoft/TypeScript#31474](https://github.com/microsoft/TypeScript/issues/31474)).
+
+@example
+```
+type ShirtSizes = 'xxxl' | 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs';
+
+type NoLargeShirts = ExtractStrict<ShirtSizes, 'm' | 's' | 'xs' | 'xxs'>;
+expectType<'m' | 's' | 'xs' | 'xxs' >('m' as NoLargeShirts);
+//=> 'm' | 's' | 'xs' | 'xxs';
+```
+
+@category Utilities
+*/
+export type ExtractStrict<Type, Union extends Type> = Extract<Type, Union>;

--- a/test-d/exclude-strict.ts
+++ b/test-d/exclude-strict.ts
@@ -1,0 +1,7 @@
+import {expectType} from 'tsd';
+import {ExcludeStrict} from '../index';
+
+type ShirtSizes = 'xxxl' | 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs';
+
+type OnlyLargeShirts = ExcludeStrict<ShirtSizes, 'm' | 's' | 'xs' | 'xxs'>;
+expectType<'xxxl' | 'xxl' | 'xl' | 'l' >('m' as OnlyLargeShirts);

--- a/test-d/extract-strict.ts
+++ b/test-d/extract-strict.ts
@@ -1,0 +1,7 @@
+import {expectType} from 'tsd';
+import {ExtractStrict} from '../index';
+
+type ShirtSizes = 'xxxl' | 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs';
+
+type NoLargeShirts = ExtractStrict<ShirtSizes, 'm' | 's' | 'xs' | 'xxs'>;
+expectType<'m' | 's' | 'xs' | 'xxs' >('m' as NoLargeShirts);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->
Solves #222 

I could not figure out how to make test cases to demonstrate that these types fail when you supply an ExcludedUnion or Union that includes an element which is not found in Type. If someone knows how, a contribution is very welcome!