### PR TITLE
Add `RemoveIndexSignature` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export {MergeExclusive} from './source/merge-exclusive';
 export {RequireAtLeastOne} from './source/require-at-least-one';
 export {RequireExactlyOne} from './source/require-exactly-one';
 export {RequireAllOrNone} from './source/require-all-or-none';
+export {RemoveIndexSignature} from './source/remove-index-signature';
 export {PartialDeep} from './source/partial-deep';
 export {ReadonlyDeep} from './source/readonly-deep';
 export {LiteralUnion} from './source/literal-union';

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ Click the type names for complete docs.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given keys.
 - [`RequireExactlyOne`](source/require-exactly-one.d.ts) - Create a type that requires exactly a single key of the given keys and disallows more.
 - [`RequireAllOrNone`](source/require-all-or-none.d.ts) - Create a type that requires all of the given keys or none of the given keys.
+- [`RemoveIndexSignature`](source/remove-index-signature.d.ts) - Create a type that only has explicitly defined properties, absent of any index signatures.
 - [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type. Use [`Partial<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype) if you only need one level deep.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of an `object`/`Map`/`Set`/`Array` type. Use [`Readonly<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype) if you only need one level deep.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).

--- a/source/remove-index-signature.d.ts
+++ b/source/remove-index-signature.d.ts
@@ -1,23 +1,23 @@
 /**
-Removes any index signatures from a given object type, so that only explicitly defined properties remain.
+Remove any index signatures from the given object type, so that only explicitly defined properties remain.
 
 Use-cases:
 - Remove overly permissive signatures from third-party types.
 
 This type was taken from this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747).
 
-It relies on the fact, that an empty object (`{}`) is assignable to an object with just an index signature, like `Record<string, unknown>`, but not to an object with explicitly defined keys, like `Record<'foo' | 'bar', unknown>`.
+It relies on the fact that an empty object (`{}`) is assignable to an object with just an index signature, like `Record<string, unknown>`, but not to an object with explicitly defined keys, like `Record<'foo' | 'bar', unknown>`.
 
 (The actual value type, `unknown`, is irrelevant and could be any type. Only the key type matters.)
 
 ```
-const indexed: Record<string, unknown> = {}; // Allowed.
+const indexed: Record<string, unknown> = {}; // Allowed
 
-const keyed: Record<'foo', unknown> = {}; // Error.
+const keyed: Record<'foo', unknown> = {}; // Error
 // => TS2739: Type '{}' is missing the following properties from type 'Record<"foo" | "bar", unknown>': foo, bar
 ```
 
-Instead of causing a type error like above you can also use a [conditional type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) to test whether a type is assignable to another:
+Instead of causing a type error like the above, you can also use a [conditional type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) to test whether a type is assignable to another:
 
 ```
 type Indexed = {} extends Record<string, unknown>
@@ -31,7 +31,7 @@ type Keyed = {} extends Record<'foo' | 'bar', unknown>
 // => "❌ `{}` is NOT assignable to `Record<'foo' | 'bar', unknown>`"
 ```
 
-Using a [mapped type](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#further-exploration) you can then check for each `KeyType` of `ObjectType`...
+Using a [mapped type](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#further-exploration), you can then check for each `KeyType` of `ObjectType`...
 
 ```
 type RemoveIndexSignature<ObjectType> = {

--- a/source/remove-index-signature.d.ts
+++ b/source/remove-index-signature.d.ts
@@ -1,0 +1,98 @@
+/**
+Removes any index signatures from a given object type, so that only explicitly defined properties remain.
+
+Use-cases:
+- Remove overly permissive signatures from third-party types.
+
+This type was taken from this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747).
+
+It relies on the fact, that an empty object (`{}`) is assignable to an object with just an index signature, like `Record<string, unknown>`, but not to an object with explicitly defined keys, like `Record<'foo' | 'bar', unknown>`.
+
+(The actual value type, `unknown`, is irrelevant and could be any type. Only the key type matters.)
+
+```
+const indexed: Record<string, unknown> = {}; // Allowed.
+
+const keyed: Record<'foo', unknown> = {}; // Error.
+// => TS2739: Type '{}' is missing the following properties from type 'Record<"foo" | "bar", unknown>': foo, bar
+```
+
+Instead of causing a type error like above you can also use a [conditional type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) to test whether a type is assignable to another:
+
+```
+type Indexed = {} extends Record<string, unknown>
+	? '✅ `{}` is assignable to `Record<string, unknown>`'
+	: '❌ `{}` is NOT assignable to `Record<string, unknown>`';
+// => '✅ `{}` is assignable to `Record<string, unknown>`'
+
+type Keyed = {} extends Record<'foo' | 'bar', unknown>
+	? "✅ `{}` is assignable to `Record<'foo' | 'bar', unknown>`"
+	: "❌ `{}` is NOT assignable to `Record<'foo' | 'bar', unknown>`";
+// => "❌ `{}` is NOT assignable to `Record<'foo' | 'bar', unknown>`"
+```
+
+Using a [mapped type](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#further-exploration) you can then check for each `KeyType` of `ObjectType`...
+
+```
+type RemoveIndexSignature<ObjectType> = {
+	[KeyType in keyof ObjectType // Map each key of `ObjectType`...
+  ]: ObjectType[KeyType]; // ...to its original value, i.e. `RemoveIndexSignature<Foo> == Foo`.
+};
+```
+
+...whether an empty object (`{}`) would be assignable to an object with that `KeyType` (`Record<KeyType, unknown>`)...
+
+```
+type RemoveIndexSignature<ObjectType> = {
+	[KeyType in keyof ObjectType
+		// Is `{}` assignable to `Record<KeyType, unknown>`?
+		as {} extends Record<KeyType, unknown>
+			? ... // ✅ `{}` is assignable to `Record<KeyType, unknown>`
+			: ... // ❌ `{}` is NOT assignable to `Record<KeyType, unknown>`
+	]: ObjectType[KeyType];
+};
+```
+
+If `{}` is assignable, it means that `KeyType` is an index signature and we want to remove it. If it is not assignable, `KeyType` is a "real" key and we want to keep it.
+
+```
+type RemoveIndexSignature<ObjectType> = {
+	[KeyType in keyof ObjectType
+		as {} extends Record<KeyType, unknown>
+			? never // => Remove this `KeyType`.
+			: KeyType // => Keep this `KeyType` as it is.
+	]: ObjectType[KeyType];
+};
+```
+
+@example
+```
+import {RemoveIndexSignature} from 'type-fest';
+
+interface Example {
+	// These index signatures will be removed.
+	[x: string]: any
+	[x: number]: any
+	[x: symbol]: any
+	[x: `head-${string}`]: string
+	[x: `${string}-tail`]: string
+	[x: `head-${string}-tail`]: string
+	[x: `${bigint}`]: string
+	[x: `embedded-${number}`]: string
+
+	// These explicitly defined keys will remain.
+	foo: 'bar';
+	qux?: 'baz';
+}
+
+type ExampleWithoutIndexSignatures = RemoveIndexSignature<Example>;
+// => { foo: 'bar'; qux?: 'baz' | undefined; }
+```
+
+@category Object
+*/
+export type RemoveIndexSignature<ObjectType> = {
+	[KeyType in keyof ObjectType as {} extends Record<KeyType, unknown>
+		? never
+		: KeyType]: ObjectType[KeyType];
+};

