### PR TITLE
Improve `@category` doc comments

### DIFF
--- a/source/async-return-type.d.ts
+++ b/source/async-return-type.d.ts
@@ -20,6 +20,6 @@ async function doSomething(value: Value) {}
 asyncFunction().then(value => doSomething(value));
 ```
 
-@category Utilities
+@category Async
 */
 export type AsyncReturnType<Target extends AsyncFunction> = PromiseValue<ReturnType<Target>>;

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -28,6 +28,6 @@ const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 }
 ```
 
-@category Utilities
+@category Async
 */
 export type Asyncify<Fn extends (...args: any[]) => any> = SetReturnType<Fn, Promise<PromiseValue<ReturnType<Fn>>>>;

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -1,14 +1,14 @@
 /**
 Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 
-@category Basic
+@category Classes
 */
 export type Class<T, Arguments extends unknown[] = any[]> = Constructor<T, Arguments> & {prototype: T};
 
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 
-@category Basic
+@category Classes
 */
 export type Constructor<T, Arguments extends unknown[] = any[]> = new(...arguments_: Arguments) => T;
 
@@ -17,21 +17,21 @@ Matches a JSON object.
 
 This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.
 
-@category Basic
+@category JSON
 */
 export type JsonObject = {[Key in string]?: JsonValue};
 
 /**
 Matches a JSON array.
 
-@category Basic
+@category JSON
 */
 export type JsonArray = JsonValue[];
 
 /**
 Matches any valid JSON primitive value.
 
-@category Basic
+@category JSON
 */
 export type JsonPrimitive = string | number | boolean | null;
 
@@ -40,6 +40,6 @@ Matches any valid JSON value.
 
 @see `Jsonify` if you need to transform a type to one that is assignable to `JsonValue`.
 
-@category Basic
+@category JSON
 */
 export type JsonValue = JsonPrimitive | JsonObject | JsonArray;

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -1,14 +1,14 @@
 /**
 Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 
-@category Classes
+@category Class
 */
 export type Class<T, Arguments extends unknown[] = any[]> = Constructor<T, Arguments> & {prototype: T};
 
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 
-@category Classes
+@category Class
 */
 export type Constructor<T, Arguments extends unknown[] = any[]> = new(...arguments_: Arguments) => T;
 

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -67,6 +67,7 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 };
 ```
 
+@category Change case
 @category Template literal
 */
 export type CamelCase<K> = K extends string ? CamelCaseStringArray<Split<K extends Uppercase<K> ? Lowercase<K> : K, WordSeparators>> : K;

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -67,6 +67,6 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 };
 ```
 
-@category Template literals
+@category Template literal
 */
 export type CamelCase<K> = K extends string ? CamelCaseStringArray<Split<K extends Uppercase<K> ? Lowercase<K> : K, WordSeparators>> : K;

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -67,6 +67,6 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type CamelCase<K> = K extends string ? CamelCaseStringArray<Split<K extends Uppercase<K> ? Lowercase<K> : K, WordSeparators>> : K;

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -38,8 +38,8 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type CamelCasedPropertiesDeep<Value> = Value extends Function
 	? Value

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -38,6 +38,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type CamelCasedPropertiesDeep<Value> = Value extends Function

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -39,6 +39,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type CamelCasedPropertiesDeep<Value> = Value extends Function
 	? Value

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -22,6 +22,7 @@ const result: CamelCasedProperties<User> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type CamelCasedProperties<Value> = Value extends Function
 	? Value

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: CamelCasedProperties<User> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type CamelCasedProperties<Value> = Value extends Function

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -21,8 +21,8 @@ const result: CamelCasedProperties<User> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type CamelCasedProperties<Value> = Value extends Function
 	? Value

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -21,6 +21,7 @@ const result: CamelCasedProperties<User> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/conditional-except.d.ts
+++ b/source/conditional-except.d.ts
@@ -37,7 +37,7 @@ type NonStringKeysOnly = ConditionalExcept<Example, string>;
 //=> {b: string | number; c: () => void; d: {}}
 ```
 
-@category Utilities
+@category Objects
 */
 export type ConditionalExcept<Base, Condition> = Except<
 	Base,

--- a/source/conditional-except.d.ts
+++ b/source/conditional-except.d.ts
@@ -37,7 +37,7 @@ type NonStringKeysOnly = ConditionalExcept<Example, string>;
 //=> {b: string | number; c: () => void; d: {}}
 ```
 
-@category Objects
+@category Object
 */
 export type ConditionalExcept<Base, Condition> = Except<
 	Base,

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -26,7 +26,7 @@ type StringKeysAndUndefined = ConditionalKeys<Example, string | undefined>;
 //=> 'a' | 'c'
 ```
 
-@category Utilities
+@category Objects
 */
 export type ConditionalKeys<Base, Condition> = NonNullable<
 	// Wrap in `NonNullable` to strip away the `undefined` type from the produced union.

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -26,7 +26,7 @@ type StringKeysAndUndefined = ConditionalKeys<Example, string | undefined>;
 //=> 'a' | 'c'
 ```
 
-@category Objects
+@category Object
 */
 export type ConditionalKeys<Base, Condition> = NonNullable<
 	// Wrap in `NonNullable` to strip away the `undefined` type from the produced union.

