### PR TITLE
Work around TypeScript limitation with the `PartialDeep` type

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -43,7 +43,11 @@ export type PartialDeep<T> = T extends Primitive
 	: T extends ((...arguments: any[]) => unknown)
 	? T | undefined
 	: T extends object
-	? PartialObjectDeep<T>
+	? T extends Array<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
+		? ItemType[] extends T // Test for arrays (non-tuples) specifically
+			? Array<PartialDeep<ItemType | undefined>> // Recreate relevant array type to prevent eager evaluation of circular reference
+			: PartialObjectDeep<T> // Tuples behave properly
+		: PartialObjectDeep<T>
 	: unknown;
 
 /**

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -4,7 +4,7 @@ import {PartialDeep} from '../index';
 const foo = {
 	baz: 'fred',
 	bar: {
-		function: (_: string): void => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+		function: (_: string): void => undefined,
 		object: {key: 'value'},
 		string: 'waldo',
 		number: 1,
@@ -47,3 +47,15 @@ expectType<readonly ['foo'?] | undefined>(partialDeepFoo.bar!.readonlyTuple);
 // Check for compiling with omitting partial keys
 partialDeepFoo = {baz: 'fred'};
 partialDeepFoo = {bar: {string: 'waldo'}};
+
+// Check that recursive array evalution isn't infinite depth
+type Recurse =
+    | string
+    | number
+    | boolean
+    | null
+    | Record<string, Recurse[]>
+    | Recurse[];
+type RecurseObject = {value: Recurse};
+const recurseObject: RecurseObject = {value: null};
+expectAssignable<PartialDeep<RecurseObject>>(recurseObject);


### PR DESCRIPTION
This fixes #295, fixing an edge-case where `PartialDeep` evaluation can result in infinite depth for specific recursive type situations. This started out trying to add the exact changes from the suggestion, but arrays and tuples behave differently so it got a little more complex.

`npm test` passes with TS 4.4.4 locally. Verified new test case failed without `PartialDeep` changes. Added comments following the convention seen in other files, but happy to remove them if they are unnecessary.
