### PR TITLE
Prevent deep copy for standard build-in types

### DIFF
--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -1,4 +1,5 @@
 import {CamelCase} from './camel-case';
+import {StandartBuildInTypes} from './utilities';
 
 /**
 Convert object properties to camel case recursively.
@@ -40,8 +41,9 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 
 @category Template Literals
 */
-export type CamelCasedPropertiesDeep<Value> = Value extends Function
-	? Value
+export type CamelCasedPropertiesDeep<Value, Exclude = never>
+  = Value extends Exclude | StandartBuildInTypes
+  ? Value
 	: Value extends Array<infer U>
 	? Array<CamelCasedPropertiesDeep<U>>
 	: Value extends Set<infer U>

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -1,5 +1,4 @@
 import {CamelCase} from './camel-case';
-import {StandartBuildInTypes} from './utilities';
 
 /**
 Convert object properties to camel case recursively.
@@ -42,7 +41,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 @category Template Literals
 */
 export type CamelCasedPropertiesDeep<Value, Exclude = never>
-  = Value extends Exclude | StandartBuildInTypes
+  = Value extends Exclude
   ? Value
 	: Value extends Array<infer U>
 	? Array<CamelCasedPropertiesDeep<U>>

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -47,5 +47,5 @@ export type CamelCasedPropertiesDeep<Value, Exclude = never>
 	? Array<CamelCasedPropertiesDeep<U>>
 	: Value extends Set<infer U>
 	? Set<CamelCasedPropertiesDeep<U>> : {
-			[K in keyof Value as CamelCase<K>]: CamelCasedPropertiesDeep<Value[K]>;
+			[K in keyof Value as CamelCase<K>]: CamelCasedPropertiesDeep<Value[K], Exclude>;
 	};

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -41,7 +41,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 @category Template Literals
 */
 export type CamelCasedPropertiesDeep<Value, Exclude = never>
-  = Value extends Exclude
+  = Value extends Exclude | Function
   ? Value
 	: Value extends Array<infer U>
 	? Array<CamelCasedPropertiesDeep<U>>

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -43,7 +43,8 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
-> = Value extends Function
+  Exclude = never,
+> = Value extends Exclude | Function
 	? Value
 	: Value extends Array<infer U>
 	? Array<DelimiterCasedPropertiesDeep<U, Delimiter>>
@@ -52,5 +53,5 @@ export type DelimiterCasedPropertiesDeep<
 			[K in keyof Value as DelimiterCase<
 				K,
 				Delimiter
-			>]: DelimiterCasedPropertiesDeep<Value[K], Delimiter>;
+			>]: DelimiterCasedPropertiesDeep<Value[K], Delimiter, Exclude>;
 	};

--- a/source/utilities.d.ts
+++ b/source/utilities.d.ts
@@ -3,3 +3,7 @@ export type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' 
 export type WordSeparators = '-' | '_' | ' ';
 
 export type StringDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+export type StandartBuildInTypes =
+  | Function
+  | Date;

--- a/source/utilities.d.ts
+++ b/source/utilities.d.ts
@@ -3,7 +3,3 @@ export type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' 
 export type WordSeparators = '-' | '_' | ' ';
 
 export type StringDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
-
-export type StandartBuildInTypes =
-  | Function
-  | Date;

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -11,6 +11,9 @@ expectType<() => {a: string}>(fooBar);
 declare const bar: CamelCasedPropertiesDeep<Set<{fooBar: string}>>;
 expectType<Set<{fooBar: string}>>(bar);
 
+declare const withDate: CamelCasedPropertiesDeep<{foo_bar: Date}>;
+expectType<{fooBar: Date}>(withDate);
+
 // Verify example
 interface User {
 	UserId: number;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
`CamelCasedPropertiesDeep` recursively copy all types including standard build-it object types. You can pass type or union of type and they will no recursively copy more. Also included for some build-it types.