--- a/source/conditional-pick.d.ts
+++ b/source/conditional-pick.d.ts
@@ -36,7 +36,7 @@ type StringKeysOnly = ConditionalPick<Example, string>;
 //=> {a: string}
 ```
 
-@category Objects
+@category Object
 */
 export type ConditionalPick<Base, Condition> = Pick<
 	Base,

--- a/source/conditional-pick.d.ts
+++ b/source/conditional-pick.d.ts
@@ -36,7 +36,7 @@ type StringKeysOnly = ConditionalPick<Example, string>;
 //=> {a: string}
 ```
 
-@category Utilities
+@category Objects
 */
 export type ConditionalPick<Base, Condition> = Pick<
 	Base,

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -3,7 +3,7 @@ import {UpperCaseCharacters, WordSeparators} from '../source/utilities';
 /**
 Unlike a simpler split, this one includes the delimiter splitted on in the resulting array literal. This is to enable splitting on, for example, upper-case characters.
 
-@category Template literals
+@category Template literal
 */
 export type SplitIncludingDelimiters<Source extends string, Delimiter extends string> =
 	Source extends '' ? [] :
@@ -79,7 +79,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 };
 ```
 
-@category Template literals
+@category Template literal
 */
 export type DelimiterCase<Value, Delimiter extends string> = Value extends string
 	? StringArrayToDelimiterCase<

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -79,6 +79,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 };
 ```
 
+@category Change case
 @category Template literal
 */
 export type DelimiterCase<Value, Delimiter extends string> = Value extends string

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -3,7 +3,7 @@ import {UpperCaseCharacters, WordSeparators} from '../source/utilities';
 /**
 Unlike a simpler split, this one includes the delimiter splitted on in the resulting array literal. This is to enable splitting on, for example, upper-case characters.
 
-@category Template Literals
+@category Template literals
 */
 export type SplitIncludingDelimiters<Source extends string, Delimiter extends string> =
 	Source extends '' ? [] :
@@ -79,7 +79,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type DelimiterCase<Value, Delimiter extends string> = Value extends string
 	? StringArrayToDelimiterCase<

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -39,6 +39,7 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type DelimiterCasedPropertiesDeep<
 	Value,

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type DelimiterCasedPropertiesDeep<

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -38,8 +38,8 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type DelimiterCasedPropertiesDeep<
 	Value,

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -38,6 +38,7 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -21,8 +21,8 @@ const result: DelimiterCasedProperties<User, '-'> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type DelimiterCasedProperties<
 	Value,

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -21,6 +21,7 @@ const result: DelimiterCasedProperties<User, '-'> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: DelimiterCasedProperties<User, '-'> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type DelimiterCasedProperties<

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -22,6 +22,7 @@ const result: DelimiterCasedProperties<User, '-'> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type DelimiterCasedProperties<
 	Value,

--- a/source/entries.d.ts
+++ b/source/entries.d.ts
@@ -49,7 +49,10 @@ const setExample = new Set(['a', 1]);
 const setEntries: Entries<typeof setExample> = [['a', 'a'], [1, 1]];
 ```
 
-@category Utilities
+@category Objects
+@category Maps
+@category Sets
+@category Arrays
 */
 export type Entries<BaseType> =
 	BaseType extends Map<unknown, unknown> ? MapEntries<BaseType>

--- a/source/entries.d.ts
+++ b/source/entries.d.ts
@@ -49,10 +49,10 @@ const setExample = new Set(['a', 1]);
 const setEntries: Entries<typeof setExample> = [['a', 'a'], [1, 1]];
 ```
 
-@category Objects
-@category Maps
-@category Sets
-@category Arrays
+@category Object
+@category Map
+@category Set
+@category Array
 */
 export type Entries<BaseType> =
 	BaseType extends Map<unknown, unknown> ? MapEntries<BaseType>

--- a/source/entry.d.ts
+++ b/source/entry.d.ts
@@ -52,10 +52,10 @@ const setEntryString: Entry<typeof setExample> = ['a', 'a'];
 const setEntryNumber: Entry<typeof setExample> = [1, 1];
 ```
 
-@category Objects
-@category Maps
-@category Arrays
-@category Sets
+@category Object
+@category Map
+@category Array
+@category Set
 */
 export type Entry<BaseType> =
 	BaseType extends Map<unknown, unknown> ? MapEntry<BaseType>

--- a/source/entry.d.ts
+++ b/source/entry.d.ts
@@ -52,7 +52,10 @@ const setEntryString: Entry<typeof setExample> = ['a', 'a'];
 const setEntryNumber: Entry<typeof setExample> = [1, 1];
 ```
 
-@category Utilities
+@category Objects
+@category Maps
+@category Arrays
+@category Sets
 */
 export type Entry<BaseType> =
 	BaseType extends Map<unknown, unknown> ? MapEntry<BaseType>

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -50,7 +50,7 @@ type FooWithoutA = Except<Foo, 'a' | 'c'>;
 //=> {b: string};
 ```
 
-@category Objects
+@category Object
 */
 export type Except<ObjectType, KeysType extends keyof ObjectType> = {
 	[KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -50,7 +50,7 @@ type FooWithoutA = Except<Foo, 'a' | 'c'>;
 //=> {b: string};
 ```
 