--- a/test-d/remove-index-signature.ts
+++ b/test-d/remove-index-signature.ts
@@ -1,0 +1,45 @@
+import {expectType} from 'tsd';
+import {RemoveIndexSignature} from '../index';
+
+interface ExampleInterface {
+	// These index signatures will be removed.
+	[x: string]: any;
+	[x: number]: any;
+
+	// Symbol and template string pattern index signatures are only available
+	// starting with TypeScript 4.4.
+	// https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#symbol-template-signatures
+	/*
+	[x: symbol]: any;
+	[x: `head-${string}`]: string;
+	[x: `${string}-tail`]: string;
+	[x: `head-${string}-tail`]: string;
+	[x: `${bigint}`]: string;
+	[x: `embedded-${number}`]: string;
+	*/
+
+	// These explicitly defined keys will remain.
+	foo: 'bar';
+	qux?: 'baz';
+}
+
+type MappedType<ObjectType> = {
+	[Key in keyof ObjectType]: {
+		key: Key;
+		value: Exclude<ObjectType[Key], undefined>;
+	};
+};
+
+declare const exampleInterfaceKnownKeys: RemoveIndexSignature<ExampleInterface>;
+expectType<{
+	foo: 'bar';
+	qux?: 'baz';
+}>(exampleInterfaceKnownKeys);
+
+declare const exampleMappedTypeKnownKeys: RemoveIndexSignature<
+	MappedType<ExampleInterface>
+>;
+expectType<{
+	foo: {key: 'foo'; value: 'bar'};
+	qux?: {key: 'qux'; value: 'baz'};
+}>(exampleMappedTypeKnownKeys);


