### PR TITLE
Add `watchOptions`field  to`TsConfig` type

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -193,6 +193,30 @@ declare namespace TsConfigJson {
 			| 'remove'
 			| 'preserve'
 			| 'error';
+
+		export type FallbackPolling =
+			| 'fixedPollingInterval'
+			| 'priorityPollingInterval'
+			| 'dynamicPriorityPolling'
+			| 'fixedInterval'
+			| 'priorityInterval'
+			| 'dynamicPriority'
+			| 'fixedChunkSize';
+
+		export type WatchDirectory =
+			| 'useFsEvents'
+			| 'fixedPollingInterval'
+			| 'dynamicPriorityPolling'
+			| 'fixedChunkSizePolling';
+
+		export type WatchFile =
+			| 'fixedPollingInterval'
+			| 'priorityPollingInterval'
+			| 'dynamicPriorityPolling'
+			| 'useFsEvents'
+			| 'useFsEventsOnParentDirectory'
+			| 'fixedChunkSizePolling';
+
 	}
 
 	export interface CompilerOptions {
@@ -569,6 +593,43 @@ declare namespace TsConfigJson {
 		@default false
 		*/
 		useUnknownInCatchVariables?: boolean;
+
+		/**
+		Watch input files.
+
+		@default false
+		@deprecated Use watchOptions instead.
+		*/
+		watch?: boolean;
+
+		/**
+		Specify the polling strategy to use when the system runs out of or doesn't support native file watchers.
+
+		Requires TypeScript version 3.8 or later.
+
+		@deprecated Use watchOptions.fallbackPolling instead.
+		*/
+		fallbackPolling?: CompilerOptions.FallbackPolling;
+
+		/**
+		Specify the strategy for watching directories under systems that lack recursive file-watching functionality.
+
+		Requires TypeScript version 3.8 or later.
+
+		@default 'useFsEvents'
+		@deprecated Use watchOptions.watchDirectory instead.
+		*/
+		watchDirectory?: CompilerOptions.WatchDirectory;
+
+		/**
+		Specify the strategy for watching individual files.
+
+		Requires TypeScript version 3.8 or later.
+
+		@default 'useFsEvents'
+		@deprecated Use watchOptions.watchFile instead.
+		*/
+		watchFile?: CompilerOptions.WatchFile;
 
 		/**
 		Enables experimental support for ES7 decorators.

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -193,30 +193,6 @@ declare namespace TsConfigJson {
 			| 'remove'
 			| 'preserve'
 			| 'error';
-
-		export type FallbackPolling =
-			| 'fixedPollingInterval'
-			| 'priorityPollingInterval'
-			| 'dynamicPriorityPolling'
-			| 'fixedInterval'
-			| 'priorityInterval'
-			| 'dynamicPriority'
-			| 'fixedChunkSize';
-
-		export type WatchDirectory =
-			| 'useFsEvents'
-			| 'fixedPollingInterval'
-			| 'dynamicPriorityPolling'
-			| 'fixedChunkSizePolling';
-
-		export type WatchFile =
-			| 'fixedPollingInterval'
-			| 'priorityPollingInterval'
-			| 'dynamicPriorityPolling'
-			| 'useFsEvents'
-			| 'useFsEventsOnParentDirectory'
-			| 'fixedChunkSizePolling';
-
 	}
 
 	export interface CompilerOptions {
@@ -595,38 +571,6 @@ declare namespace TsConfigJson {
 		useUnknownInCatchVariables?: boolean;
 
 		/**
-		Watch input files.
-
-		@default false
-		*/
-		watch?: boolean;
-
-		/**
-		Specify the polling strategy to use when the system runs out of or doesn't support native file watchers.
-
-		Requires TypeScript version 3.8 or later.
-		*/
-		fallbackPolling?: CompilerOptions.FallbackPolling;
-
-		/**
-		Specify the strategy for watching directories under systems that lack recursive file-watching functionality.
-
-		Requires TypeScript version 3.8 or later.
-
-		@default 'useFsEvents'
-		*/
-		watchDirectory?: CompilerOptions.WatchDirectory;
-
-		/**
-		Specify the strategy for watching individual files.
-
-		Requires TypeScript version 3.8 or later.
-
-		@default 'useFsEvents'
-		*/
-		watchFile?: CompilerOptions.WatchFile;
-
-		/**
 		Enables experimental support for ES7 decorators.
 
 		@default false
@@ -990,6 +934,71 @@ declare namespace TsConfigJson {
 		explainFiles?: boolean;
 	}
 
+	namespace WatchOptions {
+		export type WatchFileKind =
+			| 'FixedPollingInterval'
+			| 'PriorityPollingInterval'
+			| 'DynamicPriorityPolling'
+			| 'FixedChunkSizePolling'
+			| 'UseFsEvents'
+			| 'UseFsEventsOnParentDirectory';
+
+		export type WatchDirectoryKind =
+			| 'UseFsEvents'
+			| 'FixedPollingInterval'
+			| 'DynamicPriorityPolling'
+			| 'FixedChunkSizePolling';
+
+		export type PollingWatchKind =
+			| 'FixedInterval'
+			| 'PriorityInterval'
+			| 'DynamicPriority'
+			| 'FixedChunkSize';
+	}
+
+	export interface WatchOptions {
+
+		/**
+		Specify the strategy for watching individual files.
+
+		Requires TypeScript version 3.8 or later.
+
+		@default 'UseFsEvents'
+		*/
+		watchFile?: WatchOptions.WatchFileKind;
+
+		/**
+		Specify the strategy for watching directories under systems that lack recursive file-watching functionality.
+
+		Requires TypeScript version 3.8 or later.
+
+		@default 'UseFsEvents'
+		*/
+		watchDirectory?: WatchOptions.WatchDirectoryKind;
+
+		/**
+		Specify the polling strategy to use when the system runs out of or doesn't support native file watchers.
+
+		Requires TypeScript version 3.8 or later.
+		*/
+		fallbackPolling?: WatchOptions.PollingWatchKind;
+
+		/**
+		Enable synchronous updates on directory watchers for platforms that don't support recursive watching natively.
+		*/
+		synchronousWatchDirectory?: boolean;
+
+		/**
+		Specifies a list of directories to exclude from watch
+		*/
+		excludeDirectories?: string[];
+
+		/**
+		Specifies a list of files to exclude from watch
+		*/
+		excludeFiles?: string[];
+	}
+
 	/**
 	Auto type (.d.ts) acquisition options for this project.
 
@@ -1047,6 +1056,11 @@ export interface TsConfigJson {
 	Instructs the TypeScript compiler how to compile `.ts` files.
 	*/
 	compilerOptions?: TsConfigJson.CompilerOptions;
+
+	/**
+	Instructs the TypeScript compiler how to watch files.
+	*/
+	watchOptions?: TsConfigJson.WatchOptions;
 
 	/**
 	Auto type (.d.ts) acquisition options for this project.

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -965,7 +965,7 @@ declare namespace TsConfigJson {
 
 		@default 'UseFsEvents'
 		*/
-		watchFile?: WatchOptions.WatchFileKind;
+		watchFile?: WatchOptions.WatchFileKind | Lowercase<WatchOptions.WatchFileKind>;
 
 		/**
 		Specify the strategy for watching directories under systems that lack recursive file-watching functionality.
@@ -974,14 +974,14 @@ declare namespace TsConfigJson {
 
 		@default 'UseFsEvents'
 		*/
-		watchDirectory?: WatchOptions.WatchDirectoryKind;
+		watchDirectory?: WatchOptions.WatchDirectoryKind | Lowercase<WatchOptions.WatchDirectoryKind>;
 
 		/**
 		Specify the polling strategy to use when the system runs out of or doesn't support native file watchers.
 
 		Requires TypeScript version 3.8 or later.
 		*/
-		fallbackPolling?: WatchOptions.PollingWatchKind;
+		fallbackPolling?: WatchOptions.PollingWatchKind | Lowercase<WatchOptions.PollingWatchKind>;
 
 		/**
 		Enable synchronous updates on directory watchers for platforms that don't support recursive watching natively.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Added [`watchOptions`](https://www.typescriptlang.org/tsconfig#watchOptions).

Previously, there were watch options in `compilerOptions` that were not reflected in the docs so I removed them.

To prevent a breaking change, I can also add them back and mark them `@deprecated`.