### PR TITLE
`PartialDeep`: Ignore `Date` and `RegExp` types

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -33,55 +33,51 @@ settings = applySavedSettings({textEditor: {fontWeight: 500}});
 @category Set
 @category Map
 */
-export type PartialDeep<T, ExceptTypes = never> = T extends Primitive
-	? Partial<T>
-	: T extends ExceptTypes
+export type PartialDeep<T> = T extends BuiltIns
 	? T
 	: T extends Map<infer KeyType, infer ValueType>
-	? PartialMapDeep<KeyType, ValueType, ExceptTypes>
+	? PartialMapDeep<KeyType, ValueType>
 	: T extends Set<infer ItemType>
-	? PartialSetDeep<ItemType, ExceptTypes>
+	? PartialSetDeep<ItemType>
 	: T extends ReadonlyMap<infer KeyType, infer ValueType>
-	? PartialReadonlyMapDeep<KeyType, ValueType, ExceptTypes>
+	? PartialReadonlyMapDeep<KeyType, ValueType>
 	: T extends ReadonlySet<infer ItemType>
-	? PartialReadonlySetDeep<ItemType, ExceptTypes>
+	? PartialReadonlySetDeep<ItemType>
 	: T extends ((...arguments: any[]) => unknown)
 	? T | undefined
 	: T extends object
 	? T extends Array<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
 		? ItemType[] extends T // Test for arrays (non-tuples) specifically
-			? Array<PartialDeep<ItemType | undefined, ExceptTypes>> // Recreate relevant array type to prevent eager evaluation of circular reference
-			: PartialObjectDeep<T, ExceptTypes> // Tuples behave properly
-		: PartialObjectDeep<T, ExceptTypes>
+			? Array<PartialDeep<ItemType | undefined>> // Recreate relevant array type to prevent eager evaluation of circular reference
+			: PartialObjectDeep<T> // Tuples behave properly
+		: PartialObjectDeep<T>
 	: unknown;
+
+type BuiltIns = Primitive | Date | RegExp;
 
 /**
 Same as `PartialDeep`, but accepts only `Map`s and as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialMapDeep<KeyType, ValueType, ExceptTypes> extends Map<PartialDeep<KeyType, ExceptTypes>, PartialDeep<ValueType, ExceptTypes>> {}
+interface PartialMapDeep<KeyType, ValueType> extends Map<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
 
 /**
 Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialSetDeep<T, ExceptTypes> extends Set<PartialDeep<T, ExceptTypes>> {}
+interface PartialSetDeep<T> extends Set<PartialDeep<T>> {}
 
 /**
 Same as `PartialDeep`, but accepts only `ReadonlyMap`s as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialReadonlyMapDeep<KeyType, ValueType, ExceptTypes> extends ReadonlyMap<PartialDeep<KeyType, ExceptTypes>, PartialDeep<ValueType, ExceptTypes>> {}
+interface PartialReadonlyMapDeep<KeyType, ValueType> extends ReadonlyMap<PartialDeep<KeyType>, PartialDeep<ValueType>> {}
 
 /**
 Same as `PartialDeep`, but accepts only `ReadonlySet`s as inputs. Internal helper for `PartialDeep`.
 */