### PR DESCRIPTION
## `RemoveIndex<ObjectType>`

Removes any index signatures from a given `ObjectType`, so that only explicitly defined properties remain.

```ts
import {RemoveIndex} from 'type-fest';

type Example = RemoveIndex<{
  // Will be removed.
  [x: string]: any;

  // These explicitly defined keys will remain.
  foo: 'bar';
  qux?: 'baz';
}>;
// => { foo: 'bar'; qux?: 'baz' | undefined; }
```

### Notes

#### Attribution 

This type was taken from this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747) by @gerrit0. There are alternative solutions, but his is concise and supports [symbol and template string pattern index signatures](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#symbol-template-signatures), which were added in TypeScript 4.4.

#### Explanation of Implementation

As per [`contributing.md`](https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md), I've expanded on his explanation in the DocBlock comment and tried to explain it step by step, including links to relevant documentation. I hope it's easy to understand and not to convoluted.

<details>
<summary>Rendered Docs</summary>

It relies on the fact, that an empty object (`{}`) is assignable to an object with just an index signature, like `Record<string, unknown>`, but not to an object with explicitly defined keys, like `Record<'foo' | 'bar', unknown>`.
(The actual value type, `unknown`, is irrelevant and could be any type. Only the key type matters.)

```ts
const indexed: Record<string, unknown> = {}; // Allowed.

const keyed: Record<'foo', unknown> = {}; // Error.
// => TS2739: Type '{}' is missing the following properties from type 'Record<"foo" | "bar", unknown>': foo, bar
```

Instead of causing a type error like above you can also use a [conditional type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) to test whether a type is assignable to another:

```ts
type Indexed = {} extends Record<string, unknown>
	? '✅ `{}` is assignable to `Record<string, unknown>`'
	: '❌ `{}` is NOT assignable to `Record<string, unknown>`';
// => '✅ `{}` is assignable to `Record<string, unknown>`'

type Keyed = {} extends Record<'foo' | 'bar', unknown>
	? "✅ `{}` is assignable to `Record<'foo' | 'bar', unknown>`"
	: "❌ `{}` is NOT assignable to `Record<'foo' | 'bar', unknown>`";
// => "❌ `{}` is NOT assignable to `Record<'foo' | 'bar', unknown>`"
```

Using a [mapped type](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#further-exploration) you can then check for each `KeyType` of `ObjectType`...

```ts
type RemoveIndex<ObjectType> = {
	[KeyType in keyof ObjectType // Map each key of `ObjectType`...
	]: ObjectType[KeyType]; // ...to its original value, i.e. `RemoveIndex<Foo> == Foo`.
};
```

...whether an empty object (`{}`) would be assignable to an object with that `KeyType` (`Record<KeyType, unknown>`)...

```ts
type RemoveIndex<ObjectType> = {
	[KeyType in keyof ObjectType
		// Is `{}` assignable to `Record<KeyType, unknown>`?
		as {} extends Record<KeyType, unknown>
			? ... // ✅ `{}` is assignable to `Record<KeyType, unknown>`
			: ... // ❌ `{}` is NOT assignable to `Record<KeyType, unknown>`
	]: ObjectType[KeyType];
};
```

If `{}` is assignable, it means that `KeyType` is an index signature and we want to remove it. If it is not assignable, `KeyType` is a "real" key and we want to keep it.

```ts
type RemoveIndex<ObjectType> = {
	[KeyType in keyof ObjectType
		as {} extends Record<KeyType, unknown>
			? never // => Remove this `KeyType`.
			: KeyType // => Keep this `KeyType` as it is.
	]: ObjectType[KeyType];
};
```

</details>

### Use-cases

- #### Remove overly permissive signatures from third-party types.

  For instance, [`capacitor`](https://github.com/ionic-team/capacitor) has a [`PluginRegistry`](https://github.com/ionic-team/capacitor/blob/2.5.0/core/src/core-plugin-definitions.ts#L3-L32) interface, that is [meant to be augmented](https://capacitorjs.com/docs/v2/plugins/workflow#implementing-a-new-function) with user-land plugins.

  It is the backing type for the global [`Plugins`](https://capacitorjs.com/docs/v2/apis#api-usage) object used to access plugins, like e.g. `Plugins.Accessibility`. Unfortunately it includes an extremely permissive [index signature](https://github.com/ionic-team/capacitor/blob/2.5.0/core/src/core-plugin-definitions.ts#L29-L31) for "convenience":

  ```ts
  export interface PluginRegistry {
    Accessibility: AccessibilityPlugin;
    // ...

    [pluginName: string]: {
      [prop: string]: any;
    };
  }
  ```

  This effectively removes the ability for TypeScript to detect typos, like `Plugins.A11y`, and reduces the overall type safety.

  Using the `RemoveIndex` type, users can create a strict alias of `Plugins`:

  ```ts
  import { Plugins as CapPlugins } from '@capacitor/core';

  export const Plugins: RemoveIndex<typeof CapPlugins> = CapPlugins;

  Plugins.A11y.speak({ ... });
  // => TS2339: Property 'A11y' does not exist on type 'RemoveIndex<{ ... }>'.
  ```

### Example

[Playground Link](https://www.typescriptlang.org/play?ts=4.4.4#code/JYOwLgpgTgZghgYwgAgKIA84FsAOAbCASXGniWQG8AoASAHo7kAVACwgGcVQATCdZdsADmIOGACuUDsgDuwPHmQAjFFKwB7AG4RuAOloBtdAC4BYKKCEBdU3BABPANyGTyEOKwqoN5HadVaBmQAZXtPdUU7bmRIXDwxFHZzS2QcMUgoEGQePgFhUQkpdll5SLx2dWVVCA1tPUDGVgh7XylkdRA8FrhNOHk4JQIzOCgwFLkwFmZ7HAhghAscMGQAFl01huQWMDAcdmMGXk1B9SF2XSxgBfUKmDBdBHUsOjAZjgXgJbo7EHVxEAQlgAtK9ZuwPksgSsoUCVGA4HQAMTsMJKCIgmr4BJAwQiMSSDguUwo8J4Hx+Zw0IymAAGbDg3CBABIKEkLCAhABfGk+NmWSnU5A0ll8jmckF9PA84nJDkC1x0iAM5ms2VciXyaVmdlCeW0llKYSgMDc3lqvVCmoqbi8Rks9yeaCmmU65ybJqcZB8fBXYBgLrIXgwUA6ZAAa2axTkCmQaj6IH0NBg6nUpgA5EoRmnKQBHcToAD86czAC9s1ROQFQSgAEo1LREEC8dAAHgA8koAFYQBBgJhvAB8yAAvJRDABpZr92bZLIR+zqGDIDvd3vTlBwYoUTle9CQJvFOuPKDcFuT+zrgA0yH+Yd+MhAA9oNALbgg2igz9M5-XPhXPb7N4DB-N4rGcTk3WrZA63YcQ8GWUc61qRtmxbDBsHwRsMjICAB2cIJkGQAA9AsgA)

```ts
import {RemoveIndex} from 'type-fest';

interface Example {
	// These index signatures will be removed.
	[x: string]: any;
	[x: number]: any;

	// Symbol and template string pattern index signatures will also be removed.
	// They are only available starting with TypeScript 4.4.
	// https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#symbol-template-signatures
	[x: symbol]: any;
	[x: `head-${string}`]: string;
	[x: `${string}-tail`]: string;
	[x: `head-${string}-tail`]: string;
	[x: `${bigint}`]: string;
	[x: `embedded-${number}`]: string;

	// These explicitly defined keys will remain.
	foo: 'bar';
	qux?: 'baz';

	// These explicitly defined keys will remain.
	foo: 'bar';
	qux?: 'baz';
}

type ExampleWithoutIndexSignatures = RemoveIndex<Example>;
// => { foo: 'bar'; qux?: 'baz' | undefined; }
```