### PR TITLE
Add `Schema` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ export {SetReturnType} from './source/set-return-type';
 export {Asyncify} from './source/asyncify';
 export {Simplify} from './source/simplify';
 export {Jsonify} from './source/jsonify';
+export {Schema} from './source/schema';
 
 // Template literal types
 export {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Click the type names for complete docs.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Simplify`](source/simplify.d.ts) - Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 - [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.
-- [`Schema`](source/schema.d.ts) - Recursively replaces all the property values into a given value type for an object.
+- [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 
 ### JSON
 
@@ -201,6 +201,7 @@ Click the type names for complete docs.
 *If you know one of our types by a different name, add it here for discovery.*
 
 - `PartialBy` - See [`SetOptional`](https://github.com/sindresorhus/type-fest/blob/main/source/set-optional.d.ts)
+- `RecordDeep`- See [`Schema`](https://github.com/sindresorhus/type-fest/blob/main/source/schema.d.ts)
 
 ## Tips
 

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Click the type names for complete docs.
 - [`SetReturnType`](source/set-return-type.d.ts) - Create a function type with a return type of your choice and the same parameters as the given function type.
 - [`Simplify`](source/simplify.d.ts) - Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 - [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.
-- [`Schema`](source/schema.d.ts) - Deeply changes the values for all properties on a type to whatever specified. Useful for code e.g validation or configuration that relies on using the same structure of a type but the values are different.
+- [`Schema`](source/schema.d.ts) - Recursively replaces all the property values into a given value type for an object.
 
 ### JSON
 

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ Click the type names for complete docs.
 - [`Includes`](source/includes.d.ts) - Returns a boolean for whether the given array includes the given item.
 - [`Simplify`](source/simplify.d.ts) - Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 - [`Jsonify`](source/jsonify.d.ts) - Transform a type to one that is assignable to the `JsonValue` type.
+- [`Schema`](source/schema.d.ts) - Deeply changes the values for all properties on a type to whatever specified. Useful for code e.g validation or configuration that relies on using the same structure of a type but the values are different.
 
 ### Template literal types
 

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -40,28 +40,28 @@ const userMaskSettings: UserMask = {
 @category Utilities
 */
 export type Schema<TObject, ValueType> = TObject extends string
-	? ValueType
-	: TObject extends Map<unknown, unknown>
-	? ValueType
-	: TObject extends Set<unknown>
-	? ValueType
-	: TObject extends ReadonlyMap<unknown, unknown>
-	? ValueType
-	: TObject extends ReadonlySet<unknown>
-	? ValueType
+  ? ValueType
+  : TObject extends Map<unknown, unknown>
+  ? ValueType
+  : TObject extends Set<unknown>
+  ? ValueType
+  : TObject extends ReadonlyMap<unknown, unknown>
+  ? ValueType
+  : TObject extends ReadonlySet<unknown>
+  ? ValueType
   : TObject extends readonly unknown[]
   ? ValueType
-	: TObject extends unknown[]
-	? ValueType
-	: TObject extends (...arguments: unknown[]) => unknown
-	? ValueType
+  : TObject extends unknown[]
+  ? ValueType
+  : TObject extends (...arguments: unknown[]) => unknown
+  ? ValueType
   : TObject extends Date
   ? ValueType
   : TObject extends Function
   ? ValueType
-	: TObject extends object
-	? SchemaObject<TObject, ValueType>
-	: ValueType;
+  : TObject extends object
+  ? SchemaObject<TObject, ValueType>
+  : ValueType;
 
 /**
 Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Schema`.

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,0 +1,71 @@
+/**
+Creates a type that mimics the structure of the specified type but replaces all the property values with a string-type.
+
+Use-cases:
+- Form validation, specify on every field how it should be validated.
+- Form settings, specify configuration for input field.
+- Provide types that allow specifying settings/behavior to types when e.g masking or parsing data.
+
+@example
+```
+import {Schema} from 'type-fest';
+
+interface User {
+  id: string;
+  name: {
+    firstname: string;
+    lastname: string;
+  };
+  created: Date;
+  active: boolean;
+  passwordHash: string;
+}
+
+type UserMask = Schema<User, 'mask' | 'hide' | 'show'>;
+
+const userMaskSettings: UserMask = {
+  id: 'show',
+  name: {
+    firstname: 'show',
+    lastname: 'mask',
+  },
+  phoneNumbers: 'mask',
+  created: 'show',
+  active: 'show',
+  passwordHash: 'hide',
+}
+
+```
+
+@category Utilities
+*/
+export type Schema<T, K> = T extends string
+	? K
+	: T extends Map<unknown, unknown>
+	? K
+	: T extends Set<unknown>
+	? K
+	: T extends ReadonlyMap<unknown, unknown>
+	? K
+	: T extends ReadonlySet<unknown>
+	? K
+  : T extends readonly unknown[]
+  ? K
+	: T extends unknown[]
+	? K
+	: T extends (...arguments: unknown[]) => unknown
+	? K
+  : T extends Date
+  ? K
+  : T extends Function
+  ? K
+	: T extends object
+	? SchemaObject<T, K>
+	: K;
+
+/**
+Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Schema`.
+ */
+type SchemaObject<ObjectType extends object, K> = {
+	[KeyType in keyof ObjectType]: Schema<ObjectType[KeyType], K> | K;
+};

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -65,7 +65,7 @@ export type Schema<ObjectType, ValueType> = ObjectType extends string
 
 /**
 Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Schema`.
- */
+*/
 type SchemaObject<ObjectType extends object, K> = {
 	[KeyType in keyof ObjectType]: Schema<ObjectType[KeyType], K> | K;
 };

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -39,29 +39,29 @@ const userMaskSettings: UserMask = {
 
 @category Utilities
 */
-export type Schema<T, K> = T extends string
-	? K
-	: T extends Map<unknown, unknown>
-	? K
-	: T extends Set<unknown>
-	? K
-	: T extends ReadonlyMap<unknown, unknown>
-	? K
-	: T extends ReadonlySet<unknown>
-	? K
-  : T extends readonly unknown[]
-  ? K
-	: T extends unknown[]
-	? K
-	: T extends (...arguments: unknown[]) => unknown
-	? K
-  : T extends Date
-  ? K
-  : T extends Function
-  ? K
-	: T extends object
-	? SchemaObject<T, K>
-	: K;
+export type Schema<TObject, ValueType> = TObject extends string
+	? ValueType
+	: TObject extends Map<unknown, unknown>
+	? ValueType
+	: TObject extends Set<unknown>
+	? ValueType
+	: TObject extends ReadonlyMap<unknown, unknown>
+	? ValueType
+	: TObject extends ReadonlySet<unknown>
+	? ValueType
+  : TObject extends readonly unknown[]
+  ? ValueType
+	: TObject extends unknown[]
+	? ValueType
+	: TObject extends (...arguments: unknown[]) => unknown
+	? ValueType
+  : TObject extends Date
+  ? ValueType
+  : TObject extends Function
+  ? ValueType
+	: TObject extends object
+	? SchemaObject<TObject, ValueType>
+	: ValueType;
 
 /**
 Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Schema`.

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -2,9 +2,9 @@
 Recursively replaces all the property values into a given value type for an object.
 
 Use-cases:
-- Form validation, specify on every field how it should be validated.
-- Form settings, specify configuration for input field.
-- Provide types that allow specifying settings/behavior to types when e.g masking or parsing data.
+- Form validation: Define how each field should be validated.
+- Form settings: Define configuration for input fields.
+- Parsing: Define types that specify special behavior for specific fields.
 
 @example
 ```

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,5 +1,5 @@
 /**
-Creates a type that mimics the structure of the specified type but replaces all the property values with a given type.
+Recursively replaces all the property values into a given value type for an object.
 
 Use-cases:
 - Form validation, specify on every field how it should be validated.

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -36,7 +36,7 @@ const userMaskSettings: UserMask = {
 }
 ```
 
-@category Utilities
+@category Object
 */
 export type Schema<ObjectType, ValueType> = ObjectType extends string
 	? ValueType

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -59,6 +59,8 @@ export type Schema<ObjectType, ValueType> = ObjectType extends string
 	? ValueType
 	: ObjectType extends Function
 	? ValueType
+	: ObjectType extends RegExp
+	? ValueType
 	: ObjectType extends object
 	? SchemaObject<ObjectType, ValueType>
 	: ValueType;

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -34,7 +34,6 @@ const userMaskSettings: UserMask = {
 	active: 'show',
 	passwordHash: 'hide',
 }
-
 ```
 
 @category Utilities

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,5 +1,5 @@
 /**
-Creates a type that mimics the structure of the specified type but replaces all the property values with a string-type.
+Creates a type that mimics the structure of the specified type but replaces all the property values with a given type.
 
 Use-cases:
 - Form validation, specify on every field how it should be validated.
@@ -11,57 +11,57 @@ Use-cases:
 import {Schema} from 'type-fest';
 
 interface User {
-  id: string;
-  name: {
-    firstname: string;
-    lastname: string;
-  };
-  created: Date;
-  active: boolean;
-  passwordHash: string;
+	id: string;
+	name: {
+		firstname: string;
+		lastname: string;
+	};
+	created: Date;
+	active: boolean;
+	passwordHash: string;
 }
 
 type UserMask = Schema<User, 'mask' | 'hide' | 'show'>;
 
 const userMaskSettings: UserMask = {
-  id: 'show',
-  name: {
-    firstname: 'show',
-    lastname: 'mask',
-  },
-  phoneNumbers: 'mask',
-  created: 'show',
-  active: 'show',
-  passwordHash: 'hide',
+	id: 'show',
+	name: {
+		firstname: 'show',
+		lastname: 'mask',
+	},
+	phoneNumbers: 'mask',
+	created: 'show',
+	active: 'show',
+	passwordHash: 'hide',
 }
 
 ```
 
 @category Utilities
 */
-export type Schema<TObject, ValueType> = TObject extends string
-  ? ValueType
-  : TObject extends Map<unknown, unknown>
-  ? ValueType
-  : TObject extends Set<unknown>
-  ? ValueType
-  : TObject extends ReadonlyMap<unknown, unknown>
-  ? ValueType
-  : TObject extends ReadonlySet<unknown>
-  ? ValueType
-  : TObject extends readonly unknown[]
-  ? ValueType
-  : TObject extends unknown[]
-  ? ValueType
-  : TObject extends (...arguments: unknown[]) => unknown
-  ? ValueType
-  : TObject extends Date
-  ? ValueType
-  : TObject extends Function
-  ? ValueType
-  : TObject extends object
-  ? SchemaObject<TObject, ValueType>
-  : ValueType;
+export type Schema<ObjectType, ValueType> = ObjectType extends string
+	? ValueType
+	: ObjectType extends Map<unknown, unknown>
+	? ValueType
+	: ObjectType extends Set<unknown>
+	? ValueType
+	: ObjectType extends ReadonlyMap<unknown, unknown>
+	? ValueType
+	: ObjectType extends ReadonlySet<unknown>
+	? ValueType
+	: ObjectType extends readonly unknown[]
+	? ValueType
+	: ObjectType extends unknown[]
+	? ValueType
+	: ObjectType extends (...arguments: unknown[]) => unknown
+	? ValueType
+	: ObjectType extends Date
+	? ValueType
+	: ObjectType extends Function
+	? ValueType
+	: ObjectType extends object
+	? SchemaObject<ObjectType, ValueType>
+	: ValueType;
 
 /**
 Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Schema`.

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,5 +1,5 @@
 /**
-Recursively replaces all the property values into a given value type for an object.
+Create a deep version of another object type where property values are recursively replaced into a given value type.
 
 Use-cases:
 - Form validation: Define how each field should be validated.

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -2,46 +2,48 @@ import {expectType, expectError} from 'tsd';
 import {Schema} from '../index';
 
 const foo = {
-  baz: 'fred',
-  bar: {
-    function: (_: string): void => undefined,
-    object: {key: 'value'},
-    string: 'waldo',
-    number: 1,
-    boolean: false,
-    symbol: Symbol('test'),
-    map: new Map<string, string>(),
-    set: new Set<string>(),
-    array: ['foo'],
-    tuple: ['foo'] as ['foo'],
-    readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
-    readonlySet: new Set<string>() as ReadonlySet<string>,
-    readonlyArray: ['foo'] as readonly string[],
-    readonlyTuple: ['foo'] as const,
-  },
+	baz: 'fred',
+	bar: {
+		function: (_: string): void => undefined,
+		object: {key: 'value'},
+		string: 'waldo',
+		number: 1,
+		boolean: false,
+		symbol: Symbol('test'),
+		map: new Map<string, string>(),
+		set: new Set<string>(),
+		array: ['foo'],
+		tuple: ['foo'] as ['foo'],
+		readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
+		readonlySet: new Set<string>() as ReadonlySet<string>,
+		readonlyArray: ['foo'] as readonly string[],
+		readonlyTuple: ['foo'] as const,
+		regExp: /.*/g,
+	},
 };
 
 type FooOption = 'A' | 'B';
 type FooSchema = Schema<typeof foo, FooOption>;
 
 const fooSchema: FooSchema = {
-  baz: 'A',
-  bar: {
-    function: 'A',
-    object: {key: 'A'},
-    string: 'A',
-    number: 'A',
-    boolean: 'A',
-    symbol: 'A',
-    map: 'A',
-    set: 'A',
-    array: 'A',
-    tuple: 'A',
-    readonlyMap: 'A',
-    readonlySet: 'A',
-    readonlyArray: 'A',
-    readonlyTuple: 'A',
-  },
+	baz: 'A',
+	bar: {
+		function: 'A',
+		object: {key: 'A'},
+		string: 'A',
+		number: 'A',
+		boolean: 'A',
+		symbol: 'A',
+		map: 'A',
+		set: 'A',
+		array: 'A',
+		tuple: 'A',
+		readonlyMap: 'A',
+		readonlySet: 'A',
+		readonlyArray: 'A',
+		readonlyTuple: 'A',
+		regExp: 'A',
+	},
 };
 
 expectError<FooSchema>(foo);
