### PR TITLE
Add `TransformDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export {RequireExactlyOne} from './source/require-exactly-one';
 export {RequireAllOrNone} from './source/require-all-or-none';
 export {PartialDeep} from './source/partial-deep';
 export {ReadonlyDeep} from './source/readonly-deep';
+export {TransformDeep} from './source/transform-deep';
 export {LiteralUnion} from './source/literal-union';
 export {Promisable} from './source/promisable';
 export {Opaque} from './source/opaque';

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Click the type names for complete docs.
 - [`RequireAllOrNone`](source/require-all-or-none.d.ts) - Create a type that requires all of the given keys or none of the given keys.
 - [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type. Use [`Partial<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype) if you only need one level deep.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of an `object`/`Map`/`Set`/`Array` type. Use [`Readonly<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype) if you only need one level deep.
+- [`TransformDeep`](source/transform-deep.d.ts) - Create a deeply transformed version of another type where each value (`BuiltIns` or functions) are replaced by an arbitrary type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union. Workaround for [Microsoft/TypeScript#29729](https://github.com/Microsoft/TypeScript/issues/29729).
 - [`Opaque`](source/opaque.d.ts) - Create an [opaque type](https://codemix.com/opaque-types-in-javascript/).
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional.

--- a/source/transform-deep.d.ts
+++ b/source/transform-deep.d.ts
@@ -1,0 +1,91 @@
+import {BuiltIns} from './internal';
+
+/**
+Create a type from another type with all keys and nested keys set to an arbitrary value.
+
+Use-cases:
+- When validating an object, return an object with the same key disposition where each value is a string with a description of the error.
+
+@example
+```
+import {PartialDeep, TransformDeep} from 'type-fest';
+
+const formValues: Values = {
+	name: "John Doe",
+	address: {
+		street: "Av. de Mayo",
+		number: 505,
+		city: "Buenos Aires",
+		country: "Argentina"
+	}
+	subscribeToNewsletter: true
+};
+
+const validate = (values: Values): PartialDeep<TransformDeep<Values, string>> => {
+	// ...
+}
+
+const errors = validate(formValues);
+```
+
+@category Object
+@category Array
+@category Set
+@category Map
+*/
+export type TransformDeep<Base, Value> = Base extends
+	| BuiltIns
+	| ((...arguments: any[]) => unknown)
+	? Value
+	: Base extends Map<infer KeyType, infer ValueType>
+	? TransformMapDeep<KeyType, ValueType, Value>
+	: Base extends Set<infer ItemType>
+	? TransformSetDeep<ItemType, Value>
+	: Base extends ReadonlyMap<infer KeyType, infer ValueType>
+	? TransformReadonlyMapDeep<KeyType, ValueType, Value>
+	: Base extends ReadonlySet<infer ItemType>
+	? TransformReadonlySetDeep<ItemType, Value>
+	: Base extends object
+	? Base extends Array<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
+		? ItemType[] extends Base // Test for arrays (non-tuples) specifically
+			? Array<TransformDeep<ItemType | undefined, Value>> // Recreate relevant array type to prevent eager evaluation of circular reference
+			: TransformObjectDeep<Base, Value> // Tuples behave properly
+		: TransformObjectDeep<Base, Value>
+	: Value;
+
+/**
+Same as `TransformDeep`, but accepts only `Map`s and as inputs. Internal helper for `TransformDeep`.
+*/
+interface TransformMapDeep<KeyType, ValueType, TransformValue>
+	extends Map<
+		TransformDeep<KeyType, TransformValue>,
+		TransformDeep<ValueType, TransformValue>
+	> {}
+
+/**
+Same as `TransformDeep`, but accepts only `Set`s as inputs. Internal helper for `TransformDeep`.
+*/
+interface TransformSetDeep<Base, Value>
+	extends Set<TransformDeep<Base, Value>> {}
+
+/**
+Same as `TransformDeep`, but accepts only `ReadonlyMap`s as inputs. Internal helper for `TransformDeep`.
+*/
+interface TransformReadonlyMapDeep<KeyType, ValueType, TransformValue>
+	extends ReadonlyMap<
+		TransformDeep<KeyType, TransformValue>,
+		TransformDeep<ValueType, TransformValue>
+	> {}
+
+/**
+Same as `TransformDeep`, but accepts only `ReadonlySet`s as inputs. Internal helper for `TransformDeep`.
+*/
+interface TransformReadonlySetDeep<Base, Value>
+	extends ReadonlySet<TransformDeep<Base, Value>> {}
+
+/**
+Same as `TransformDeep`, but accepts only `object`s as inputs. Internal helper for `TransformDeep`.
+*/
+type TransformObjectDeep<ObjectType extends object, Value> = {
+	[KeyType in keyof ObjectType]: TransformDeep<ObjectType[KeyType], Value>;
+};

--- a/source/transform-deep.d.ts
+++ b/source/transform-deep.d.ts
@@ -1,5 +1,7 @@
 import {BuiltIns} from './internal';
 
+type IsAny<T> = 0 extends 1 & T ? true : false; // https://stackoverflow.com/a/49928360/3406963
+
 /**
 Create a type from another type with all keys and nested keys set to an arbitrary value.
 
@@ -33,9 +35,9 @@ const errors = validate(formValues);
 @category Set
 @category Map
 */
-export type TransformDeep<Base, Value> = Base extends
-	| BuiltIns
-	| ((...arguments: any[]) => unknown)
+export type TransformDeep<Base, Value> = IsAny<Base> extends true
+	? Value
+	: Base extends BuiltIns | ((...arguments: any[]) => unknown)
 	? Value
 	: Base extends Map<infer KeyType, infer ValueType>
 	? TransformMapDeep<KeyType, ValueType, Value>

--- a/test-d/transform-deep.ts
+++ b/test-d/transform-deep.ts
@@ -1,0 +1,67 @@
+import {expectType, expectError} from 'tsd';
+import {TransformDeep} from '../index';
+
+const data = {
+	object: {
+		foo: 'bar',
+	},
+	fn: (_: string) => true,
+	string: 'foo',
+	number: 1,
+	boolean: false,
+	symbol: Symbol('test'),
+	date: new Date(),
+	regExp: new RegExp(/.*/),
+	null: null as null,
+	undefined: undefined as undefined, // eslint-disable-line object-shorthand
+	map: new Map<string, number>(),
+	set: new Set<{id: number, label: string}>(),
+	array: ['foo'],
+	tuple: ['foo'] as ['foo'],
+	readonlyMap: new Map<string, {foo: boolean}>() as ReadonlyMap<string, {foo: boolean}>,
+	readonlySet: new Set<{foo: boolean}>() as ReadonlySet<{foo: boolean}>,
+	readonlyArray: ['foo'] as readonly string[],
+	readonlyTuple: ['foo'] as const,
+};
+
+const transformedData: TransformDeep<typeof data, string> = {
+	object: {
+		foo: 'string',
+	},
+	fn: 'string',
+	string: 'string',
+	number: 'string',
+	boolean: 'string',
+	symbol: 'string',
+	date: 'string',
+	regExp: 'string',
+	null: 'string',
+	undefined: 'string',
+	map: new Map<string, string>(),
+	set: new Set<{id: string, label: string}>(),
+	array: ['string'],
+	tuple: ['string'],
+	readonlyMap: new Map<string, {foo: string}>(),
+	readonlySet: new Set<{foo: string}>(),
+	readonlyArray: ['string'],
+	readonlyTuple: ['string'],
+};
+
+expectError(transformedData.date = new Date());
+expectType<{foo: string}>(transformedData.object);
+expectType<string>(transformedData.string);
+expectType<string>(transformedData.number);
+expectType<string>(transformedData.boolean);
+expectType<string>(transformedData.symbol);
+expectType<string>(transformedData.null);
+expectType<string>(transformedData.undefined);
+expectType<string>(transformedData.date);
+expectType<string>(transformedData.regExp);
+expectType<ReadonlyMap<string, string>>(transformedData.map);
+expectType<ReadonlySet<{id: string, label: string}>>(transformedData.set);
+expectType<readonly string[]>(transformedData.array);
+expectType<readonly [string]>(transformedData.tuple);
+expectType<ReadonlyMap<string, {foo: string}>>(transformedData.readonlyMap);
+expectType<ReadonlySet<{foo: string}>>(transformedData.readonlySet);
+expectType<readonly string[]>(transformedData.readonlyArray);
+expectType<readonly [string]>(transformedData.readonlyTuple);

--- a/test-d/transform-deep.ts
+++ b/test-d/transform-deep.ts
@@ -12,8 +12,8 @@ const data = {
 	symbol: Symbol('test'),
 	date: new Date(),
 	regExp: new RegExp(/.*/),
-	null: null as null, // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
-	undefined: undefined as undefined, // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+	null: null,
+	undefined: undefined,
 	map: new Map<string, number>(),
 	set: new Set<{id: number; label: string}>(),
 	array: ['foo'],

--- a/test-d/transform-deep.ts
+++ b/test-d/transform-deep.ts
@@ -12,10 +12,10 @@ const data = {
 	symbol: Symbol('test'),
 	date: new Date(),
 	regExp: new RegExp(/.*/),
-	null: null as null,
-	undefined: undefined as undefined, // eslint-disable-line object-shorthand
+	null: null as null, // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+	undefined: undefined as undefined, // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
 	map: new Map<string, number>(),
-	set: new Set<{id: number, label: string}>(),
+	set: new Set<{id: number; label: string}>(),
 	array: ['foo'],
 	tuple: ['foo'] as ['foo'],
 	readonlyMap: new Map<string, {foo: boolean}>() as ReadonlyMap<string, {foo: boolean}>,
@@ -38,7 +38,7 @@ const transformedData: TransformDeep<typeof data, string> = {
 	null: 'string',
 	undefined: 'string',
 	map: new Map<string, string>(),
-	set: new Set<{id: string, label: string}>(),
+	set: new Set<{id: string; label: string}>(),
 	array: ['string'],
 	tuple: ['string'],
 	readonlyMap: new Map<string, {foo: string}>(),
@@ -58,7 +58,7 @@ expectType<string>(transformedData.undefined);
 expectType<string>(transformedData.date);
 expectType<string>(transformedData.regExp);
 expectType<ReadonlyMap<string, string>>(transformedData.map);
-expectType<ReadonlySet<{id: string, label: string}>>(transformedData.set);
+expectType<ReadonlySet<{id: string; label: string}>>(transformedData.set);
 expectType<readonly string[]>(transformedData.array);
 expectType<readonly [string]>(transformedData.tuple);
 expectType<ReadonlyMap<string, {foo: string}>>(transformedData.readonlyMap);


### PR DESCRIPTION
## `TransformDeep<Base, Value>`

Create a deeply transformed version of another type where each value (`BuiltIns` or functions) are replaced by an arbitrary type.

```ts
import {TransformDeep} from 'type-fest';

type Example = TransformDeep<{
  foo: number
  bar: { qux: boolean }
}, string>;

// => { foo: string; bar: { qux: string } }
```

### Use case

When validating an object, return an object with the same key disposition where each value is a string with a description of the error.

```ts
import {PartialDeep, TransformDeep} from 'type-fest';
const formValues: Values = {
  name: "John Doe",
  address: {
    street: "Av. de Mayo",
    number: 505,
    city: "Buenos Aires",
    country: "Argentina"
  }
  subscribeToNewsletter: true
};

const validate = (values: Values): PartialDeep<TransformDeep<Values, string>> => {
  // ...
}

const errors = validate(formValues);
// => 
// { 
//   name?: string
//   address?: {
//     street?: string
//     number?: string
//     city?: string
//     country?: string
//   }
//   subscribeToNewsletter?: string
// }
```