### PR TITLE
Fix handling of pascal case inputs in `DelimiterCase`

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -24,8 +24,9 @@ Format a specific part of the splitted string literal that `StringArrayToDelimit
 
 @see StringArrayToDelimiterCase
 */
-type StringPartToDelimiterCase<StringPart extends string, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
+type StringPartToDelimiterCase<StringPart extends string, Start extends boolean, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
 	StringPart extends UsedWordSeparators ? Delimiter :
+	Start extends true ? Lowercase<StringPart> :
 	StringPart extends UsedUpperCaseCharacters ? `${Delimiter}${Lowercase<StringPart>}` :
 	StringPart;
 
@@ -36,9 +37,9 @@ It receives `UsedWordSeparators` and `UsedUpperCaseCharacters` as input to ensur
 
 @see SplitIncludingDelimiters
 */
-type StringArrayToDelimiterCase<Parts extends readonly any[], UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
+type StringArrayToDelimiterCase<Parts extends readonly any[], Start extends boolean, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
 	Parts extends [`${infer FirstPart}`, ...infer RemainingParts]
-		? `${StringPartToDelimiterCase<FirstPart, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}${StringArrayToDelimiterCase<RemainingParts, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}`
+		? `${StringPartToDelimiterCase<FirstPart, Start, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}${StringArrayToDelimiterCase<RemainingParts, false, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}`
 		: '';
 
 /**
@@ -81,6 +82,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 export type DelimiterCase<Value, Delimiter extends string> = Value extends string
 	? StringArrayToDelimiterCase<
 		SplitIncludingDelimiters<Value, WordSeparators | UpperCaseCharacters>,
+		true,
 		WordSeparators,
 		UpperCaseCharacters,
 		Delimiter

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -16,6 +16,9 @@ expectType<'foo#bar'>(delimiterFromCamel);
 const delimiterFromComplexCamel: DelimiterCase<'fooBarAbc123', '#'> = 'foo#bar#abc123';
 expectType<'foo#bar#abc123'>(delimiterFromComplexCamel);
 
+const delimiterFromPascal: DelimiterCase<'FooBar', '#'> = 'foo#bar';
+expectType<'foo#bar'>(delimiterFromPascal);
+
 const delimiterFromKebab: DelimiterCase<'foo-bar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromKebab);
 

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -4,6 +4,9 @@ import {SnakeCase} from '../index';
 const snakeFromCamel: SnakeCase<'fooBar'> = 'foo_bar';
 expectType<'foo_bar'>(snakeFromCamel);
 
+const snakeFromPascal: SnakeCase<'FooBar'> = 'foo_bar';
+expectType<'foo_bar'>(snakeFromPascal);
+
 const snakeFromKebab: SnakeCase<'foo-bar'> = 'foo_bar';
 expectType<'foo_bar'>(snakeFromKebab);
 


### PR DESCRIPTION
Handles PascalCase inputs in `DelimiterCase`. Previously, the initial upper case letter caused the conditional type to reach the branch that prepends the delimiter. So `DelimiterCase<'FooBar', '#'>` produced `#foo#bar` rather than `foo#bar`. 

Now, on the initial call, `Start` is passed in, set to `true`. When recursing, `Start` is set to `false`. If `Start` is true, the part will only be lowercased and not prepended with a delimiter. 

See https://github.com/bendrucker/snakecase-keys/issues/56