-interface PartialReadonlySetDeep<T, ExceptTypes> extends ReadonlySet<PartialDeep<T, ExceptTypes>> {}
+interface PartialReadonlySetDeep<T> extends ReadonlySet<PartialDeep<T>> {}
 
 /**
 Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialObjectDeep<ObjectType extends object, ExceptTypes> = {
-	[KeyType in keyof ObjectType]?: PartialDeep<ObjectType[KeyType], ExceptTypes>
+type PartialObjectDeep<ObjectType extends object> = {
+	[KeyType in keyof ObjectType]?: PartialDeep<ObjectType[KeyType]>
 };
-
-type AddSymbolToPrimitive<T> = T extends
-  {[Symbol.toPrimitive]: infer V} ?
-  {[Symbol.toPrimitive]: V} : {};

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -9,6 +9,7 @@ const foo = {
 		string: 'waldo',
 		number: 1,
 		boolean: false,
+		date: new Date(),
 		symbol: Symbol('test'),
 		null: null,
 		undefined: undefined, // eslint-disable-line object-shorthand
@@ -23,16 +24,17 @@ const foo = {
 	},
 };
 
-let partialDeepFoo: PartialDeep<typeof foo> = foo;
+let partialDeepFoo: PartialDeep<typeof foo, Date> = foo;
 
 expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
-const partialDeepBar: PartialDeep<typeof foo.bar> = foo.bar;
+const partialDeepBar: PartialDeep<typeof foo.bar, Date> = foo.bar;
 expectType<typeof partialDeepBar | undefined>(partialDeepFoo.bar);
 expectType<((_: string) => void) | undefined>(partialDeepFoo.bar!.function);
 expectAssignable<object | undefined>(partialDeepFoo.bar!.object);
 expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);
 expectType<boolean | undefined>(partialDeepFoo.bar!.boolean);
+expectType<Date | undefined>(partialDeepFoo.bar!.date);
 expectType<symbol | undefined>(partialDeepFoo.bar!.symbol);
 expectType<null | undefined>(partialDeepFoo.bar!.null);
 expectType<undefined>(partialDeepFoo.bar!.undefined);
@@ -47,7 +49,7 @@ expectType<readonly ['foo'?] | undefined>(partialDeepFoo.bar!.readonlyTuple);
 // Check for compiling with omitting partial keys
 partialDeepFoo = {baz: 'fred'};
 partialDeepFoo = {bar: {string: 'waldo'}};
-
+partialDeepFoo = {bar: {date: new Date()}};
 // Check that recursive array evalution isn't infinite depth
 type Recurse =
     | string

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -10,6 +10,7 @@ const foo = {
 		number: 1,
 		boolean: false,
 		date: new Date(),
+		regexp: new RegExp(/.*/),
 		symbol: Symbol('test'),
 		null: null,
 		undefined: undefined, // eslint-disable-line object-shorthand
@@ -24,10 +25,10 @@ const foo = {
 	},
 };
 
-let partialDeepFoo: PartialDeep<typeof foo, Date> = foo;
+let partialDeepFoo: PartialDeep<typeof foo> = foo;
 
 expectError(expectType<Partial<typeof foo>>(partialDeepFoo));
-const partialDeepBar: PartialDeep<typeof foo.bar, Date> = foo.bar;
+const partialDeepBar: PartialDeep<typeof foo.bar> = foo.bar;
 expectType<typeof partialDeepBar | undefined>(partialDeepFoo.bar);
 expectType<((_: string) => void) | undefined>(partialDeepFoo.bar!.function);
 expectAssignable<object | undefined>(partialDeepFoo.bar!.object);
@@ -35,6 +36,7 @@ expectType<string | undefined>(partialDeepFoo.bar!.string);
 expectType<number | undefined>(partialDeepFoo.bar!.number);
 expectType<boolean | undefined>(partialDeepFoo.bar!.boolean);
 expectType<Date | undefined>(partialDeepFoo.bar!.date);
+expectType<RegExp | undefined>(partialDeepFoo.bar!.regexp);
 expectType<symbol | undefined>(partialDeepFoo.bar!.symbol);
 expectType<null | undefined>(partialDeepFoo.bar!.null);
 expectType<undefined>(partialDeepFoo.bar!.undefined);


### PR DESCRIPTION
Addresses issue https://github.com/sindresorhus/type-fest/issues/207, using feedback/code from closed pr https://github.com/sindresorhus/type-fest/pull/208 as a starting point.

This pr adds an additional `ExceptTypes` argument to `PartialDeep`, allowing consumers to state that certain types like `Date` or perhaps custom types written by somebody else, should be treated as exceptions.

Super excited to contribute and open to whatever feedback. Glad to help.