@@ -64,38 +66,40 @@ expectType<FooOption>(barSchema.readonlyMap);
 expectType<FooOption>(barSchema.readonlySet);
 expectType<FooOption>(barSchema.readonlyArray);
 expectType<FooOption>(barSchema.readonlyTuple);
+expectType<FooOption>(barSchema.regExp);
 
 interface ComplexOption {
-  type: 'readonly' | 'required' | 'optional';
-  validation(value: unknown): boolean;
+	type: 'readonly' | 'required' | 'optional';
+	validation(value: unknown): boolean;
 }
 type ComplexSchema = Schema<typeof foo, ComplexOption>;
 
 const createComplexOption = (type: ComplexOption['type']): ComplexOption => ({
-  type,
-  validation(value) {
-    return value !== undefined;
-  },
+	type,
+	validation(value) {
+		return value !== undefined;
+	},
 });
 
 const complexFoo: ComplexSchema = {
-  baz: createComplexOption('optional'),
-  bar: {
-    function: createComplexOption('required'),
-    object: createComplexOption('readonly'),
-    string: createComplexOption('readonly'),
-    number: createComplexOption('readonly'),
-    boolean: createComplexOption('readonly'),
-    symbol: createComplexOption('readonly'),
-    map: createComplexOption('readonly'),
-    set: createComplexOption('readonly'),
-    array: createComplexOption('readonly'),
-    tuple: createComplexOption('readonly'),
-    readonlyMap: createComplexOption('readonly'),
-    readonlySet: createComplexOption('readonly'),
-    readonlyArray: createComplexOption('readonly'),
-    readonlyTuple: createComplexOption('readonly'),
-  },
+	baz: createComplexOption('optional'),
+	bar: {
+		function: createComplexOption('required'),
+		object: createComplexOption('readonly'),
+		string: createComplexOption('readonly'),
+		number: createComplexOption('readonly'),
+		boolean: createComplexOption('readonly'),
+		symbol: createComplexOption('readonly'),
+		map: createComplexOption('readonly'),
+		set: createComplexOption('readonly'),
+		array: createComplexOption('readonly'),
+		tuple: createComplexOption('readonly'),
+		readonlyMap: createComplexOption('readonly'),
+		readonlySet: createComplexOption('readonly'),
+		readonlyArray: createComplexOption('readonly'),
+		readonlyTuple: createComplexOption('readonly'),
+		regExp: createComplexOption('readonly'),
+	},
 };
 
 expectError<ComplexSchema>(foo);
