### PR TITLE
Fix #284 - Stricter FixedLengthArray

### DIFF
--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,10 +1,7 @@
-/**
-Methods to exclude.
-*/
-type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';
+import {BuildTuple} from './internal';
 
 /**
-Create a type that represents an array of the given type and length. The array's length and the `Array` prototype methods that manipulate its length are excluded in the resulting type.
+Create a type that represents an array of the given type and length.
 
 Please participate in [this issue](https://github.com/microsoft/TypeScript/issues/26223) if you want to have a similiar type built into TypeScript.
 
@@ -30,11 +27,4 @@ guestFencingTeam.push('Sam');
 
 @category Utilities
 */
-export type FixedLengthArray<Element, Length extends number, ArrayPrototype = [Element, ...Element[]]> = Pick<
-	ArrayPrototype,
-	Exclude<keyof ArrayPrototype, ArrayLengthMutationKeys>
-> & {
-	[index: number]: Element;
-	[Symbol.iterator]: () => IterableIterator<Element>;
-	readonly length: Length;
-};
+export type FixedLengthArray<Element, Length extends number> = BuildTuple<Length, Element>;

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -1,4 +1,12 @@
-import {BuildTuple} from './internal';
+/**
+ * Creates a ReadonlyArray<Element> of length Length (aka a tuple)
+ * @private
+ * @see FixedLengthArray which is safer because it tests if `Length` is a specific finite number
+ */
+type BuildTupleHelper<Element, Length extends number, Rest extends Element[]> =
+	Rest['length'] extends Length ?
+		readonly [...Rest] : // Terminate with readonly array (aka tuple)
+		BuildTupleHelper<Element, Length, [Element, ...Rest]>;
 
 /**
 Create a type that represents an array of the given type and length.
@@ -27,4 +35,8 @@ guestFencingTeam.push('Sam');
 
 @category Utilities
 */
-export type FixedLengthArray<Element, Length extends number> = BuildTuple<Length, Element>;
+export type FixedLengthArray<Element, Length extends number> =
+	number extends Length ?
+		// Because `Length extends number` and `number extends Length`, then Length is not a specific finite number
+		Element[] : // It's not fixed length
+		BuildTupleHelper<Element, Length, []>; // Otherwise it is fixed length tuple

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -18,14 +18,13 @@ Infer the length of the given array `<T>`.
 type TupleLength<T extends readonly unknown[]> = T extends {readonly length: infer L} ? L : never;
 
 /**
-Create a tuple type of the given length `<Length>` and type type `<Element>`.
+Create a tuple type of the given length `<Length>`.
 
 @link https://itnext.io/implementing-arithmetic-within-typescripts-type-system-a1ef140a6f6f
-@link https://github.com/sindresorhus/type-fest/pull/286#discussion_r727799560
 */
-export type BuildTuple<Length extends number, Element = unknown, InputTuple extends readonly unknown[] = []> = InputTuple extends {readonly length: Length}
-	? InputTuple
-	: BuildTuple<Length, Element, [...InputTuple, Element]>;
+type BuildTuple<Length extends number, Rest extends readonly unknown[] = []> = Rest['length'] extends Length
+	? Rest
+	: BuildTuple<Length, [...Rest, unknown]>;
 
 /**
 Create a tuple of length `A` and a tuple composed of two other tuples,

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -18,13 +18,14 @@ Infer the length of the given array `<T>`.
 type TupleLength<T extends readonly unknown[]> = T extends {readonly length: infer L} ? L : never;
 
 /**
-Create a tuple type of the given length `<L>`.
+Create a tuple type of the given length `<Length>` and type type `<Element>`.
 
 @link https://itnext.io/implementing-arithmetic-within-typescripts-type-system-a1ef140a6f6f
+@link https://github.com/sindresorhus/type-fest/pull/286#discussion_r727799560
 */
