### PR TITLE
Extend `Get` to accept `Path` as `string[]`

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -169,5 +169,5 @@ Get<Record<string, string>, 'foo', {strict: true}> // => string | undefined
 @category Array
 @category Template literal
 */
-export type Get<BaseType, Path extends string, Options extends GetOptions = {}> =
-	GetWithPath<BaseType, ToPath<Path>, Options>;
+export type Get<BaseType, Path extends string | string[], Options extends GetOptions = {}> =
+	GetWithPath<BaseType, Path extends string ? ToPath<Path> : Path, Options>;

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -138,7 +138,7 @@ Use-case: Retrieve a property from deep inside an API response or some other com
 import {Get} from 'type-fest';
 import * as lodash from 'lodash';
 
-const get = <BaseType, Path extends string>(object: BaseType, path: Path): Get<BaseType, Path> =>
+const get = <BaseType, Path extends string | string[]>(object: BaseType, path: Path): Get<BaseType, Path> =>
 	lodash.get(object, path);
 
 interface ApiResponse {
@@ -158,6 +158,11 @@ interface ApiResponse {
 
 const getName = (apiResponse: ApiResponse) =>
 	get(apiResponse, 'hits.hits[0]._source.name');
+	//=> Array<{given: string[]; family: string}>
+
+// Path also supports an array of strings
+const getNameWithPathArray = (apiResponse: ApiResponse) =>
+	get(apiResponse, ['hits','hits', '0', '_source', 'name']);
 	//=> Array<{given: string[]; family: string}>
 
 // Strict mode:

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -97,9 +97,9 @@ expectTypeOf<Get<number[], '[0][0]'>>().toBeUnknown();
 expectTypeOf<Get<number[][][], '[0][0][0]'>>().toBeNumber();
 expectTypeOf<Get<number[][][], '[0][0][0][0]'>>().toBeUnknown();
 expectTypeOf<Get<{a: {b: Array<Array<Array<{id: number}>>>}}, 'a.b[0][0][0].id'>>().toBeNumber();
+expectTypeOf<Get<{a: {b: Array<Array<Array<{id: number}>>>}}, ['a', 'b', '0', '0', '0', 'id']>>().toBeNumber();
 
 // Test strict version:
-
 type Strict = {strict: true};
 expectTypeOf<Get<string[], '0', Strict>>().toEqualTypeOf<string | undefined>();
 expectTypeOf<Get<Record<string, number>, 'foo', Strict>>().toEqualTypeOf<number | undefined>();
@@ -120,3 +120,4 @@ interface WithDictionary {
 expectTypeOf<Get<WithDictionary, 'foo.whatever', Strict>>().toEqualTypeOf<{bar: number} | undefined>();
 expectTypeOf<Get<WithDictionary, 'foo.whatever.bar', Strict>>().toEqualTypeOf<number | undefined>();
 expectTypeOf<Get<WithDictionary, 'baz.whatever.qux[3].x', Strict>>().toEqualTypeOf<boolean | undefined>();
+expectTypeOf<Get<WithDictionary, ['baz', 'whatever', 'qux', '3', 'x'], Strict>>().toEqualTypeOf<boolean | undefined>();


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/305