@@ -116,3 +120,4 @@ expectType<ComplexOption>(complexBarSchema.readonlyMap);
 expectType<ComplexOption>(complexBarSchema.readonlySet);
 expectType<ComplexOption>(complexBarSchema.readonlyArray);
 expectType<ComplexOption>(complexBarSchema.readonlyTuple);
+expectType<ComplexOption>(complexBarSchema.regExp);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -2,23 +2,23 @@ import {expectType, expectError} from 'tsd';
 import {Schema} from '../index';
 
 const foo = {
-	baz: 'fred',
-	bar: {
-		function: (_: string): void => undefined,
-		object: {key: 'value'},
-		string: 'waldo',
-		number: 1,
-		boolean: false,
-		symbol: Symbol('test'),
-		map: new Map<string, string>(),
-		set: new Set<string>(),
-		array: ['foo'],
-		tuple: ['foo'] as ['foo'],
-		readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
-		readonlySet: new Set<string>() as ReadonlySet<string>,
-		readonlyArray: ['foo'] as readonly string[],
-		readonlyTuple: ['foo'] as const,
-	},
+  baz: 'fred',
+  bar: {
+    function: (_: string): void => undefined,
+    object: {key: 'value'},
+    string: 'waldo',
+    number: 1,
+    boolean: false,
+    symbol: Symbol('test'),
+    map: new Map<string, string>(),
+    set: new Set<string>(),
+    array: ['foo'],
+    tuple: ['foo'] as ['foo'],
+    readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
+    readonlySet: new Set<string>() as ReadonlySet<string>,
+    readonlyArray: ['foo'] as readonly string[],
+    readonlyTuple: ['foo'] as const,
+  },
 };
 
 type FooOption = 'A' | 'B';
