### PR TITLE
Fix `DelimiterCase` type incorrectly converting string to empty string

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -40,6 +40,8 @@ It receives `UsedWordSeparators` and `UsedUpperCaseCharacters` as input to ensur
 type StringArrayToDelimiterCase<Parts extends readonly any[], Start extends boolean, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
 	Parts extends [`${infer FirstPart}`, ...infer RemainingParts]
 		? `${StringPartToDelimiterCase<FirstPart, Start, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}${StringArrayToDelimiterCase<RemainingParts, false, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}`
+		: Parts extends [string]
+		? string
 		: '';
 
 /**

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -46,6 +46,9 @@ expectType<'##very#prefixed'>(delimiterFromDoublePrefixedKebab);
 const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'> = 'foo####bar';
 expectType<'foo####bar'>(delimiterFromRepeatedSeparators);
 
+const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
+expectType<string>(delimiterFromString);
+
 // Verifying example
 type OddCasedProperties<T> = {
 	[K in keyof T as DelimiterCase<K, '#'>]: T[K]


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fix #293

<img width="481" alt="截圖 2021-11-17 下午3 27 40" src="https://user-images.githubusercontent.com/3382565/142155279-b9211e7d-7654-4bb5-97a3-1e957b58c30a.png">

