### PR TITLE
`Get`: Support read only arrays

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -139,7 +139,7 @@ Use-case: Retrieve a property from deep inside an API response or some other com
 import {Get} from 'type-fest';
 import * as lodash from 'lodash';
 
-const get = <BaseType, Path extends string | readonly string[]>>(object: BaseType, path: Path): Get<BaseType, Path> =>
+const get = <BaseType, Path extends string | readonly string[]>(object: BaseType, path: Path): Get<BaseType, Path> =>
 	lodash.get(object, path);
 
 interface ApiResponse {

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -12,7 +12,7 @@ Like the `Get` type but receives an array of strings as a path parameter.
 type GetWithPath<BaseType, Keys extends readonly string[], Options extends GetOptions = {}> =
 	Keys extends []
 	? BaseType
-	: Keys extends [infer Head, ...infer Tail]
+	: Keys extends readonly [infer Head, ...infer Tail]
 	? GetWithPath<
 		PropertyOf<BaseType, Extract<Head, string>, Options>,
 		Extract<Tail, string[]>,
@@ -175,5 +175,5 @@ Get<Record<string, string>, 'foo', {strict: true}> // => string | undefined
 @category Array
 @category Template literal
 */
-export type Get<BaseType, Path extends string | string[], Options extends GetOptions = {}> =
+export type Get<BaseType, Path extends string | readonly string[], Options extends GetOptions = {}> =
 	GetWithPath<BaseType, Path extends string ? ToPath<Path> : Path, Options>;

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -139,7 +139,7 @@ Use-case: Retrieve a property from deep inside an API response or some other com
 import {Get} from 'type-fest';
 import * as lodash from 'lodash';
 
-const get = <BaseType, Path extends string | string[]>(object: BaseType, path: Path): Get<BaseType, Path> =>
+const get = <BaseType, Path extends string | readonly string[]>>(object: BaseType, path: Path): Get<BaseType, Path> =>
 	lodash.get(object, path);
 
 interface ApiResponse {

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -161,9 +161,9 @@ const getName = (apiResponse: ApiResponse) =>
 	get(apiResponse, 'hits.hits[0]._source.name');
 	//=> Array<{given: string[]; family: string}>
 
-// Path also supports an array of strings
+// Path also supports a readonly array of strings
 const getNameWithPathArray = (apiResponse: ApiResponse) =>
-	get(apiResponse, ['hits','hits', '0', '_source', 'name']);
+	get(apiResponse, ['hits','hits', '0', '_source', 'name'] as const);
 	//=> Array<{given: string[]; family: string}>
 
 // Strict mode:


### PR DESCRIPTION
Fixes #305

Improves upon #353 by requiring a `readonly string[]` instead of `string[]`, since `Get<SomeObj, string[]>` seems to evaluate to `never` in all cases. Passing a read only tuple (`["foo", "bar"] as const`) would result in the actual type being returned, but is currently not supported since a read only tuple can't be assigned to a mutable `string[]`.

With this change it's now possible to accept actual TypeScript arrays in functions that use `Get`, but consumers of such functions will need to use `as const`:

```ts
declare const get: <Obj, Keys extends readonly string[]>(obj: Obj, keys: Keys) => Get<Obj, Keys>;

get({ foo: "bar" }, ["foo"] as const); // string
```

Changing the type from `string[]` to `readonly string[]` is probably technically a breaking change, but at the same time passing `string[]` would only result in `never`, so I don't think it's really a concern here. Also, type-level tuples like in the existing tests aren't affected by this change.

I also updated the documentation since it seemed sort of misleading (it had an example that evaluated to `never`).