### PR TITLE
Update get.d.ts for TS 4.7

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -97,9 +97,14 @@ type WithStringsKeys = keyof WithStrings;
 //=> 'foo' | '0'
 ```
 */
-type WithStringKeys<BaseType extends Record<string | number, any>> = {
-	[Key in StringKeyOf<BaseType>]: BaseType[Key]
+type WithStringKeys<BaseType> = {
+	[Key in StringKeyOf<BaseType>]: UncheckedIndex<BaseType, Key>
 };
+
+/**
+Perform a `T[U]` operation if `T` supports indexing
+*/
+type UncheckedIndex<T, U extends string | number> = [T] extends [Record<string | number, any>] ? T[U] : never;
 
 /**
 Get a property of an object or array. Works when indexing arrays using number-literal-strings, for example, `PropertyOf<number[], '0'> = number`, and when indexing objects with number keys.

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -102,7 +102,7 @@ type WithStringKeys<BaseType> = {
 };
 
 /**
-Perform a `T[U]` operation if `T` supports indexing
+Perform a `T[U]` operation if `T` supports indexing.
 */
 type UncheckedIndex<T, U extends string | number> = [T] extends [Record<string | number, any>] ? T[U] : never;
 


### PR DESCRIPTION
Callers of `WithStringKeys` pass in an unconstrained type parameter, and `StringKeyOf` uses an unconstrained type parameter, so `WithStringKeys` should handle an unconstrained type parameter. TS 4.7 calls out this inconsistency.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
