### PR TITLE
Skip `Date` and `RegExp` in "deep" types

### DIFF
--- a/source/built-ins.d.ts
+++ b/source/built-ins.d.ts
@@ -1,0 +1,7 @@
+import {Primitive} from './primitive';
+/**
+Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
+
+@category Type
+*/
+export type BuiltIns = Primitive | Date | RegExp;

--- a/source/built-ins.d.ts
+++ b/source/built-ins.d.ts
@@ -1,6 +1,6 @@
 import {Primitive} from './primitive';
 /**
-Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
+Matches any primite, date, or regexp value
 
 @category Type
 */

--- a/source/built-ins.d.ts
+++ b/source/built-ins.d.ts
@@ -1,6 +1,6 @@
 import {Primitive} from './primitive';
 /**
-Matches any primite, date, or regexp value
+Matches any primitive, date, or regexp value
 
 @category Type
 */

--- a/source/built-ins.d.ts
+++ b/source/built-ins.d.ts
@@ -1,7 +1,0 @@
-import {Primitive} from './primitive';
-/**
-Matches any primitive, date, or regexp value
-
-@category Type
-*/
-export type BuiltIns = Primitive | Date | RegExp;

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -45,7 +45,7 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
-> = Value extends Function
+> = Value extends Function | Date | RegExp
 	? Value
 	: Value extends Array<infer U>
 	? Array<DelimiterCasedPropertiesDeep<U, Delimiter>>

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -39,8 +39,6 @@ export type Subtract<A extends number, B extends number> = BuildTuple<A> extends
 	: never;
 
 /**
-Matches any primitive, date, or regexp value
-
-@category Type
+Matches any primitive, `Date`, or `RegExp` value.
 */
 export type BuiltIns = Primitive | Date | RegExp;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -1,3 +1,5 @@
+import {Primitive} from './primitive';
+
 /**
 Returns a boolean for whether the two given types are equal.
 
@@ -35,3 +37,10 @@ the inferred tuple `U` and a tuple of length `B`, then extracts the length of tu
 export type Subtract<A extends number, B extends number> = BuildTuple<A> extends [...(infer U), ...BuildTuple<B>]
 	? TupleLength<U>
 	: never;
+
+/**
+Matches any primitive, date, or regexp value
+
+@category Type
+*/
+export type BuiltIns = Primitive | Date | RegExp;

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,4 +1,4 @@
-import {BuiltIns} from './built-ins';
+import {BuiltIns} from './internal';
 
 /**
 Create a type from another type with all keys and nested keys set to optional.

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,4 +1,4 @@
-import {Primitive} from './primitive';
+import {BuiltIns} from './built-ins';
 
 /**
 Create a type from another type with all keys and nested keys set to optional.
@@ -52,8 +52,6 @@ export type PartialDeep<T> = T extends BuiltIns
 			: PartialObjectDeep<T> // Tuples behave properly
 		: PartialObjectDeep<T>
 	: unknown;
-
-type BuiltIns = Primitive | Date | RegExp;
 
 /**
 Same as `PartialDeep`, but accepts only `Map`s and as inputs. Internal helper for `PartialDeep`.

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -42,7 +42,7 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 @category Template literal
 @category Object
 */
-export type PascalCasedPropertiesDeep<Value> = Value extends Function
+export type PascalCasedPropertiesDeep<Value> = Value extends Function | Date | RegExp
 	? Value
 	: Value extends Array<infer U>
 	? Array<PascalCasedPropertiesDeep<U>>

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -1,4 +1,4 @@
-import {Primitive} from './primitive';
+import {BuiltIns} from './built-ins';
 
 /**
 Convert `object`s, `Map`s, `Set`s, and `Array`s and all of their keys/elements into immutable structures recursively.
@@ -34,7 +34,7 @@ data.foo.push('bar');
 @category Set
 @category Map
 */
-export type ReadonlyDeep<T> = T extends Primitive | ((...arguments: any[]) => unknown)
+export type ReadonlyDeep<T> = T extends BuiltIns | ((...arguments: any[]) => unknown)
 	? T
 	: T extends ReadonlyMap<infer KeyType, infer ValueType>
 	? ReadonlyMapDeep<KeyType, ValueType>

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -1,4 +1,4 @@
-import {BuiltIns} from './built-ins';
+import {BuiltIns} from './internal';
 
 /**
 Convert `object`s, `Map`s, `Set`s, and `Array`s and all of their keys/elements into immutable structures recursively.

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -15,6 +15,8 @@ expectType<Set<{fooBar: string}>>(bar);
 interface User {
 	UserId: number;
 	UserName: string;
+	Date: Date;
+	RegExp: RegExp;
 }
 
 interface UserWithFriends {
@@ -26,15 +28,21 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 	userInfo: {
 		userId: 1,
 		userName: 'Tom',
+		date: new Date(),
+		regExp: new RegExp(/.*/),
 	},
 	userFriends: [
 		{
 			userId: 2,
 			userName: 'Jerry',
+			date: new Date(),
+			regExp: new RegExp(/.*/),
 		},
 		{
 			userId: 3,
 			userName: 'Spike',
+			date: new Date(),
+			regExp: new RegExp(/.*/),
 		},
 	],
 };

