### PR TITLE
Add `Float` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ export {
 	NegativeInfinity,
 	Finite,
 	Integer,
+	Float,
 	Negative,
 	NonNegative,
 	NegativeInteger,

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ export {
 	Negative,
 	NonNegative,
 	NegativeInteger,
+	NegativeFloat,
 	NonNegativeInteger,
 } from './source/numeric';
 

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Click the type names for complete docs.
 - [`NegativeInfinity`](source/numeric.d.ts) - Matches the hidden `-Infinity` type.
 - [`Finite`](source/numeric.d.ts) - A finite `number`.
 - [`Integer`](source/numeric.d.ts) - A `number` that is an integer.
+- [`Float`](source/numeric.d.ts) - A `number` that is not an integer.
 - [`Negative`](source/numeric.d.ts) - A negative `number`/`bigint` (`-∞ < x < 0`)
 - [`NonNegative`](source/numeric.d.ts) - A non-negative `number`/`bigint` (`0 <= x < ∞`).
 - [`NegativeInteger`](source/numeric.d.ts) - A negative (`-∞ < x < 0`) `number` that is an integer.

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ Click the type names for complete docs.
 - [`Negative`](source/numeric.d.ts) - A negative `number`/`bigint` (`-∞ < x < 0`)
 - [`NonNegative`](source/numeric.d.ts) - A non-negative `number`/`bigint` (`0 <= x < ∞`).
 - [`NegativeInteger`](source/numeric.d.ts) - A negative (`-∞ < x < 0`) `number` that is an integer.
+- [`NegativeFloat`](source/numeric.d.ts) - A negative (`-∞ < x < 0`) `number` that is not an integer.
 - [`NonNegativeInteger`](source/numeric.d.ts) - A non-negative (`0 <= x < ∞`) `number` that is an integer.
 
 ### Template literal types

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -68,6 +68,25 @@ declare function setYear<T extends number>(length: Integer<T>): void;
 export type Integer<T extends number> = `${T}` extends `${bigint}` ? T : never;
 
 /**
+A `number` that is not an integer.
+You can't pass a `bigint` as they are already guaranteed to be integers.
+
+Use-case: Validating and documenting parameters.
+
+@example
+```
+import {Float} from 'type-fest';
+
+declare function setPercentage<T extends number>(length: Float<T>): void;
+```
+
+@see Integer
+
+@category Utilities
+*/
+export type Float<T extends number> = T extends Integer<T> ? never : T;
+
+/**
 A negative `number`/`bigint` (`-∞ < x < 0`)
 
 Use-case: Validating and documenting parameters.

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -114,6 +114,19 @@ Use-case: Validating and documenting parameters.
 export type NegativeInteger<T extends number> = Negative<Integer<T>>;
 
 /**
+A negative (`-∞ < x < 0`) `number` that is not an integer.
+Equivalent to `Negative<Float<T>>`.
+
+Use-case: Validating and documenting parameters.
+
+@see Negative
+@see Float
+
+@category Utilities
+*/
+export type NegativeFloat<T extends number> = Negative<Float<T>>;
+
+/**
 A non-negative `number`/`bigint` (`0 <= x < ∞`).
 
 Use-case: Validating and documenting parameters.

--- a/test-d/numeric.ts
+++ b/test-d/numeric.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import {Finite, Integer, Negative, NegativeInfinity, NegativeInteger, NonNegative, NonNegativeInteger, PositiveInfinity} from '../index';
+import {Finite, Float, Integer, Negative, NegativeInfinity, NegativeInteger, NonNegative, NonNegativeInteger, PositiveInfinity} from '../index';
 
 // Finite
 declare const infinity: Finite<PositiveInfinity | NegativeInfinity>;
@@ -18,6 +18,17 @@ expectType<1>(integer);
 expectType<never>(integerMixed); // This may be undesired behavior
 expectType<never>(nonInteger);
 expectType<never>(infinityInteger);
+
+// Float
+declare const float: Float<1.5>;
+declare const floatMixed: Float<1 | 1.5>;
+declare const nonFloat: Float<1>;
+declare const infinityFloat: Float<PositiveInfinity | NegativeInfinity>;
+
+expectType<1.5>(float);
+expectType<1.5>(floatMixed);
+expectType<never>(nonFloat);
+expectType<PositiveInfinity | NegativeInfinity>(infinityFloat); // According to Number.isInteger
 
 // Negative
 declare const negative: Negative<-1 | -1n | 0 | 0n | 1 | 1n>;

--- a/test-d/numeric.ts
+++ b/test-d/numeric.ts
@@ -1,5 +1,16 @@
 import {expectType} from 'tsd';
-import {Finite, Float, Integer, Negative, NegativeInfinity, NegativeInteger, NonNegative, NonNegativeInteger, PositiveInfinity} from '../index';
+import {
+	Finite,
+	Float,
+	Integer,
+	Negative,
+	NegativeFloat,
+	NegativeInfinity,
+	NegativeInteger,
+	NonNegative,
+	NonNegativeInteger,
+	PositiveInfinity,
+} from '../index';
 
 // Finite
 declare const infinity: Finite<PositiveInfinity | NegativeInfinity>;
@@ -39,6 +50,11 @@ expectType<-1 | -1n>(negative);
 declare const negativeInteger: NegativeInteger<-1 | 0 | 1>;
 
 expectType<-1>(negativeInteger);
+
+// NegativeFloat
+declare const negativeFloat: NegativeFloat<-1.5 | -1 | 0 | 1 | 1.5>;
+
+expectType<-1.5>(negativeFloat);
 
 // NonNegative
 declare const nonNegative: NonNegative<-1 | -1n | 0 | 0n | 1 | 1n>;


### PR DESCRIPTION
Adds a `Float` and `NegativeFloat` type.
Not really sure what the use case for `NegativeFloat` would be though.

Also: Should these be called `NonInteger` instead of `Float`? Might be a more accurate description of what the type is, especially considering JS `number`s are always float64s.

Fixes #329