### PR TITLE
Upgrade `typescript` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@sindresorhus/tsconfig": "~0.7.0",
 		"expect-type": "^0.12.0",
 		"tsd": "^0.17.0",
-		"typescript": "^4.1.3",
+		"typescript": ">=4.2",
 		"xo": "^0.43.0"
 	},
 	"types": "./index.d.ts",


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/master/.github/contributing.md

-->

The README says typescript >=4.2 is required. However, package.json instead lists ^4.1.3. The tests fail with TypeScript 4.1.3 but pass in more recent versions, so the package.json should not permit it.

This PR updates the dependency in the package.json, so that it matches with the README.