-@category Utilities
+@category Objects
 */
 export type Except<ObjectType, KeysType extends keyof ObjectType> = {
 	[KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -28,7 +28,7 @@ guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
 ```
 
-@category Utilities
+@category Arrays
 */
 export type FixedLengthArray<Element, Length extends number, ArrayPrototype = [Element, ...Element[]]> = Pick<
 	ArrayPrototype,

--- a/source/fixed-length-array.d.ts
+++ b/source/fixed-length-array.d.ts
@@ -28,7 +28,7 @@ guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
 ```
 
-@category Arrays
+@category Array
 */
 export type FixedLengthArray<Element, Length extends number, ArrayPrototype = [Element, ...Element[]]> = Pick<
 	ArrayPrototype,

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -130,8 +130,8 @@ const getName = (apiResponse: ApiResponse) =>
 	//=> Array<{given: string[]; family: string}>
 ```
 
-@category Template literals
-@category Objects
-@category Arrays
+@category Template literal
+@category Object
+@category Array
 */
 export type Get<BaseType, Path extends string> = GetWithPath<BaseType, ToPath<Path>>;

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -130,7 +130,7 @@ const getName = (apiResponse: ApiResponse) =>
 	//=> Array<{given: string[]; family: string}>
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 @category Arrays
 */

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -131,5 +131,7 @@ const getName = (apiResponse: ApiResponse) =>
 ```
 
 @category Template Literals
+@category Objects
+@category Arrays
 */
 export type Get<BaseType, Path extends string> = GetWithPath<BaseType, ToPath<Path>>;

--- a/source/includes.d.ts
+++ b/source/includes.d.ts
@@ -12,7 +12,7 @@ import {Includes} from 'type-fest';
 type hasRed<array extends any[]> = Includes<array, 'red'>;
 ```
 
-@category Utilities
+@category Arrays
 */
 export type Includes<Value extends readonly any[], Item> =
 	IsEqual<Value[0], Item> extends true

--- a/source/includes.d.ts
+++ b/source/includes.d.ts
@@ -12,7 +12,7 @@ import {Includes} from 'type-fest';
 type hasRed<array extends any[]> = Includes<array, 'red'>;
 ```
 
-@category Arrays
+@category Array
 */
 export type Includes<Value extends readonly any[], Item> =
 	IsEqual<Value[0], Item> extends true

--- a/source/iterable-element.d.ts
+++ b/source/iterable-element.d.ts
@@ -38,7 +38,7 @@ An example with an array of strings:
 type MeString = IterableElement<string[]>
 ```
 
-@category Utilities
+@category Iterables
 */
 export type IterableElement<TargetIterable> =
 	TargetIterable extends Iterable<infer ElementType> ?

--- a/source/iterable-element.d.ts
+++ b/source/iterable-element.d.ts
@@ -38,7 +38,7 @@ An example with an array of strings:
 type MeString = IterableElement<string[]>
 ```
 
-@category Iterables
+@category Iterable
 */
 export type IterableElement<TargetIterable> =
 	TargetIterable extends Iterable<infer ElementType> ?

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -17,7 +17,7 @@ const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
 const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type Join<
 	Strings extends Array<string | number>,

--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -17,7 +17,7 @@ const path: Join<['foo', 'bar', 'baz'], '.'> = ['foo', 'bar', 'baz'].join('.');
 const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 ```
 
-@category Template literals
+@category Template literal
 */
 export type Join<
 	Strings extends Array<string | number>,

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -54,7 +54,7 @@ const timeJson = JSON.parse(JSON.stringify(time)) as Jsonify<typeof time>;
 
 @link https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173
 
-@category Utilities
+@category JSON
 */
 type Jsonify<T> =
 	// Check if there are any non-JSONable types represented in the union.

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -32,6 +32,6 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type KebabCase<Value> = DelimiterCase<Value, '-'>;

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -32,6 +32,7 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 };
 ```
 
+@category Change case
 @category Template literal
 */
 export type KebabCase<Value> = DelimiterCase<Value, '-'>;

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -32,6 +32,6 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 };
 ```
 
-@category Template literals
+@category Template literal
 */
 export type KebabCase<Value> = DelimiterCase<Value, '-'>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type KebabCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '-'>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type KebabCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '-'>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -39,5 +39,6 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type KebabCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '-'>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -38,6 +38,7 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: KebabCasedProperties<User> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type KebabCasedProperties<Value> = DelimiterCasedProperties<Value, '-'>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -21,6 +21,7 @@ const result: KebabCasedProperties<User> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: KebabCasedProperties<User> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type KebabCasedProperties<Value> = DelimiterCasedProperties<Value, '-'>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -22,5 +22,6 @@ const result: KebabCasedProperties<User> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type KebabCasedProperties<Value> = DelimiterCasedProperties<Value, '-'>;

--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -15,7 +15,7 @@ typeof lastOf(array);
 //=> number
 ```
 
-@category Template Literals
+@category Template literals
 @category Arrays
 */
 export type LastArrayElement<ValueType extends readonly unknown[]> =

--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -15,8 +15,8 @@ typeof lastOf(array);
 //=> number
 ```
 
-@category Template literals
-@category Arrays
+@category Template literal
+@category Array
 */
 export type LastArrayElement<ValueType extends readonly unknown[]> =
 	ValueType extends readonly [infer ElementType]

--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -16,6 +16,7 @@ typeof lastOf(array);
 ```
 
 @category Template Literals
+@category Arrays
 */
 export type LastArrayElement<ValueType extends readonly unknown[]> =
 	ValueType extends readonly [infer ElementType]

--- a/source/literal-union.d.ts
+++ b/source/literal-union.d.ts
@@ -27,7 +27,7 @@ const pet: Pet2 = '';
 // You **will** get auto-completion for `dog` and `cat` literals.
 ```
 
-@category Types
+@category Type
  */
 export type LiteralUnion<
 	LiteralType,

--- a/source/literal-union.d.ts
+++ b/source/literal-union.d.ts
@@ -27,7 +27,7 @@ const pet: Pet2 = '';
 // You **will** get auto-completion for `dog` and `cat` literals.
 ```
 
-@category Utilities
+@category Types
  */
 export type LiteralUnion<
 	LiteralType,

--- a/source/merge-exclusive.d.ts
+++ b/source/merge-exclusive.d.ts
@@ -32,7 +32,7 @@ exclusiveOptions = {exclusive1: true, exclusive2: 'hi'};
 //=> Error
 ```
 
-@category Utilities
+@category Objects
 */
 export type MergeExclusive<FirstType, SecondType> =
 	(FirstType | SecondType) extends object ?

--- a/source/merge-exclusive.d.ts
+++ b/source/merge-exclusive.d.ts
@@ -32,7 +32,7 @@ exclusiveOptions = {exclusive1: true, exclusive2: 'hi'};
 //=> Error
 ```
 
-@category Objects
+@category Object
 */
 export type MergeExclusive<FirstType, SecondType> =
 	(FirstType | SecondType) extends object ?

--- a/source/merge.d.ts
+++ b/source/merge.d.ts
@@ -22,6 +22,6 @@ type Bar = {
 const ab: Merge<Foo, Bar> = {a: 1, b: 2};
 ```
 
-@category Utilities
+@category Objects
 */
 export type Merge<FirstType, SecondType> = Simplify<Merge_<FirstType, SecondType>>;

--- a/source/merge.d.ts
+++ b/source/merge.d.ts
@@ -22,6 +22,6 @@ type Bar = {
 const ab: Merge<Foo, Bar> = {a: 1, b: 2};
 ```
 
-@category Objects
+@category Object
 */
 export type Merge<FirstType, SecondType> = Simplify<Merge_<FirstType, SecondType>>;

--- a/source/multidimensional-array.d.ts
+++ b/source/multidimensional-array.d.ts
@@ -34,7 +34,7 @@ const matrix = emptyMatrix(3);
 matrix[0][0][0] = 42;
 ```
 
-@category Arrays
+@category Array
 */
 export type MultidimensionalArray<Element, Dimensions extends number> = number extends Dimensions
 	? Recursive<Element>

--- a/source/multidimensional-array.d.ts
+++ b/source/multidimensional-array.d.ts
@@ -34,7 +34,7 @@ const matrix = emptyMatrix(3);
 matrix[0][0][0] = 42;
 ```
 
-@category Utilities
+@category Arrays
 */
 export type MultidimensionalArray<Element, Dimensions extends number> = number extends Dimensions
 	? Recursive<Element>

--- a/source/multidimensional-readonly-array.d.ts
+++ b/source/multidimensional-readonly-array.d.ts
@@ -38,7 +38,7 @@ const matrix = emptyMatrix(3);
 const answer = matrix[0][0][0]; // 42
 ```
 
-@category Arrays
+@category Array
 */
 export type MultidimensionalReadonlyArray<Element, Dimensions extends number> = number extends Dimensions
 	? Recursive<Element>

--- a/source/multidimensional-readonly-array.d.ts
+++ b/source/multidimensional-readonly-array.d.ts
@@ -38,7 +38,7 @@ const matrix = emptyMatrix(3);
 const answer = matrix[0][0][0]; // 42
 ```
 
-@category Utilities
+@category Arrays
 */
 export type MultidimensionalReadonlyArray<Element, Dimensions extends number> = number extends Dimensions
 	? Recursive<Element>

--- a/source/mutable.d.ts
+++ b/source/mutable.d.ts
@@ -29,7 +29,7 @@ type SomeMutable = Mutable<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Objects
+@category Object
 */
 export type Mutable<BaseType, Keys extends keyof BaseType = keyof BaseType> =
 	Simplify<

--- a/source/mutable.d.ts
+++ b/source/mutable.d.ts
@@ -29,7 +29,7 @@ type SomeMutable = Mutable<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Utilities
+@category Objects
 */
 export type Mutable<BaseType, Keys extends keyof BaseType = keyof BaseType> =
 	Simplify<

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -9,7 +9,7 @@ Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/32277)
 
 @see NegativeInfinity
 
-@category Basic
+@category Numeric
 */
 // See https://github.com/microsoft/TypeScript/issues/31752
 // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
@@ -22,7 +22,7 @@ Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/32277)
 
 @see PositiveInfinity
 
