### PR TITLE
Add strict mode for `Get`

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -16,7 +16,7 @@ type GetWithPath<BaseType, Keys extends readonly string[], Strict extends boolea
 	: never;
 
 /** If `Strict` is `true`, includes `undefined` in the returned type when accessing dictionary properties
- * 
+ *
  *  Known limitations:
 	- Returns `T | undefined` for required properties on object types with an index signature (f ex. `{ a: string; [key: string]: string }`)
 */

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -19,20 +19,23 @@ type GetWithPath<BaseType, Keys extends readonly string[], Options extends GetOp
 	>
 	: never;
 
-/** Adds `undefined` to `Type` if `strict` is enabled */
+/**
+Adds `undefined` to `Type` if `strict` is enabled.
+*/
 type Strictify<Type, Options extends GetOptions> =
 	Options['strict'] extends true ? Type | undefined : Type;
 
-/** If `Options["strict"]` is `true`, includes `undefined` in the returned type when accessing properties on `Record<string, any>`
- *
- *  Known limitations:
-	- Does not include `undefined` in the type on object types with an index signature (f ex. `{ a: string; [key: string]: string }`)
+/**
+If `Options['strict']` is `true`, includes `undefined` in the returned type when accessing properties on `Record<string, any>`.
+
+Known limitations:
+- Does not include `undefined` in the type on object types with an index signature (for example, `{a: string; [key: string]: string}`).
 */
 type StrictPropertyOf<BaseType, Key extends keyof BaseType, Options extends GetOptions> =
 	Record<string, any> extends BaseType
 	? string extends keyof BaseType
 		? Strictify<BaseType[Key], Options> // Record<string, any>
-		: BaseType[Key] // Record<"a" | "b", any> (Records with a string union as keys have required properties)
+		: BaseType[Key] // Record<'a' | 'b', any> (Records with a string union as keys have required properties)
 	: BaseType[Key];
 
 /**

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -162,7 +162,7 @@ const getName = (apiResponse: ApiResponse) =>
 
 // Strict mode:
 Get<string[], '3', {strict: true}> //=> string | undefined
-Get<Record<string, string>, "foo", {strict: true}> // => string | undefined
+Get<Record<string, string>, 'foo', {strict: true}> // => string | undefined
 ```
 
 @category Template Literals

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -161,8 +161,8 @@ const getName = (apiResponse: ApiResponse) =>
 	//=> Array<{given: string[]; family: string}>
 
 // Strict mode:
-Get<string[], "3", { strict: true }> //=> string | undefined
-Get<Record<string, string>, "foo", { strict: true }> // => string | undefined
+Get<string[], '3', {strict: true}> //=> string | undefined
+Get<Record<string, string>, "foo", {strict: true}> // => string | undefined
 ```
 
 @category Template Literals

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -51,8 +51,12 @@ type ToPath<S extends string> = Split<FixPathSquareBrackets<S>, '.'>;
 Replaces square-bracketed dot notation with dots, for example, `foo[0].bar` -> `foo.0.bar`.
 */
 type FixPathSquareBrackets<Path extends string> =