@@ -79,23 +79,23 @@ const createComplexOption = (type: ComplexOption['type']): ComplexOption => ({
 });
 
 const complexFoo: ComplexSchema = {
-	baz: createComplexOption('optional'),
-	bar: {
-		function: createComplexOption('required'),
-		object: createComplexOption('readonly'),
-		string: createComplexOption('readonly'),
-		number: createComplexOption('readonly'),
-		boolean: createComplexOption('readonly'),
-		symbol: createComplexOption('readonly'),
+  baz: createComplexOption('optional'),
+  bar: {
+    function: createComplexOption('required'),
+    object: createComplexOption('readonly'),
+    string: createComplexOption('readonly'),
+    number: createComplexOption('readonly'),
+    boolean: createComplexOption('readonly'),
+    symbol: createComplexOption('readonly'),
     map: createComplexOption('readonly'),
-		set: createComplexOption('readonly'),
-		array: createComplexOption('readonly'),
-		tuple: createComplexOption('readonly'),
-		readonlyMap: createComplexOption('readonly'),
-		readonlySet: createComplexOption('readonly'),
-		readonlyArray: createComplexOption('readonly'),
-		readonlyTuple: createComplexOption('readonly'),
-	},
+    set: createComplexOption('readonly'),
+    array: createComplexOption('readonly'),
+    tuple: createComplexOption('readonly'),
+    readonlyMap: createComplexOption('readonly'),
+    readonlySet: createComplexOption('readonly'),
+    readonlyArray: createComplexOption('readonly'),
+    readonlyTuple: createComplexOption('readonly'),
+  },
 };
 
 expectError<ComplexSchema>(foo);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -1,0 +1,118 @@