-@category Basic
+@category Numeric
 */
 // See https://github.com/microsoft/TypeScript/issues/31752
 // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
@@ -41,7 +41,7 @@ import {Finite} from 'type-fest';
 declare function setScore<T extends number>(length: Finite<T>): void;
 ```
 
-@category Utilities
+@category Numeric
 */
 export type Finite<T extends number> = T extends PositiveInfinity | NegativeInfinity ? never : T;
 
@@ -61,7 +61,7 @@ declare function setYear<T extends number>(length: Integer<T>): void;
 @see NegativeInteger
 @see NonNegativeInteger
 
-@category Utilities
+@category Numeric
 */
 // `${bigint}` is a type that matches a valid bigint literal without the `n` (ex. 1, 0b1, 0o1, 0x1)
 // Because T is a number and not a string we can effectively use this to filter out any numbers containing decimal points
@@ -75,7 +75,7 @@ Use-case: Validating and documenting parameters.
 @see NegativeInteger
 @see NonNegative
 
-@category Utilities
+@category Numeric
 */
 export type Negative<T extends Numeric> = T extends Zero ? never : `${T}` extends `-${string}` ? T : never;
 
@@ -90,7 +90,7 @@ Use-case: Validating and documenting parameters.
 @see Negative
 @see Integer
 
-@category Utilities
+@category Numeric
 */
 export type NegativeInteger<T extends number> = Negative<Integer<T>>;
 
@@ -109,7 +109,7 @@ import {NonNegative} from 'type-fest';
 declare function setLength<T extends number>(length: NonNegative<T>): void;
 ```
 
