### PR TITLE
Add `Nullish` type

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -43,3 +43,10 @@ Matches any valid JSON value.
 @category Basic
 */
 export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+/**
+Matches a nullish value.
+
+@category Basic
+*/
+export type Nullish = null | undefined;


### PR DESCRIPTION
Implements a type for the nullish values described in the ECMAScript Language Specification:

> “nullish” values (`null` or `undefined`)

([source](https://tc39.es/ecma262/#:~:text=%E2%80%9Cnullish%E2%80%9D%20values%20(null%20or%20undefined)))