### PR TITLE
fix: PromiseValue JSDoc examples

### DIFF
--- a/source/promise-value.d.ts
+++ b/source/promise-value.d.ts
@@ -10,7 +10,7 @@ If the type is not a `Promise`, the type itself is returned.
 import type {PromiseValue} from 'type-fest';
 
 type AsyncData = Promise<string>;
-let asyncData: PromiseValue<AsyncData> = Promise.resolve('ABC');
+let asyncData: AsyncData = Promise.resolve('ABC');
 
 type Data = PromiseValue<AsyncData>;
 let data: Data = await asyncData;
@@ -20,8 +20,8 @@ type SyncData = PromiseValue<string>;
 let syncData: SyncData = getSyncData();
 
 // Here's an example that shows how this type reacts to recursive Promise types.
-type RecursiveAsyncData = Promise<Promise<string> >;
-let recursiveAsyncData: PromiseValue<RecursiveAsyncData> = Promise.resolve(Promise.resolve('ABC'));
+type RecursiveAsyncData = Promise<Promise<string>>;
+let recursiveAsyncData: PromiseValue<RecursiveAsyncData> = await Promise.resolve(Promise.resolve('ABC'));
 ```
 
 @category Async


### PR DESCRIPTION
Hello 👋 I was poking around the library and noticed some inaccuracies in the `PromiseValue` examples.

Here's a [TS Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBACgTgewLYEsDOEBqBDANgVwgB55l0IAVcCAPigF5ZFUMrIoIAPYCAOwBM0TMhgAyKANbEUvAGYQ4UHAVpQA-MJZY8hIssJ0AXJvJsIAbgCwAKBuh2AQTQheAYwAi2YNgYmMRNGA4GQBzGitrXAhgKGxnN09vY1ItfWInFw8vbDpGFPIAOjgINARcADcIAAoAcgcAIQBhGoBKCIB6dqgnKAQwMAQMfihgBEMbTqgomLjMxOxjDITs33yMIpKyytqG5rabO2ooedXmcjSiJazvcJsq2bcoKpaGOgBvGynoqH5s4xPGNgAO7YFAzeLXbA2AC+LWeEQmXQAEgoIDUhNheBxONgkGAoiMABZeKBoQkIIFCclAonoEZHYrYVzAISjKDFVz4OBoFCVPzQewlAqHdgAJQgnO5vIgVwB-JIZ38gWCvDCt2s9whTxe9Heny+MQ5XJ5lVlf35F3FkpNMoh81y-I2pQq1TWECdW2qdSarX21igUEmPT6AyGIzG+sm03ZEuN0rNSQtOmIVrjprt2QdwNBMTdHpdVTzxWd229ez9sOeNiAA) for reference. I also see a deprecation notice in the docs so feel free to close this PR if the updates are unecessary.