-type BuildTuple<L extends number, T extends readonly unknown[] = []> = T extends {readonly length: L}
-	? T
-	: BuildTuple<L, [...T, unknown]>;
+export type BuildTuple<Length extends number, Element = unknown, InputTuple extends readonly unknown[] = []> = InputTuple extends {readonly length: Length}
+	? InputTuple
+	: BuildTuple<Length, Element, [...InputTuple, Element]>;
 
 /**
 Create a tuple of length `A` and a tuple composed of two other tuples,

--- a/test-d/fixed-length-array.ts
+++ b/test-d/fixed-length-array.ts
@@ -10,11 +10,16 @@ expectNotAssignable<FixedToThreeStrings>(['a']);
 expectNotAssignable<FixedToThreeStrings>(['a', 'b']);
 expectNotAssignable<FixedToThreeStrings>(['a', 'b', 'c', 'd']);
 
-declare const a: FixedLengthArray<number, 2>;
+declare const a: FixedToThreeStrings;
 
-expectAssignable<typeof a.length>(2);
-expectNotAssignable<typeof a.length>(3);
+expectType<IterableIterator<string>>(a[Symbol.iterator]());
+expectType<string>(a[1]);
 
-expectType<2>(a.length);
-expectType<IterableIterator<number>>(a[Symbol.iterator]());
-expectType<number>(a[1]);
+// FixedLengthArray<string, 3> is a readonly array and cannot be assigned to array.
+// * it does not have .push() etc..
+expectNotAssignable<string[]>(a);
+
+// FixedLengthArray<string, number> is not a readonly array because Length is not finite number
+// * So it is assiable to string[]
+declare const b: FixedLengthArray<string, number>;
+expectAssignable<string[]>(b);

--- a/test-d/fixed-length-array.ts
+++ b/test-d/fixed-length-array.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import {FixedLengthArray} from '../index';
 
 type FixedToThreeStrings = FixedLengthArray<string, 3>;
@@ -9,3 +9,12 @@ expectNotAssignable<FixedToThreeStrings>(['a', 'b', 123]);
 expectNotAssignable<FixedToThreeStrings>(['a']);
 expectNotAssignable<FixedToThreeStrings>(['a', 'b']);
 expectNotAssignable<FixedToThreeStrings>(['a', 'b', 'c', 'd']);
+
+declare const a: FixedLengthArray<number, 2>;
+
+expectAssignable<typeof a.length>(2);
+expectNotAssignable<typeof a.length>(3);
+
+expectType<2>(a.length);
+expectType<IterableIterator<number>>(a[Symbol.iterator]());
+expectType<number>(a[1]);


### PR DESCRIPTION
Hi @sindresorhus, I've implemented the changes requested by the issue #284, but I still have some doubts about them.

There's a "problem" with this implementation, it's the fact that all the mutation methods are now present again in the `FixedLengthArray` type, that said, also in the standard Typescript tuple all those methods are available:
```typescript
const a: [number, number] = [0, 1];
a.push(2);
a[2] = 2; // Error
```
So this may not be a problem.

If instead we want to remove them we can still use the `Omit` utility from typescript as follows:
```typescript
type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';

export type FixedLengthArray<Element, Length extends number> = Omit<
	BuildTuple<Length, Element>,
	ArrayLengthMutationKeys
> & {readonly length: Length};
```
The problem with that is that each type you merge a tuple type with another type in Typescript, the tuple usually becomes an array of the tuple type so with these changes we lose the initial strictness:
```typescript
const a: FixedLengthArray<number, 2> = [0, 1];
a.push(2); // Error
a[2] = 2;
```

There is still another option and that's to exclude also the `number` type from our tuple:
```typescript
type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' | 'unshift';

export type FixedLengthArray<Element, Length extends number> = Omit<
	BuildTuple<Length, Element>,
	number | ArrayLengthMutationKeys
> & {readonly length: Length};
```

This prevents accessing all the mutation methods and keys that are not present in our tuple, but it has another disadvantage, you can't reference tuple elements by numerical index, so that's prevent you to use for loops (unless you specify explicitly the type of the index variable as `0 | 1 | ...`
```typescript
const a: FixedLengthArray<number, 2> = [0, 1];
a[0] = 1; // Ok
a[1] = a[0]; // Ok
a.push(2); // Error
a[2] = 2; // error

for (let index = 0; index < a.length; ++index) {
  a[index] = index; // Error
}
```

What do you think about these changes?


(@darcyparker **fyi**)