-@category Utilities
+@category Numeric
 */
 export type NonNegative<T extends Numeric> = T extends Zero ? T : Negative<T> extends never ? T : never;
 
@@ -131,6 +131,6 @@ import {NonNegativeInteger} from 'type-fest';
 declare function setLength<T extends number>(length: NonNegativeInteger<T>): void;
 ```
 
-@category Utilities
+@category Numeric
 */
 export type NonNegativeInteger<T extends number> = NonNegative<Integer<T>>;

--- a/source/observable-like.d.ts
+++ b/source/observable-like.d.ts
@@ -11,15 +11,29 @@ As well, some guideance on making an `Observable` do not include `closed` proper
 @see https://github.com/tc39/proposal-observable/blob/master/src/Observable.js#L129-L130
 @see https://github.com/staltz/xstream/blob/6c22580c1d84d69773ee4b0905df44ad464955b3/src/index.ts#L79-L85
 @see https://github.com/benlesh/symbol-observable#making-an-object-observable
+
+@category Observables
 */
 export type Unsubscribable = {
 	unsubscribe(): void;
 };
 
+/**
+@category Observables
+*/
 type OnNext<ValueType> = (value: ValueType) => void;
+/**
+@category Observables
+*/
 type OnError = (error: unknown) => void;
+/**
+@category Observables
+*/
 type OnComplete = () => void;
 
+/**
+@category Observables
+*/
 export type Observer<ValueType> = {
 	next: OnNext<ValueType>;
 	error: OnError;
@@ -40,7 +54,7 @@ But `Observable` implementations have evolved to preferring case 2 and some impl
 @see https://github.com/tc39/proposal-observable/blob/master/src/Observable.js#L246-L259
 @see https://benlesh.com/posts/learning-observable-by-building-observable/
 
-@category Basic
+@category Observables
 */
 export interface ObservableLike<ValueType = unknown> {
 	subscribe(observer?: Partial<Observer<ValueType>>): Unsubscribable;

--- a/source/observable-like.d.ts
+++ b/source/observable-like.d.ts
@@ -12,27 +12,27 @@ As well, some guideance on making an `Observable` do not include `closed` proper
 @see https://github.com/staltz/xstream/blob/6c22580c1d84d69773ee4b0905df44ad464955b3/src/index.ts#L79-L85
 @see https://github.com/benlesh/symbol-observable#making-an-object-observable
 
-@category Observables
+@category Observable
 */
 export type Unsubscribable = {
 	unsubscribe(): void;
 };
 
 /**
-@category Observables
+@category Observable
 */
 type OnNext<ValueType> = (value: ValueType) => void;
 /**
-@category Observables
+@category Observable
 */
 type OnError = (error: unknown) => void;
 /**
-@category Observables
+@category Observable
 */
 type OnComplete = () => void;
 
 /**
-@category Observables
+@category Observable
 */
 export type Observer<ValueType> = {
 	next: OnNext<ValueType>;
@@ -54,7 +54,7 @@ But `Observable` implementations have evolved to preferring case 2 and some impl
 @see https://github.com/tc39/proposal-observable/blob/master/src/Observable.js#L246-L259
 @see https://benlesh.com/posts/learning-observable-by-building-observable/
 
-@category Observables
+@category Observable
 */
 export interface ObservableLike<ValueType = unknown> {
 	subscribe(observer?: Partial<Observer<ValueType>>): Unsubscribable;

--- a/source/opaque.d.ts
+++ b/source/opaque.d.ts
@@ -69,6 +69,6 @@ type Person = {
 };
 ```
 