--- a/test-d/delimiter-cased-properties-deep.ts
+++ b/test-d/delimiter-cased-properties-deep.ts
@@ -14,6 +14,8 @@ expectType<Set<{'foo-bar': string}>>(bar);
 interface User {
 	userId: number;
 	userName: string;
+	date: Date;
+	regExp: RegExp;
 }
 
 interface UserWithFriends {
@@ -25,15 +27,21 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 	'user-info': {
 		'user-id': 1,
 		'user-name': 'Tom',
+		date: new Date(),
+		'reg-exp': new RegExp(/.*/),
 	},
 	'user-friends': [
 		{
 			'user-id': 2,
 			'user-name': 'Jerry',
+			date: new Date(),
+			'reg-exp': new RegExp(/.*/),
 		},
 		{
 			'user-id': 3,
 			'user-name': 'Spike',
+			date: new Date(),
+			'reg-exp': new RegExp(/.*/),
 		},
 	],
 };

--- a/test-d/kebab-cased-properties-deep.ts
+++ b/test-d/kebab-cased-properties-deep.ts
@@ -11,6 +11,8 @@ expectType<Set<{'foo-bar': string}>>(bar);
 interface User {
 	userId: number;
 	userName: string;
+	date: Date;
+	regExp: RegExp;
 }
 
 interface UserWithFriends {
@@ -22,15 +24,21 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 	'user-info': {
 		'user-id': 1,
 		'user-name': 'Tom',
+		date: new Date(),
+		'reg-exp': new RegExp(/.*/),
 	},
 	'user-friends': [
 		{
 			'user-id': 2,
 			'user-name': 'Jerry',
+			date: new Date(),
+			'reg-exp': new RegExp(/.*/),
 		},
 		{
 			'user-id': 3,
 			'user-name': 'Spike',
+			date: new Date(),
+			'reg-exp': new RegExp(/.*/),
 		},
 	],
 };

--- a/test-d/pascal-cased-properties-deep.ts
+++ b/test-d/pascal-cased-properties-deep.ts
@@ -14,6 +14,8 @@ expectType<Set<{FooBar: string}>>(bar);
 interface User {
 	userId: number;
 	userName: string;
+	date: Date;
+	regExp: RegExp;
 }
 
 interface UserWithFriends {
@@ -25,15 +27,21 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 	UserInfo: {
 		UserId: 1,
 		UserName: 'Tom',
+		Date: new Date(),
+		RegExp: new RegExp(/.*/),
 	},
 	UserFriends: [
 		{
 			UserId: 2,
 			UserName: 'Jerry',
+			Date: new Date(),
+			RegExp: new RegExp(/.*/),
 		},
 		{
 			UserId: 3,
 			UserName: 'Spike',
+			Date: new Date(),
+			RegExp: new RegExp(/.*/),
 		},
 	],
 };

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -10,6 +10,8 @@ const data = {
 	number: 1,
 	boolean: false,
 	symbol: Symbol('test'),
+	date: new Date(),
+	regExp: new RegExp(/.*/),
 	null: null,
 	undefined: undefined, // eslint-disable-line object-shorthand
 	map: new Map<string, string>(),
@@ -34,6 +36,8 @@ expectType<boolean>(readonlyData.boolean);
 expectType<symbol>(readonlyData.symbol);
 expectType<null>(readonlyData.null);
 expectType<undefined>(readonlyData.undefined);
+expectType<Date>(readonlyData.date);
+expectType<RegExp>(readonlyData.regExp);
 expectType<ReadonlyMap<string, string>>(readonlyData.map);
 expectType<ReadonlySet<string>>(readonlyData.set);
 expectType<readonly string[]>(readonlyData.array);

--- a/test-d/snake-cased-properties-deep.ts
+++ b/test-d/snake-cased-properties-deep.ts
@@ -11,6 +11,8 @@ expectType<Set<{foo_bar: string}>>(bar);
 interface User {
 	userId: number;
 	userName: string;
+	date: Date;
+	regExp: RegExp;
 }
 
 interface UserWithFriends {
@@ -22,15 +24,21 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 	user_info: {
 		user_id: 1,
 		user_name: 'Tom',
+		date: new Date(),
+		reg_exp: new RegExp(/.*/),
 	},
 	user_friends: [
 		{
 			user_id: 2,
 			user_name: 'Jerry',
+			date: new Date(),
+			reg_exp: new RegExp(/.*/),
 		},
 		{
 			user_id: 3,
 			user_name: 'Spike',
+			date: new Date(),
+			reg_exp: new RegExp(/.*/),
 		},
 	],
 };


### PR DESCRIPTION
Adding Date/RegExp support to `PascalCasedPropertiesDeep`, `DelimiterCasedPropertiesDeep`, `ReadonlyDeep`, `CamelCasedPropertiesDeep`, `KebabCasedPropertiesDeep`, `SnakeCasePropertiesDeep`.

Fixes https://github.com/sindresorhus/type-fest/issues/347.