+import {expectType, expectError} from 'tsd';
+import {Schema} from '../index';
+
+const foo = {
+	baz: 'fred',
+	bar: {
+		function: (_: string): void => undefined,
+		object: {key: 'value'},
+		string: 'waldo',
+		number: 1,
+		boolean: false,
+		symbol: Symbol('test'),
+		map: new Map<string, string>(),
+		set: new Set<string>(),
+		array: ['foo'],
+		tuple: ['foo'] as ['foo'],
+		readonlyMap: new Map<string, string>() as ReadonlyMap<string, string>,
+		readonlySet: new Set<string>() as ReadonlySet<string>,
+		readonlyArray: ['foo'] as readonly string[],
+		readonlyTuple: ['foo'] as const,
+	},
+};
+
+type FooOption = 'A' | 'B';
+type FooSchema = Schema<typeof foo, FooOption>;
+
+const fooSchema: FooSchema = {
+  baz: 'A',
+  bar: {
+    function: 'A',
+    object: {key: 'A'},
+    string: 'A',
+    number: 'A',
+    boolean: 'A',
+    symbol: 'A',
+    map: 'A',
+    set: 'A',
+    array: 'A',
+    tuple: 'A',
+    readonlyMap: 'A',
+    readonlySet: 'A',
+    readonlyArray: 'A',
+    readonlyTuple: 'A',
+  },
+};
+
+expectError<FooSchema>(foo);
+expectError<FooSchema>({key: 'value'});
+expectError<FooSchema>(new Date());
+expectType<FooOption>(fooSchema.baz);
+
+const barSchema = fooSchema.bar as Schema<typeof foo['bar'], FooOption>;
+expectType<FooOption>(barSchema.function);
+expectType<FooOption | {key: FooOption}>(barSchema.object);
+expectType<FooOption>(barSchema.string);
+expectType<FooOption>(barSchema.number);
+expectType<FooOption>(barSchema.boolean);
+expectType<FooOption>(barSchema.symbol);
+expectType<FooOption>(barSchema.map);
+expectType<FooOption>(barSchema.set);
+expectType<FooOption>(barSchema.array);
+expectType<FooOption>(barSchema.tuple);
+expectType<FooOption>(barSchema.readonlyMap);
+expectType<FooOption>(barSchema.readonlySet);
+expectType<FooOption>(barSchema.readonlyArray);
+expectType<FooOption>(barSchema.readonlyTuple);
+
+interface ComplexOption {
+  type: 'readonly' | 'required' | 'optional';
+  validation(value: unknown): boolean;
+}
+type ComplexSchema = Schema<typeof foo, ComplexOption>;
+
+const createComplexOption = (type: ComplexOption['type']): ComplexOption => ({
+  type,
+  validation(value) {
+    return value !== undefined;
+  },
+});
+
+const complexFoo: ComplexSchema = {
+	baz: createComplexOption('optional'),
+	bar: {
+		function: createComplexOption('required'),
+		object: createComplexOption('readonly'),
+		string: createComplexOption('readonly'),
+		number: createComplexOption('readonly'),
+		boolean: createComplexOption('readonly'),
+		symbol: createComplexOption('readonly'),
+    map: createComplexOption('readonly'),
+		set: createComplexOption('readonly'),
+		array: createComplexOption('readonly'),
+		tuple: createComplexOption('readonly'),
+		readonlyMap: createComplexOption('readonly'),
+		readonlySet: createComplexOption('readonly'),
+		readonlyArray: createComplexOption('readonly'),
+		readonlyTuple: createComplexOption('readonly'),
+	},
+};
+
+expectError<ComplexSchema>(foo);
+expectType<ComplexOption>(complexFoo.baz);
+
+const complexBarSchema = complexFoo.bar as Schema<typeof foo['bar'], ComplexOption>;
+expectType<ComplexOption>(complexBarSchema.function);
+expectType<ComplexOption | {key: ComplexOption}>(complexBarSchema.object);
+expectType<ComplexOption>(complexBarSchema.string);
+expectType<ComplexOption>(complexBarSchema.number);
+expectType<ComplexOption>(complexBarSchema.boolean);
+expectType<ComplexOption>(complexBarSchema.symbol);
+expectType<ComplexOption>(complexBarSchema.map);
+expectType<ComplexOption>(complexBarSchema.set);
+expectType<ComplexOption>(complexBarSchema.array);
+expectType<ComplexOption>(complexBarSchema.tuple);
+expectType<ComplexOption>(complexBarSchema.readonlyMap);
+expectType<ComplexOption>(complexBarSchema.readonlySet);
+expectType<ComplexOption>(complexBarSchema.readonlyArray);
+expectType<ComplexOption>(complexBarSchema.readonlyTuple);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