-@category Utilities
+@category Types
 */
 export type Opaque<Type, Token = unknown> = Type & Tagged<Token>;

--- a/source/opaque.d.ts
+++ b/source/opaque.d.ts
@@ -69,6 +69,6 @@ type Person = {
 };
 ```
 
-@category Types
+@category Type
 */
 export type Opaque<Type, Token = unknown> = Type & Tagged<Token>;

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -635,7 +635,7 @@ declare namespace PackageJson {
 /**
 Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Also includes types for fields used by other popular projects, like TypeScript and Yarn.
 
-@category Files
+@category File
 */
 export type PackageJson =
 PackageJson.PackageJsonStandard &

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -635,7 +635,7 @@ declare namespace PackageJson {
 /**
 Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). Also includes types for fields used by other popular projects, like TypeScript and Yarn.
 
-@category Miscellaneous
+@category Files
 */
 export type PackageJson =
 PackageJson.PackageJsonStandard &

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -28,7 +28,10 @@ const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
 settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```
 
-@category Utilities
+@category Objects
+@category Arrays
+@category Sets
+@category Maps
 */
 export type PartialDeep<T> = T extends Primitive
 	? Partial<T>

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -28,10 +28,10 @@ const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
 settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```
 
-@category Objects
-@category Arrays
-@category Sets
-@category Maps
+@category Object
+@category Array
+@category Set
+@category Map
 */
 export type PartialDeep<T> = T extends Primitive
 	? Partial<T>

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -30,6 +30,7 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 };
 ```
 
+@category Change case
 @category Template literal
 */
 export type PascalCase<Value> = CamelCase<Value> extends string

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -30,7 +30,7 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 };
 ```
 
-@category Template literals
+@category Template literal
 */
 export type PascalCase<Value> = CamelCase<Value> extends string
 	? Capitalize<CamelCase<Value>>

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -30,7 +30,7 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type PascalCase<Value> = CamelCase<Value> extends string
 	? Capitalize<CamelCase<Value>>

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -39,6 +39,7 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type PascalCasedPropertiesDeep<Value> = Value extends Function
 	? Value

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -38,6 +38,7 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type PascalCasedPropertiesDeep<Value> = Value extends Function

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -38,8 +38,8 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type PascalCasedPropertiesDeep<Value> = Value extends Function
 	? Value

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -22,6 +22,7 @@ const result: PascalCasedProperties<User> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type PascalCasedProperties<Value> = Value extends Function
 	? Value

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -21,6 +21,7 @@ const result: PascalCasedProperties<User> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: PascalCasedProperties<User> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type PascalCasedProperties<Value> = Value extends Function

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -21,8 +21,8 @@ const result: PascalCasedProperties<User> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type PascalCasedProperties<Value> = Value extends Function
 	? Value

--- a/source/primitive.d.ts
+++ b/source/primitive.d.ts
@@ -1,7 +1,7 @@
 /**
 Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
 
-@category Basic
+@category Types
 */
 export type Primitive =
 	| null

--- a/source/primitive.d.ts
+++ b/source/primitive.d.ts
@@ -1,7 +1,7 @@
 /**
 Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
 
-@category Types
+@category Type
 */
 export type Primitive =
 	| null

--- a/source/promisable.d.ts
+++ b/source/promisable.d.ts
@@ -18,8 +18,8 @@ async function logger(getLogEntry: () => Promisable<string>): Promise<void> {
 
 logger(() => 'foo');
 logger(() => Promise.resolve('bar'));
-
-@category Utilities
 ```
+
+@category Async
 */
 export type Promisable<T> = T | PromiseLike<T>;

--- a/source/promise-value.d.ts
+++ b/source/promise-value.d.ts
@@ -24,6 +24,6 @@ type RecursiveAsyncData = Promise<Promise<string> >;
 let recursiveAsyncData: PromiseValue<RecursiveAsyncData> = Promise.resolve(Promise.resolve('ABC'));
 ```
 
-@category Utilities
+@category Async
 */
 export type PromiseValue<PromiseType> = PromiseType extends PromiseLike<infer Value> ? PromiseValue<Value> : PromiseType;

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -29,7 +29,10 @@ data.foo.push('bar');
 //=> error TS2339: Property 'push' does not exist on type 'readonly string[]'
 ```
 
