### PR TITLE
Add `NullableToOptional` and `NonNullableKeys` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ export {
 	NonNegativeInteger,
 } from './source/numeric';
 export {StringKeyOf} from './source/string-key-of';
+export {NonNullableKeys} from './source/non-nullable-keys';
+export {NullableToOptional} from './source/nullable-to-optional';
 
 // Template literal types
 export {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,8 @@ Click the type names for complete docs.
 - [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.
 - [`StringKeyOf`](source/string-key-of.d.ts) - Get keys of the given type as strings.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
+- [`NonNullableKeys`](source/non-nullable-keys.d.ts) - Extract the keys from a type where the value type of the key include `null`.
+- [`NullableToOptional`](source/nullable-to-optional.d.ts) - Make the keys of a type where the value type of the key include `null` optional.
 
 ### JSON
 

--- a/source/non-nullable-keys.d.ts
+++ b/source/non-nullable-keys.d.ts
@@ -1,0 +1,26 @@
+/**
+Extract the keys from a type where the value type of the key include `null`.
+
+Internally this is used for the `NullableToOptional` type.
+
+@example
+```
+import {NullableKeys} from 'type-fest';
+
+interface Example {
+	a: string;
+	b: string | number;
+	c: string | null;
+	d: {} | null;
+}
+
+type NullableKeys = ConditionalKeys<Example>;
+//=> 'c' | 'd'
+```
+
+@category Object
+*/
+export type NonNullableKeys<Base> = {
+	// Pick all keys where the value type of the key include `null`
+	[K in keyof Base]: null extends Base[K] ? never : K
+}[keyof Base];

--- a/source/nullable-to-optional.d.ts
+++ b/source/nullable-to-optional.d.ts
@@ -1,0 +1,38 @@
+import {NonNullableKeys} from './non-nullable-keys';
+import {Simplify} from './simplify';
+import {UnionToIntersection} from './union-to-intersection';
+
+/**
+Make the keys of a type where the value type of the key include `null` optional.
+
+@example
+```
+import {NullableToOptional} from 'type-fest';
+
+interface Example {
+  a: string;
+  b: number | null;
+  c: null;
+}
+
+type NullIsOptional = NullableToOptional<Example>;
+//=> { a: string, b?: number | null, c?: null }
+```
+
+@category Object
+*/
+export type NullableToOptional<Base> = Simplify<
+  // Simplify to display as a single type instead of the union
+  UnionToIntersection<
+    // Wrap in `UnionToIntersection` to create singular type
+    | Pick<
+        // Keep all non-nullable key-value pairs as is
+        Base,
+        NonNullableKeys<Base>
+      >
+    | Partial<
+        // Make all nullable key-value pairs optional
+        Omit<Base, NonNullableKeys<Base>>
+      >
+  >
+>;

--- a/test-d/non-nullable-keys.ts
+++ b/test-d/non-nullable-keys.ts
@@ -1,0 +1,32 @@
+import {expectType} from 'tsd';
+import {NonNullableKeys} from '../index';
+
+type Mixed = {
+	a: number;
+	b: string;
+	c: number | string;
+	d: number | null;
+	e: string | null;
+	f: number | string | null;
+};
+
+type StandaloneNull = {
+	a: string;
+	b: null;
+};
+
+type ObjectOrNull = {
+	a: string;
+	b: {
+		c: number;
+	} | null;
+};
+
+declare const MixedKeys: NonNullableKeys<Mixed>;
+expectType<'a' | 'b' | 'c'>(MixedKeys);
+
+declare const StandaloneNullKeys: NonNullableKeys<StandaloneNull>;
+expectType<'a'>(StandaloneNullKeys);
+
+declare const ObjectOrNullKeys: NonNullableKeys<ObjectOrNull>;
+expectType<'a'>(ObjectOrNullKeys);

--- a/test-d/nullable-to-partial.ts
+++ b/test-d/nullable-to-partial.ts
@@ -1,0 +1,44 @@
+import {expectType} from 'tsd';
+import {NullableToOptional} from '../index';
+
+type Mixed = {
+	a: number;
+	b: string;
+	c: number | string;
+	d: number | null;
+	e: string | null;
+	f: number | string | null;
+};
+
+type StandaloneNull = {
+	a: string;
+	b: null;
+};
+
+type ObjectOrNull = {
+	a: string;
+	b: {
+		c: number;
+	} | null;
+};
+
+declare const MixedKeys: NullableToOptional<Mixed>;
+expectType<{
+	a: number;
+	b: string;
+	c: number | string;
+	d?: number | null;
+	e?: string | null;
+	f?: number | string | null;
+}>(MixedKeys);
+
+declare const StandaloneNullKeys: NullableToOptional<StandaloneNull>;
+expectType<{a: string; b?: null}>(StandaloneNullKeys);
+
+declare const ObjectOrNullKeys: NullableToOptional<ObjectOrNull>;
+expectType<{
+	a: string;
+	b?: {
+		c: number;
+	} | null;
+}>(ObjectOrNullKeys);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This adds the new type [`NullableToOptional`](source/nullable-to-optional.d.ts) and the type [`NonNullableKeys`](source/non-nullable-keys.d.ts) which is used internally by `NullableToOptional`.

###  [`NullableToOptional`](source/nullable-to-optional.d.ts)

Make the keys of a type where the value type of the key include `null` optional.

```
import {NullableToOptional} from 'type-fest';

interface Example {
  a: string;
  b: number | null;
  c: null;
}

type NullIsOptional = NullableToOptional<Example>;
//=> { a: string, b?: number | null, c?: null }
```

### [`NonNullableKeys`](source/non-nullable-keys.d.ts)

Extract the keys from a type where the value type of the key include `null`.

Internally this is used for the `NullableToOptional` type.

```
import {NullableKeys} from 'type-fest';

interface Example {
	a: string;
	b: string | number;
	c: string | null;
	d: {} | null;
}

type NullableKeys = ConditionalKeys<Example>;
//=> 'c' | 'd'
```

### Use cases

A use case I recently came across is models that are generated by [`typeorm`](https://github.com/typeorm/typeorm). Nullable fields are typed like `'propertyName': string | null` instead of `'propertyName'?: string | null`. This can be problematic when creating new entries, when typescript (rightfully) complains about unassigned nullable properties.

***

I'm not 100% sure on the naming, feel free to suggest different ones. I have also noticed some weird editor behaviour where `NonNullableKeys` resolves to `never` in `.ts` files while working in the `.d.ts` file. If this is not only for me the type should probably be revised somewhat.
