### PR TITLE
`ReadonlyDeep`: Fix handling of objects with call signatures

### DIFF
--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -34,8 +34,12 @@ data.foo.push('bar');
 @category Set
 @category Map
 */
-export type ReadonlyDeep<T> = T extends BuiltIns | ((...arguments: any[]) => unknown)
+export type ReadonlyDeep<T> = T extends BuiltIns
 	? T
+	: T extends (...arguments: any[]) => unknown
+	? {} extends ReadonlyObjectDeep<T>
+		? T
+		: ((...arguments: Parameters<T>) => ReturnType<T>) & ReadonlyObjectDeep<T>
 	: T extends Readonly<ReadonlyMap<infer KeyType, infer ValueType>>
 	? ReadonlyMapDeep<KeyType, ValueType>
 	: T extends Readonly<ReadonlySet<infer ItemType>>

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -70,9 +70,11 @@ type ReadonlyObjectDeep<ObjectType extends object> = {
 };
 
 /**
-Test if the given function has multiple call signatures. Internal helper for `ReadonlyDeep`.
+Test if the given function has multiple call signatures.
+
 Needed to handle the case of a single call signature with properties.
-Multipile call signatures cannot currently be supported due to a TypeScript limitation.
+
+Multiple call signatures cannot currently be supported due to a TypeScript limitation.
 @see https://github.com/microsoft/TypeScript/issues/29732
 */
 type HasMultipleCallSignatures<T extends (...arguments: any[]) => unknown> =

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -39,6 +39,8 @@ export type ReadonlyDeep<T> = T extends BuiltIns
 	: T extends (...arguments: any[]) => unknown
 	? {} extends ReadonlyObjectDeep<T>
 		? T
+		: HasMultipleCallSignatures<T> extends true
+		? T // Limitation - can't be made readonly
 		: ((...arguments: Parameters<T>) => ReturnType<T>) & ReadonlyObjectDeep<T>
 	: T extends Readonly<ReadonlyMap<infer KeyType, infer ValueType>>
 	? ReadonlyMapDeep<KeyType, ValueType>
@@ -66,3 +68,14 @@ Same as `ReadonlyDeep`, but accepts only `object`s as inputs. Internal helper fo
 type ReadonlyObjectDeep<ObjectType extends object> = {
 	readonly [KeyType in keyof ObjectType]: ReadonlyDeep<ObjectType[KeyType]>
 };
+
+/**
+Test if the given function has multiple call signatures. Internal helper for `ReadonlyDeep`.
+Maybe wants to me exported as it's own until type.
+*/
+type HasMultipleCallSignatures<T extends (...arguments: any[]) => unknown> =
+	T extends {(...arguments: infer A): unknown; (...arguments: any[]): unknown}
+		? unknown[] extends A
+			? false
+			: true
+		: false;

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -40,7 +40,7 @@ export type ReadonlyDeep<T> = T extends BuiltIns
 	? {} extends ReadonlyObjectDeep<T>
 		? T
 		: HasMultipleCallSignatures<T> extends true
-		? T // Limitation - can't be made readonly
+		? T
 		: ((...arguments: Parameters<T>) => ReturnType<T>) & ReadonlyObjectDeep<T>
 	: T extends Readonly<ReadonlyMap<infer KeyType, infer ValueType>>
 	? ReadonlyMapDeep<KeyType, ValueType>
@@ -71,7 +71,9 @@ type ReadonlyObjectDeep<ObjectType extends object> = {
 
 /**
 Test if the given function has multiple call signatures. Internal helper for `ReadonlyDeep`.
-Maybe wants to me exported as it's own until type.
+Needed to handle the case of a single call signature with properties.
+Multipile call signatures cannot currently be supported due to a TypeScript limitation.
+@see https://github.com/microsoft/TypeScript/issues/29732
 */
 type HasMultipleCallSignatures<T extends (...arguments: any[]) => unknown> =
 	T extends {(...arguments: infer A): unknown; (...arguments: any[]): unknown}

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -16,20 +16,14 @@ type NamespaceWithOverload = Overloaded & {
 	baz: boolean[];
 };
 
-const namespace = (() => 1) as unknown as Namespace;
-namespace.baz = [true];
-
-const namespaceWithOverload = (() => 1) as unknown as NamespaceWithOverload;
-namespace.baz = [true];
-
 const data = {
 	object: {
 		foo: 'bar',
 	},
 	fn: (_: string) => true,
 	fnWithOverload: ((_: number) => 'foo') as Overloaded,
-	namespace,
-	namespaceWithOverload,
+	namespace: {} as unknown as Namespace,
+	namespaceWithOverload: {} as unknown as NamespaceWithOverload,
 	string: 'foo',
 	number: 1,
 	boolean: false,


### PR DESCRIPTION
partial fix of #337

Makes objects with a call signatures readonly.

**Limitations:**

- An object with both properties and multiple call signatures cannot be mapped to another type without losing the call signatures.
  - see https://github.com/microsoft/TypeScript/issues/29732

Current this PR assumes that any object that has an call signatures is not a map or set. I can extends this PR to handle maps and sets with call signatures.