-@category Utilities
+@category Objects
+@category Arrays
+@category Sets
+@category Maps
 */
 export type ReadonlyDeep<T> = T extends Primitive | ((...arguments: any[]) => unknown)
 	? T

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -29,10 +29,10 @@ data.foo.push('bar');
 //=> error TS2339: Property 'push' does not exist on type 'readonly string[]'
 ```
 
-@category Objects
-@category Arrays
-@category Sets
-@category Maps
+@category Object
+@category Array
+@category Set
+@category Map
 */
 export type ReadonlyDeep<T> = T extends Primitive | ((...arguments: any[]) => unknown)
 	? T

--- a/source/require-all-or-none.d.ts
+++ b/source/require-all-or-none.d.ts
@@ -27,7 +27,7 @@ const responder2: RequireAllOrNone<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Utilities
+@category Objects
 */
 export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = never> = (
 	| Required<Pick<ObjectType, KeysType>> // Require all of the given keys.

--- a/source/require-all-or-none.d.ts
+++ b/source/require-all-or-none.d.ts
@@ -27,7 +27,7 @@ const responder2: RequireAllOrNone<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Objects
+@category Object
 */
 export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = never> = (
 	| Required<Pick<ObjectType, KeysType>> // Require all of the given keys.

--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -20,7 +20,7 @@ const responder: RequireAtLeastOne<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Objects
+@category Object
 */
 export type RequireAtLeastOne<
 	ObjectType,

--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -20,7 +20,7 @@ const responder: RequireAtLeastOne<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Utilities
+@category Objects
 */
 export type RequireAtLeastOne<
 	ObjectType,

--- a/source/require-exactly-one.d.ts
+++ b/source/require-exactly-one.d.ts
@@ -25,7 +25,7 @@ const responder: RequireExactlyOne<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Objects
+@category Object
 */
 export type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
 	{[Key in KeysType]: (

--- a/source/require-exactly-one.d.ts
+++ b/source/require-exactly-one.d.ts
@@ -25,7 +25,7 @@ const responder: RequireExactlyOne<Responder, 'text' | 'json'> = {
 };
 ```
 
