### PR TITLE
`LiteralUnion`: Replace _ key with empty Record

### DIFF
--- a/source/literal-union.d.ts
+++ b/source/literal-union.d.ts
@@ -32,4 +32,4 @@ const pet: Pet2 = '';
 export type LiteralUnion<
 	LiteralType,
 	BaseType extends Primitive,
-> = LiteralType | (BaseType & {_?: never});
+> = LiteralType | (BaseType & Record<never, never>);


### PR DESCRIPTION
I think it's cleaner, I feel a bit uncomfortable defining a key for nothing. It's subjective though.