`Schema` allows re-using the structure of an interface and applying new values to it. This is commonly seen in validation where libraries like [joi](https://www.npmjs.com/package/joi) and [yup](https://www.npmjs.com/package/yup) when used with TypeScript replaces interface values with validation schema types.

The intention of `Schema` is to make it easier to provide similar workflows which also support other use-cases like masking data or providing config to parsing.

The schema is recursive/deep which means that it will dig down objects to provide the same value on all properties.

`Schema` might be better named as `RecordDeep` since it is very similar to a TypeScript `Record<TObject, ValueType>`. But compared to a `Record` the `Schema` traverses the objects in the tree.

**Example:**

```ts
import { Schema } from 'type-fest';

interface Foo {
  array: any[];
  primitive: boolean;
  object: {
    primitive: boolean;
  }
}

type FooSchema = Schema<Foo, 'A'>;

// FooSchema is now the same as this interface
interface FooSchema {
  array: 'A';
  primitive: 'A';
  object: 'A' | { primitive: 'A' }; // For an ordinary Record this would only be 'A'
};
```

**Real life use-case:**

I use it to apply behavior for how data should be outputted in logs. So the below code is somewhat similar to actual code.

```ts
interface HttpRequest {
  url: string;
  headers: {
    authorization: string;
    contentType: string;
  };
  body: {
    userId: string;
    settings: {
      foo: boolean;
      bar: boolean;
    };
  };
};

type SchemaOptions =
  'hide'
  | 'hash' 
  | 'show' // default behavior

const schema: PartialDeep<Schema<HttpRequest, 'hide' | 'hash' | 'show'>> = {
  headers: {
    authorization: 'hide',
  },
  body: {
    userId: 'hash',
  },
};

const request: HttpRequest = { /* create request */ };

log.debug(sanitizeObject(request, schema));
```

---

Fixes #103 
Closes #354