-@category Utilities
+@category Objects
 */
 export type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
 	{[Key in KeysType]: (

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -23,7 +23,7 @@ import {ScreamingSnakeCase} from 'type-fest';
 const someVariable: ScreamingSnakeCase<'fooBar'> = 'FOO_BAR';
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type ScreamingSnakeCase<Value> = Value extends string
 	? IsScreamingSnakeCase<Value> extends true

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -23,6 +23,7 @@ import {ScreamingSnakeCase} from 'type-fest';
 const someVariable: ScreamingSnakeCase<'fooBar'> = 'FOO_BAR';
 ```
 
+@category Change case
 @category Template literal
 */
 export type ScreamingSnakeCase<Value> = Value extends string

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -23,7 +23,7 @@ import {ScreamingSnakeCase} from 'type-fest';
 const someVariable: ScreamingSnakeCase<'fooBar'> = 'FOO_BAR';
 ```
 
-@category Template literals
+@category Template literal
 */
 export type ScreamingSnakeCase<Value> = Value extends string
 	? IsScreamingSnakeCase<Value> extends true

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -24,7 +24,7 @@ type SomeOptional = SetOptional<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Objects
+@category Object
 */
 export type SetOptional<BaseType, Keys extends keyof BaseType> =
 	Simplify<

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -24,7 +24,7 @@ type SomeOptional = SetOptional<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Utilities
+@category Objects
 */
 export type SetOptional<BaseType, Keys extends keyof BaseType> =
 	Simplify<

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -24,7 +24,7 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Utilities
+@category Objects
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType> =
 	Simplify<

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -24,7 +24,7 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 // }
 ```
 
-@category Objects
+@category Object
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType> =
 	Simplify<

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -17,7 +17,7 @@ type MyWrappedFunction = SetReturnType<MyFunctionThatCanThrow, SomeOtherType | u
 //=> type MyWrappedFunction = (foo: SomeType, bar: unknown) => SomeOtherType | undefined;
 ```
 
-@category Utilities
+@category Functions
 */
 export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =
 	// Just using `Parameters<Fn>` isn't ideal because it doesn't handle the `this` fake parameter.

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -17,7 +17,7 @@ type MyWrappedFunction = SetReturnType<MyFunctionThatCanThrow, SomeOtherType | u
 //=> type MyWrappedFunction = (foo: SomeType, bar: unknown) => SomeOtherType | undefined;
 ```
 
-@category Functions
+@category Function
 */
 export type SetReturnType<Fn extends (...args: any[]) => any, TypeToReturn> =
 	// Just using `Parameters<Fn>` isn't ideal because it doesn't handle the `this` fake parameter.

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -53,6 +53,6 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @link https://github.com/microsoft/TypeScript/issues/15300
 
-@category Objects
+@category Object
 */
 export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]};

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -53,6 +53,6 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @link https://github.com/microsoft/TypeScript/issues/15300
 
-@category Utilities
+@category Objects
 */
 export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]};

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -32,6 +32,6 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 };
 ```
 
-@category Template literals
+@category Template literal
 */
 export type SnakeCase<Value> = DelimiterCase<Value, '_'>;

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -32,6 +32,6 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type SnakeCase<Value> = DelimiterCase<Value, '_'>;

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -32,6 +32,7 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 };
 ```
 
+@category Change case
 @category Template literal
 */
 export type SnakeCase<Value> = DelimiterCase<Value, '_'>;

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -38,6 +38,7 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -39,5 +39,6 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type SnakeCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '_'>;

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type SnakeCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '_'>;

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -38,7 +38,7 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type SnakeCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '_'>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -22,5 +22,6 @@ const result: SnakeCasedProperties<User> = {
 ```
 
 @category Template Literals
+@category Objects
 */
 export type SnakeCasedProperties<Value> = DelimiterCasedProperties<Value, '_'>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: SnakeCasedProperties<User> = {
 };
 ```
 
-@category Template Literals
+@category Template literals
 @category Objects
 */
 export type SnakeCasedProperties<Value> = DelimiterCasedProperties<Value, '_'>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -21,6 +21,7 @@ const result: SnakeCasedProperties<User> = {
 };
 ```
 
+@category Change case
 @category Template literal
 @category Object
 */

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -21,7 +21,7 @@ const result: SnakeCasedProperties<User> = {
 };
 ```
 
-@category Template literals
-@category Objects
+@category Template literal
+@category Object
 */
 export type SnakeCasedProperties<Value> = DelimiterCasedProperties<Value, '_'>;

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -16,7 +16,7 @@ let array: Item[];
 array = split(items, ',');
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type Split<
 	S extends string,

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -16,7 +16,7 @@ let array: Item[];
 array = split(items, ',');
 ```
 
-@category Template literals
+@category Template literal
 */
 export type Split<
 	S extends string,

--- a/source/stringified.d.ts
+++ b/source/stringified.d.ts
@@ -18,6 +18,6 @@ const carForm: Stringified<Car> = {
 };
 ```
 
-@category Utilities
+@category Objects
 */
 export type Stringified<ObjectType> = {[KeyType in keyof ObjectType]: string};

--- a/source/stringified.d.ts
+++ b/source/stringified.d.ts
@@ -18,6 +18,6 @@ const carForm: Stringified<Car> = {
 };
 ```
 
-@category Objects
+@category Object
 */
 export type Stringified<ObjectType> = {[KeyType in keyof ObjectType]: string};

--- a/source/trim.d.ts
+++ b/source/trim.d.ts
@@ -19,6 +19,6 @@ Trim<' foo '>
 //=> 'foo'
 ```
 
-@category Template Literals
+@category Template literals
 */
 export type Trim<V extends string> = TrimLeft<TrimRight<V>>;

--- a/source/trim.d.ts
+++ b/source/trim.d.ts
@@ -19,6 +19,6 @@ Trim<' foo '>
 //=> 'foo'
 ```
 
-@category Template literals
+@category Template literal
 */
 export type Trim<V extends string> = TrimLeft<TrimRight<V>>;

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -1040,7 +1040,7 @@ declare namespace TsConfigJson {
 /**
 Type for [TypeScript's `tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) (TypeScript 3.7).
 
-@category Miscellaneous
+@category Files
 */
 export interface TsConfigJson {
 	/**

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -1040,7 +1040,7 @@ declare namespace TsConfigJson {
 /**
 Type for [TypeScript's `tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) (TypeScript 3.7).
 
-@category Files
+@category File
 */
 export interface TsConfigJson {
 	/**

--- a/source/typed-array.d.ts
+++ b/source/typed-array.d.ts
@@ -1,7 +1,7 @@
 /**
 Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
 
-@category Arrays
+@category Array
 */
 export type TypedArray =
 	| Int8Array

--- a/source/typed-array.d.ts
+++ b/source/typed-array.d.ts
@@ -1,7 +1,7 @@
 /**
 Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
 
-@category Basic
+@category Arrays
 */
 export type TypedArray =
 	| Int8Array

--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -41,7 +41,7 @@ type Intersection = UnionToIntersection<Union>;
 //=> {a1(): void; b1(): void; a2(argA: string): void; b2(argB: string): void}
 ```
 
-@category Types
+@category Type
 */
 export type UnionToIntersection<Union> = (
 	// `extends unknown` is always going to be the case and is used to convert the

--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -41,7 +41,7 @@ type Intersection = UnionToIntersection<Union>;
 //=> {a1(): void; b1(): void; a2(argA: string): void; b2(argB: string): void}
 ```
 
-@category Utilities
+@category Types
 */
 export type UnionToIntersection<Union> = (
 	// `extends unknown` is always going to be the case and is used to convert the

--- a/source/value-of.d.ts
+++ b/source/value-of.d.ts
@@ -37,6 +37,6 @@ onlyBar('bar');
 //=> 2
 ```
 
-@category Objects
+@category Object
 */
 export type ValueOf<ObjectType, ValueType extends keyof ObjectType = keyof ObjectType> = ObjectType[ValueType];

--- a/source/value-of.d.ts
+++ b/source/value-of.d.ts
@@ -37,6 +37,6 @@ onlyBar('bar');
 //=> 2
 ```
 
-@category Utilities
+@category Objects
 */
 export type ValueOf<ObjectType, ValueType extends keyof ObjectType = keyof ObjectType> = ObjectType[ValueType];


### PR DESCRIPTION
Nearly every type was `@category Utilities`, not very helpful.

This PR changes all types to have one or more of the following categories:
- Objects
- Classes
- Maps
- Sets
- Arrays
- Async
- Functions
- Types
- JSON
- Numeric
- Observables

<details>
  <summary>TypeDoc output before:</summary>

  ![typedoc_before](https://user-images.githubusercontent.com/7608555/144145256-5c6910cc-017f-46ad-9e17-982f5cdeab43.png)
</details>

<details>
  <summary>TypeDoc output after:</summary>

  ![typedoc_after](https://user-images.githubusercontent.com/7608555/144145275-7fb724c2-d337-4899-932d-5fc233de7d30.png)
</details>

AFAIK Paka does not support multiple `@category` comments, it just uses the first one it sees.
Because Paka is closed source the only way to test this PR would be to publish this to npm and see what Paka renders.