### PR TITLE
Fix `TsConfigJson` to require paths array

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -713,7 +713,7 @@ declare namespace TsConfigJson {
 		/**
 		Specify path mapping to be computed relative to baseUrl option.
 		*/
-		paths?: Partial<Record<string, string[]>>;
+		paths?: Record<string, string[]>;
 
 		/**
 		List of TypeScript language server plugins to load.

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectType} from 'tsd';
 import type {TsConfigJson} from '../index';
 
 const tsConfig: TsConfigJson = {};
@@ -11,6 +11,3 @@ expectType<string[] | undefined>(tsConfig.files);
 expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
-
-// Undefined assigns
-expectAssignable<NonNullable<typeof tsConfig['compilerOptions']>['paths']>({path: undefined});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

## Problem

Since https://github.com/sindresorhus/type-fest/pull/269, `paths` property in `TsConfigJson` is allowed to have an `undefined` value, but that is not correct.


VSCode doesn't allow `undefined` to be set:
<img width="480" alt="Screen Shot 2022-06-07 at 5 00 50 PM" src="https://user-images.githubusercontent.com/1075694/172481843-f35b95f0-f6a2-4479-87c5-aa0cdca02678.png">


tsc requires a non-empty array value:

<img width="1108" alt="Screen Shot 2022-06-07 at 5 01 49 PM" src="https://user-images.githubusercontent.com/1075694/172481991-ff9a5e87-b2f8-4587-9022-d198cfc8689e.png">



## Changes

Reverted https://github.com/sindresorhus/type-fest/pull/269/commits/ec64dfe57697c0cf8cd0f54f4248fe4ffa654b58