-	Path extends `${infer Head}[${infer Middle}]${infer Tail}`
-	? `${Head}.${Middle}${FixPathSquareBrackets<Tail>}`
+	Path extends `[${infer Head}]${infer Tail}`
+	? Tail extends `[${string}`
+		? `${Head}.${FixPathSquareBrackets<Tail>}`
+		: `${Head}${FixPathSquareBrackets<Tail>}`
+	: Path extends `${infer Head}[${infer Middle}]${infer Tail}`
+	? `${Head}.${FixPathSquareBrackets<`[${Middle}]${Tail}`>}`
 	: Path;
 
 /**

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -103,7 +103,6 @@ expectTypeOf<Get<{a: {b: Array<Array<Array<{id: number}>>>}}, 'a.b[0][0][0].id'>
 type Strict = {strict: true};
 expectTypeOf<Get<string[], '0', Strict>>().toEqualTypeOf<string | undefined>();
 expectTypeOf<Get<Record<string, number>, 'foo', Strict>>().toEqualTypeOf<number | undefined>();
-expectTypeOf<Get<Record<number, string>, '1', Strict>>().toEqualTypeOf<string | undefined>();
 expectTypeOf<Get<Record<'a' | 'b', number>, 'a', Strict>>().toEqualTypeOf<number>();
 expectTypeOf<Get<Record<1 | 2, string>, '1', Strict>>().toEqualTypeOf<string>();
 expectTypeOf<Get<{1: boolean}, '1', Strict>>().toBeBoolean();

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -92,13 +92,15 @@ expectTypeOf<Get<WithModifiers, 'foo[0].abc.def.ghi'>>().toEqualTypeOf<string | 
 
 // Test strict version:
 
-expectTypeOf<Get<string[], '0', true>>().toEqualTypeOf<string | undefined>();
-expectTypeOf<Get<Record<string, number>, 'foo', true>>().toEqualTypeOf<number | undefined>();
-expectTypeOf<Get<Record<number, string>, '1', true>>().toEqualTypeOf<string | undefined>();
-expectTypeOf<Get<Record<'a' | 'b', number>, 'a', true>>().toEqualTypeOf<number>();
-expectTypeOf<Get<Record<1 | 2, string>, '1', true>>().toEqualTypeOf<string>();
-expectTypeOf<Get<{1: boolean}, '1', true>>().toBeBoolean();
-expectTypeOf<Get<[number, string], '0', true>>().toBeNumber();
+type Strict = {strict: true};
+expectTypeOf<Get<string[], '0', Strict>>().toEqualTypeOf<string | undefined>();
+expectTypeOf<Get<Record<string, number>, 'foo', Strict>>().toEqualTypeOf<number | undefined>();
+expectTypeOf<Get<Record<number, string>, '1', Strict>>().toEqualTypeOf<string | undefined>();
+expectTypeOf<Get<Record<'a' | 'b', number>, 'a', Strict>>().toEqualTypeOf<number>();
+expectTypeOf<Get<Record<1 | 2, string>, '1', Strict>>().toEqualTypeOf<string>();
+expectTypeOf<Get<{1: boolean}, '1', Strict>>().toBeBoolean();
+expectTypeOf<Get<[number, string], '0', Strict>>().toBeNumber();
+expectTypeOf<Get<{[key: string]: string; a: string}, 'a', Strict>>().toBeString();
 
 interface WithDictionary {
 	foo: Record<string, {
@@ -108,6 +110,6 @@ interface WithDictionary {
 		qux: Array<{x: boolean}>;
 	}>;
 }
-expectTypeOf<Get<WithDictionary, 'foo.whatever', true>>().toEqualTypeOf<{bar: number} | undefined>();
-expectTypeOf<Get<WithDictionary, 'foo.whatever.bar', true>>().toEqualTypeOf<number | undefined>();
-expectTypeOf<Get<WithDictionary, 'baz.whatever.qux[3].x', true>>().toEqualTypeOf<boolean | undefined>();
+expectTypeOf<Get<WithDictionary, 'foo.whatever', Strict>>().toEqualTypeOf<{bar: number} | undefined>();
+expectTypeOf<Get<WithDictionary, 'foo.whatever.bar', Strict>>().toEqualTypeOf<number | undefined>();
+expectTypeOf<Get<WithDictionary, 'baz.whatever.qux[3].x', Strict>>().toEqualTypeOf<boolean | undefined>();

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -89,3 +89,25 @@ interface WithModifiers {
 
 expectTypeOf<Get<WithModifiers, 'foo[0].bar.baz'>>().toEqualTypeOf<{qux: number} | undefined>();
 expectTypeOf<Get<WithModifiers, 'foo[0].abc.def.ghi'>>().toEqualTypeOf<string | undefined>();
+
+// Test strict version:
+
+expectTypeOf<Get<string[], '0', true>>().toEqualTypeOf<string | undefined>();
+expectTypeOf<Get<Record<string, number>, 'foo', true>>().toEqualTypeOf<number | undefined>();
+expectTypeOf<Get<Record<number, string>, '1', true>>().toEqualTypeOf<string | undefined>();
+expectTypeOf<Get<Record<'a' | 'b', number>, 'a', true>>().toEqualTypeOf<number>();
+expectTypeOf<Get<Record<1 | 2, string>, '1', true>>().toEqualTypeOf<string>();
+expectTypeOf<Get<{1: boolean}, '1', true>>().toBeBoolean();
+expectTypeOf<Get<[number, string], '0', true>>().toBeNumber();
+
+interface WithDictionary {
+	foo: Record<string, {
+		bar: number;
+	}>;
+	baz: Record<string, {
+		qux: Array<{x: boolean}>;
+	}>;
+}
+expectTypeOf<Get<WithDictionary, 'foo.whatever', true>>().toEqualTypeOf<{bar: number} | undefined>();
+expectTypeOf<Get<WithDictionary, 'foo.whatever.bar', true>>().toEqualTypeOf<number | undefined>();
+expectTypeOf<Get<WithDictionary, 'baz.whatever.qux[3].x', true>>().toEqualTypeOf<boolean | undefined>();

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -90,6 +90,14 @@ interface WithModifiers {
 expectTypeOf<Get<WithModifiers, 'foo[0].bar.baz'>>().toEqualTypeOf<{qux: number} | undefined>();
 expectTypeOf<Get<WithModifiers, 'foo[0].abc.def.ghi'>>().toEqualTypeOf<string | undefined>();
 
+// Test bracket notation
+expectTypeOf<Get<number[], '[0]'>>().toBeNumber();
+// NOTE: This would fail if `[0][0]` was converted into `00`:
+expectTypeOf<Get<number[], '[0][0]'>>().toBeUnknown();
+expectTypeOf<Get<number[][][], '[0][0][0]'>>().toBeNumber();
+expectTypeOf<Get<number[][][], '[0][0][0][0]'>>().toBeUnknown();
+expectTypeOf<Get<{a: {b: Array<Array<Array<{id: number}>>>}}, 'a.b[0][0][0].id'>>().toBeNumber();
+
 // Test strict version:
 
 type Strict = {strict: true};


### PR DESCRIPTION
Fixes #313 

As discussed in #313 the strict mode is opt-in.
~~I discovered one unfortunate edge case, and I believe that the strict mode should probably be kept as opt-in even in the next major release. The edge case is that if a type has both required named properties _and_ an index signature, the evaluated type includes `undefined`: `Get<{ a: string; [key: string]: string }, "a", true>` incorrectly evaluates to `string | undefined`. I haven't found a way around this and I don't know if it's even possible. It seems like there's no difference between `"a" | string` and `string`, so the compiler possibly just collapses the key type into `string`. If we're unable to fix it we should document it somewhere, but I'm not sure where?~~
Edit: There's one known case where strictness doesn't work: when accessing properties of an object with an index signature, `undefined` is _not_ included in the type when accessing the indexed property (`Get<{ a: string; [key: string]: string }, "foo", { strict: true }>` evaluates to `string`).

I also discovered to my surprise that accessing properties of `Record<number, any>` always evaluates to `unknown`, even before my changes. ~~I've left a failing test that demonstrates this~~. There's a comment on line 104 (in my fork) that says something about being lax with records, which I don't fully understand. Is there a particular reason that `Record<number, any>` shouldn't be allowed?

Edit: I also discovered that array brackets couldn't be used at the start of a path, and also could be repeated (like `"[0][0]"`), so I've included a fix for that too.