### PR TITLE
Add `Replace` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ export {DelimiterCasedPropertiesDeep} from './source/delimiter-cased-properties-
 export {Join} from './source/join';
 export {Split} from './source/split';
 export {Trim} from './source/trim';
+export {Replace} from './source/replace';
 export {Includes} from './source/includes';
 export {Get} from './source/get';
 export {LastArrayElement} from './source/last-array-element';

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ Click the type names for complete docs.
 
 - [`Trim`](source/trim.d.ts) - Remove leading and trailing spaces from a string.
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
+- [`Replace`](source/replace.d.ts) - Returns a new string with some or all matches of a string replaced by a replacement.
 
 ### Array
 

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ Click the type names for complete docs.
 
 - [`Trim`](source/trim.d.ts) - Remove leading and trailing spaces from a string.
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
-- [`Replace`](source/replace.d.ts) - Represents a string with some or all matches of a string replaced by a replacement.
+- [`Replace`](source/replace.d.ts) - Represents a string with some or all matches replaced by a replacement.
 
 ### Array
 

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ Click the type names for complete docs.
 
 - [`Trim`](source/trim.d.ts) - Remove leading and trailing spaces from a string.
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
-- [`Replace`](source/replace.d.ts) - Returns a new string with some or all matches of a string replaced by a replacement.
+- [`Replace`](source/replace.d.ts) - Represents a string with some or all matches of a string replaced by a replacement.
 
 ### Array
 

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -1,0 +1,58 @@
+type ReplaceOptions = {
+	all?: boolean;
+};
+
+/**
+Returns a new string with some or all matches
+of a string replaced by a replacement.
+
+Use-case:
+	- snake-case-path to dotted.path.notation
+	- Date/Time format "01-08-2042" -> "01/08/2042"
+	- Manipulation of type properties e.g. removal of prefixes
+
+@example
+```
+import {Replace} from 'type-fest';
+
+declare function replace<
+	Input extends string,
+	Search extends string,
+	Replacement extends string
+>(
+	input: Input,
+	search: Search,
+	replacement: Replacement
+): Replace<Input, Search, Replacement>;
+
+declare function replaceAll<
+	Input extends string,
+	Search extends string,
+	Replacement extends string
+>(
+	input: Input,
+	search: Search,
+	replacement: Replacement
+): Replace<Input, Search, Replacement, { all: true }>;
+
+replace("hello ?", "?", "🦄"); // => "hello 🦄"
+replace("hello ??", "?", "❓"); // => "hello ❓?"
+
+replaceAll("10:42:00", ":", "-");     // => "10-42-00"
+replaceAll("__userName__", "__", ""); // => "userName"
+replaceAll("My Cool Title", " ", ""); // => "MyCoolTitle"
+```
+
+@category String
+@category Template literal
+*/
+export type Replace<
+	Input extends string,
+	Search extends string,
+	Replacement extends string,
+	Options extends ReplaceOptions = {},
+> = Input extends `${infer Head}${Search}${infer Tail}`
+	? Options['all'] extends true
+		? Replace<`${Head}${Replacement}${Tail}`, Search, Replacement, Options>
+		: `${Head}${Replacement}${Tail}`
+	: Input;

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -3,13 +3,12 @@ type ReplaceOptions = {
 };
 
 /**
-Returns a new string with some or all matches
-of a string replaced by a replacement.
+Represents a string with some or all matches replaced by a replacement.
 
 Use-case:
-	- snake-case-path to dotted.path.notation
-	- Date/Time format "01-08-2042" -> "01/08/2042"
-	- Manipulation of type properties e.g. removal of prefixes
+- `snake-case-path` to `dotted.path.notation`
+- Changing date/time format: `01-08-2042` → `01/08/2042`
+- Manipulation of type properties, for example, removal of prefixes
 
 @example
 ```
@@ -33,14 +32,24 @@ declare function replaceAll<
 	input: Input,
 	search: Search,
 	replacement: Replacement
-): Replace<Input, Search, Replacement, { all: true }>;
+): Replace<Input, Search, Replacement, {all: true}>;
 
-replace("hello ?", "?", "🦄"); // => "hello 🦄"
-replace("hello ??", "?", "❓"); // => "hello ❓?"
+// The return type is the exact string literal, not just `string`.
 
-replaceAll("10:42:00", ":", "-");     // => "10-42-00"
-replaceAll("__userName__", "__", ""); // => "userName"
-replaceAll("My Cool Title", " ", ""); // => "MyCoolTitle"
+replace('hello ?', '?', '🦄');
+//=> 'hello 🦄'
+
+replace('hello ??', '?', '❓');
+//=> 'hello ❓?'
+
+replaceAll('10:42:00', ':', '-');
+//=> '10-42-00'
+
+replaceAll('__userName__', '__', '');
+//=> 'userName'
+
+replaceAll('My Cool Title', ' ', '');
+//=> 'MyCoolTitle'
 ```
 
 @category String

--- a/test-d/replace.ts
+++ b/test-d/replace.ts
@@ -1,0 +1,28 @@
+import {expectType} from 'tsd';
+import {Replace} from '../index';
+
+declare function replace<
+	Input extends string,
+	Search extends string,
+	Replacement extends string,
+>(
+	input: Input,
+	search: Search,
+	replacement: Replacement
+): Replace<Input, Search, Replacement>;
+
+declare function replaceAll<
+	Input extends string,
+	Search extends string,
+	Replacement extends string,
+>(
+	input: Input,
+	search: Search,
+	replacement: Replacement
+): Replace<Input, Search, Replacement, {all: true}>;
+
+expectType<'hello 🦄'>(replace('hello ?', '?', '🦄'));
+expectType<'hello ❓?'>(replace('hello ??', '?', '❓'));
+expectType<'10-42-00'>(replaceAll('10:42:00', ':', '-'));
+expectType<'userName'>(replaceAll('__userName__', '__', ''));
+expectType<'MyCoolTitle'>(replaceAll('My Cool Title', ' ', ''));

--- a/test-d/replace.ts
+++ b/test-d/replace.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import {Replace} from '../index';
+import type {Replace} from '../index';
 
 declare function replace<
 	Input extends string,


### PR DESCRIPTION
Adds the `Replace` type which may be useful in the following cases.

- snake-case-path to dotted.path.notation
- Date/Time format "01-08-2042" -> "01/08/2042"
- Manipulation of type properties e.g. removal of prefixes
- Your own case ...?

```ts
import {Replace} from 'type-fest';

declare function replace<
	Input extends string,
	Search extends string,
	Replacement extends string
>(
	input: Input,
	search: Search,
	replacement: Replacement
): Replace<Input, Search, Replacement>;

declare function replaceAll<
	Input extends string,
	Search extends string,
	Replacement extends string
>(
	input: Input,
	search: Search,
	replacement: Replacement
): Replace<Input, Search, Replacement, { all: true }>;

replace("hello ?", "?", "🦄"); // => "hello 🦄"
replace("hello ??", "?", "❓"); // => "hello ❓?"

replaceAll("10:42:00", ":", "-");     // => "10-42-00"
replaceAll("__userName__", "__", ""); // => "userName"
replaceAll("My Cool Title", " ", ""); // => "MyCoolTitle"
```