### PR TITLE
Test with 4.5.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@sindresorhus/tsconfig": "~0.7.0",
 		"expect-type": "^0.12.0",
 		"tsd": "^0.17.0",
-		"typescript": "^4.1.3",
+		"typescript": "^4.5.0-beta",
 		"xo": "^0.43.0"
 	},
 	"types": "./index.d.ts",


### PR DESCRIPTION
I tried v4.5.0-beta on my project and I got this error. I don't even use Substract (directly, anyway)

```
node_modules/type-fest/source/internal.d.ts:35:97 - error TS2574: A rest element type must be an array type.

35 export type Subtract<A extends number, B extends number> = BuildTuple<A> extends [...(infer U), ...BuildTuple<B>]
                                                                                                   ~~~~~~~~~~~~~~~~
```