### PR TITLE
Fix `Join` edge case when type inference fails

### DIFF
--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -26,4 +26,4 @@ export type Join<
 	Strings extends [string | number] ? `${Strings[0]}` :
 	// @ts-expect-error `Rest` is inferred as `unknown` here: https://github.com/microsoft/TypeScript/issues/45281
 	Strings extends [string | number, ...infer Rest] ? `${Strings[0]}${Delimiter}${Join<Rest, Delimiter>}` :
-	string | number;
+	string;


### PR DESCRIPTION
When adding support for numbers in #258 , I introduced a regression when TypeScript fails to infer the typings of the `Join`'s first parameter.

This PR sets the default type of the `Join`'s return to be `string`, not `string | number`