### PR TITLE
Add `MergeDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export {Except} from './source/except';
 export {Mutable} from './source/mutable';
 export {Writable} from './source/writable';
 export {Merge} from './source/merge';
-export {MergeDeep} from './source/merge-deep';
+export {MergeDeep, MergeDeepOptions} from './source/merge-deep';
 export {MergeExclusive} from './source/merge-exclusive';
 export {RequireAtLeastOne} from './source/require-at-least-one';
 export {RequireExactlyOne} from './source/require-exactly-one';

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export {Except} from './source/except';
 export {Mutable} from './source/mutable';
 export {Writable} from './source/writable';
 export {Merge} from './source/merge';
+export {MergeDeep} from './source/merge-deep';
 export {MergeExclusive} from './source/merge-exclusive';
 export {RequireAtLeastOne} from './source/require-at-least-one';
 export {RequireExactlyOne} from './source/require-exactly-one';

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ Click the type names for complete docs.
 - [`Except`](source/except.d.ts) - Create a type from an object type without certain keys. This is a stricter version of [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys).
 - [`Writable`](source/writable.d.ts) - Create a type that strips `readonly` from all or some of an object's keys. The inverse of `Readonly<T>`. Formerly named `Mutable`.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
+- [`MergeDeep`](source/merge-deep.d.ts) - Merge two types `recursively` into a new type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive keys.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given keys.
 - [`RequireExactlyOne`](source/require-exactly-one.d.ts) - Create a type that requires exactly a single key of the given keys and disallows more.

--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ Click the type names for complete docs.
 - [`Except`](source/except.d.ts) - Create a type from an object type without certain keys. This is a stricter version of [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys).
 - [`Writable`](source/writable.d.ts) - Create a type that strips `readonly` from all or some of an object's keys. The inverse of `Readonly<T>`. Formerly named `Mutable`.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
-- [`MergeDeep`](source/merge-deep.d.ts) - Merge two types `recursively` into a new type.
+- [`MergeDeep`](source/merge-deep.d.ts) - Merge two types recursively into a new type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive keys.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given keys.
 - [`RequireExactlyOne`](source/require-exactly-one.d.ts) - Create a type that requires exactly a single key of the given keys and disallows more.

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -65,3 +65,13 @@ Extracts the type of an array minus the first element.
 export type ArrayTail<TArray> = TArray extends readonly [unknown, ...infer TTail]
   ? TTail
   : [];
+
+/**
+Matches any Array.
+*/
+export type AnyArray = unknown[] | readonly unknown[];
+
+/**
+Matches any Record.
+*/
+export type AnyRecord = Record<PropertyKey, unknown>;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -55,7 +55,7 @@ export type KeysOfUnion<T> = T extends T ? keyof T : never;
 /**
 Extracts the type of the first element of an array.
 */
-export type ArrayHead<TArray> = TArray extends readonly [infer THead, ...unknown[]]
+export type FirstArrayElement<TArray> = TArray extends readonly [infer THead, ...unknown[]]
   ? THead
   : never;
 

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -51,3 +51,17 @@ The reason a simple `keyof Union` does not work is because `keyof` always return
 @link https://stackoverflow.com/a/49402091
 */
 export type KeysOfUnion<T> = T extends T ? keyof T : never;
+
+/**
+Extracts the type of the first element of an array.
+*/
+export type ArrayHead<TArray> = TArray extends readonly [infer THead, ...unknown[]]
+  ? THead
+  : never;
+
+/**
+Extracts the type of an array minus the first element.
+*/
+export type ArrayTail<TArray> = TArray extends readonly [unknown, ...infer TTail]
+  ? TTail
+  : [];

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,3 +1,5 @@
+import {ConditionalExcept} from './conditional-except';
+
 /**
 MergeDeep options.
 
@@ -58,19 +60,13 @@ type GetValue<
   ? Destination[Key]
   : never;
 
-type ExtractType<TType, TUnion> = {
-  [Key in keyof TType]-?: TUnion extends TType[Key] ? Key : never;
-}[keyof TType];
-
-type OmitType<TType, TUnion> = Omit<TType, ExtractType<TType, TUnion>>;
-
 type MergeDeepLazy<Destination, Source, Options> = {
   [Key in Keyof<Destination, Source>]: Unwrap<
     GetValue<Destination, Source, Key, Options>
   >;
 };
 
-type MergeDeepStrict<Destination, Source, Options> = OmitType<
+type MergeDeepStrict<Destination, Source, Options> = ConditionalExcept<
   MergeDeepLazy<Destination, Source, Options>,
   undefined
 >;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,58 +1,100 @@
-type MergeDeepOptions = {
-	strict?: boolean;
-};
+interface MergeDeepOptions {
+  strict?: boolean;
+}
 
 type UnknownRecord = Record<string, unknown>;
 
 type Unwrap<Type> = Type extends UnknownRecord
-	? {[Key in keyof Type]: Type[Key]}
-	: Type;
+  ? {[Key in keyof Type]: Type[Key]}
+  : Type;
 
 type MergeValue<Destination, Source, Key, Options> =
-	Key extends keyof Destination
-		? Key extends keyof Source
-			? Destination[Key] extends UnknownRecord
-				? MergeDeep<Destination[Key], Source[Key], Options>
-				: Source[Key]
-			: never
-		: never;
+  Key extends keyof Destination
+    ? Key extends keyof Source
+      ? Destination[Key] extends UnknownRecord
+        ? MergeDeep<Destination[Key], Source[Key], Options>
+        : Source[Key]
+      : never
+    : never;
 
 type Keyof<Destination, Source> = keyof Destination | keyof Source;
 
+type MergeArrayValue<Destination, Source, Options> =
+  Destination extends UnknownArray
+    ? Source extends UnknownArray
+      ? ArrayMerge<Destination, Source, Options>
+      : Source
+    : Source;
+
 type GetValue<
-	Destination,
-	Source,
-	Key extends Keyof<Destination, Source>,
-	Options,
+  Destination,
+  Source,
+  Key extends Keyof<Destination, Source>,
+  Options,
 > = Key extends keyof Source
-	? Source[Key] extends UnknownRecord
-		? MergeValue<Destination, Source, Key, Options>
-		: Source[Key]
-	: Key extends keyof Destination
-	? Destination[Key] | null
-	: never;
+  ? Source[Key] extends UnknownRecord
+    ? MergeValue<Destination, Source, Key, Options>
+    : Source[Key] extends UnknownArray
+			? Key extends keyof Destination
+				? MergeArrayValue<Destination[Key], Source[Key], Options>
+				: Source[Key]
+			: Source[Key]
+  : Key extends keyof Destination
+  ? Destination[Key]
+  : never;
 
 type ExtractType<TType, TUnion> = {
-	[Key in keyof TType]-?: TUnion extends TType[Key] ? Key : never;
+  [Key in keyof TType]-?: TUnion extends TType[Key] ? Key : never;
 }[keyof TType];
 
 type OmitType<TType, TUnion> = Omit<TType, ExtractType<TType, TUnion>>;
 
 type MergeDeepLazy<Destination, Source, Options> = {
-	[Key in Keyof<Destination, Source>]: Unwrap<
-		GetValue<Destination, Source, Key, Options>
-	>;
+  [Key in Keyof<Destination, Source>]: Unwrap<
+    GetValue<Destination, Source, Key, Options>
+  >;
 };
 
 type MergeDeepStrict<Destination, Source, Options> = OmitType<
-	MergeDeepLazy<Destination, Source, Options>,
-	undefined
+  MergeDeepLazy<Destination, Source, Options>,
+  undefined
 >;
+
+type ArrayHead<TArray> = TArray extends readonly [infer THead, ...unknown[]]
+  ? THead
+  : never;
+
+type ArrayTail<TArray> = TArray extends readonly [unknown, ...infer TTail]
+  ? TTail
+  : [];
+
+type UnknownArray = readonly unknown[];
+
+type ArrayMergeValue<Destination, Source, Options> =
+  Destination extends UnknownRecord
+    ? Source extends UnknownRecord
+      ? Unwrap<MergeDeep<Destination, Source, Options>>
+      : Source
+    : Source;
+
+type ArrayMerge<
+  Destination extends UnknownArray,
+  Source extends UnknownArray,
+  Options extends MergeDeepOptions = {strict: true},
+> = Destination extends []
+  ? Source
+  : Source extends []
+  ? Destination
+  : [
+      ArrayMergeValue<ArrayHead<Destination>, ArrayHead<Source>, Options>,
+      ...ArrayMerge<ArrayTail<Destination>, ArrayTail<Source>>,
+    ];
 
 /**
 Merge two types recursively into a new type.
 
-Properties set to `undefined` value are skipped when strict is true (true by default).
+Properties set to `undefined` value are skipped
+when `strict` option is set to `true` (default).
 
 @example
 ```
@@ -84,9 +126,9 @@ Type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;
 @category Object
 */
 export type MergeDeep<
-	Destination,
-	Source,
-	Options extends MergeDeepOptions = {strict: true},
+  Destination,
+  Source,
+  Options extends MergeDeepOptions = {strict: true},
 > = Options['strict'] extends true
-	? MergeDeepStrict<Destination, Source, Options>
-	: MergeDeepLazy<Destination, Source, Options>;
+  ? MergeDeepStrict<Destination, Source, Options>
+  : MergeDeepLazy<Destination, Source, Options>;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,4 +1,11 @@
-interface MergeDeepOptions {
+/**
+MergeDeep options.
+
+@param strict Properties set to `undefined` value are skipped when set to `true` (default).
+
+@see MergeDeep
+*/
+export interface MergeDeepOptions {
   strict?: boolean;
 }
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -4,12 +4,12 @@ import {ArrayHead, ArrayTail} from './internal';
 /**
 MergeDeep options.
 
-@param strict Properties set to `undefined` value are skipped when set to `true` (default).
+@param strict - Properties set to `undefined` value are skipped when set to `true` (default).
 
 @see MergeDeep
 */
 export interface MergeDeepOptions {
-  strict?: boolean;
+	strict?: boolean;
 }
 
 /**
@@ -24,8 +24,8 @@ Unfortunately Simplify does not support the case where the type cannot be flatte
 @see Simplify
 */
 type Unwrap<Type> = Type extends UnknownRecord
-  ? {[Key in keyof Type]: Type[Key]}
-  : Type;
+	? {[Key in keyof Type]: Type[Key]}
+	: Type;
 
 /**
 Determines the value to be returned according to the type of the `Source` and `Destination`.
@@ -34,15 +34,15 @@ If both are records, returns the result of the merge.
 Otherwise returns the `Source` if present or the `Destination` if nothing matches.
 */
 type MergeDeepRecord<Destination, Source, Key, Options> =
-  Key extends keyof Destination
-    ? Key extends keyof Source
-      ? Destination[Key] extends UnknownRecord
-        ? MergeDeep<Destination[Key], Source[Key], Options>
-        : Source[Key]
-      : Destination[Key]
-    : Key extends keyof Source
-      ? Source[Key]
-      : never;
+	Key extends keyof Destination
+		? Key extends keyof Source
+			? Destination[Key] extends UnknownRecord
+				? MergeDeep<Destination[Key], Source[Key], Options>
+				: Source[Key]
+			: Destination[Key]
+		: Key extends keyof Source
+		? Source[Key]
+		: never;
 
 /**
 Determines the value to be returned according to the type of the `Source` and `Destination`.
@@ -50,11 +50,11 @@ Determines the value to be returned according to the type of the `Source` and `D
 If both are array, returns the result of the merge, otherwise returns the `Source`.
 */
 type MergeDeepArray<Destination, Source, Options> =
-  Destination extends UnknownArray
-    ? Source extends UnknownArray
-      ? ArrayMergeDeep<Destination, Source, Options>
-      : Source
-    : Source;
+	Destination extends UnknownArray
+		? Source extends UnknownArray
+			? ArrayMergeDeep<Destination, Source, Options>
+			: Source
+		: Source;
 
 /**
 Returns the union of the keys of both types.
@@ -68,21 +68,21 @@ If both are mergeable types, returns the result of the merge.
 Otherwise returns the `Source` if present or the `Destination` if nothing matches.
 */
 type MergeDeepValue<
-  Destination,
-  Source,
-  Key extends Keyof<Destination, Source>,
-  Options,
+	Destination,
+	Source,
+	Key extends Keyof<Destination, Source>,
+	Options,
 > = Key extends keyof Source
-  ? Source[Key] extends UnknownRecord
-    ? MergeDeepRecord<Destination, Source, Key, Options>
-    : Source[Key] extends UnknownArray
-			? Key extends keyof Destination
-				? MergeDeepArray<Destination[Key], Source[Key], Options>
-				: Source[Key]
+	? Source[Key] extends UnknownRecord
+		? MergeDeepRecord<Destination, Source, Key, Options>
+		: Source[Key] extends UnknownArray
+		? Key extends keyof Destination
+			? MergeDeepArray<Destination[Key], Source[Key], Options>
 			: Source[Key]
-  : Key extends keyof Destination
-  ? Destination[Key]
-  : never;
+		: Source[Key]
+	: Key extends keyof Destination
+	? Destination[Key]
+	: never;
 
 /**
 Represents an unknown array.
@@ -95,26 +95,26 @@ Determines the value to be returned according to the type of the `Source` and `D
 If both are mergeable records, returns the result of the merge, otherwise returns the `Source`.
 */
 type ArrayMergeDeepValue<Destination, Source, Options> =
-  Destination extends UnknownRecord
-    ? Source extends UnknownRecord
-      ? Unwrap<MergeDeep<Destination, Source, Options>>
-      : Source
-    : Source;
+	Destination extends UnknownRecord
+		? Source extends UnknownRecord
+			? Unwrap<MergeDeep<Destination, Source, Options>>
+			: Source
+		: Source;
 
 /**
 Merge two array recursively into a new array.
 */
 type ArrayMergeDeep<
-  Destination extends UnknownArray,
-  Source extends UnknownArray,
-  Options extends MergeDeepOptions = {strict: true},
+	Destination extends UnknownArray,
+	Source extends UnknownArray,
+	Options extends MergeDeepOptions = {strict: true},
 > = Destination extends []
-  ? Source
-  : Source extends []
-  ? Destination
-  : [
-      ArrayMergeDeepValue<ArrayHead<Destination>, ArrayHead<Source>, Options>,
-      ...ArrayMergeDeep<ArrayTail<Destination>, ArrayTail<Source>>,
+	? Source
+	: Source extends []
+	? Destination
+	: [
+			ArrayMergeDeepValue<ArrayHead<Destination>, ArrayHead<Source>, Options>,
+			...ArrayMergeDeep<ArrayTail<Destination>, ArrayTail<Source>>,
     ];
 
 /**
@@ -123,9 +123,9 @@ Merge two types recursively into a new type.
 Properties set to `undefined` value are **preserved**.
 */
 type MergeDeepLazy<Destination, Source, Options> = {
-  [Key in Keyof<Destination, Source>]: Unwrap<
-    MergeDeepValue<Destination, Source, Key, Options>
-  >;
+	[Key in Keyof<Destination, Source>]: Unwrap<
+		MergeDeepValue<Destination, Source, Key, Options>
+	>;
 };
 
 /**
@@ -134,15 +134,14 @@ Merge two types recursively into a new type.
 Properties set to `undefined` value are **skipped**.
 */
 type MergeDeepStrict<Destination, Source, Options> = ConditionalExcept<
-  MergeDeepLazy<Destination, Source, Options>,
-  undefined
+	MergeDeepLazy<Destination, Source, Options>,
+	undefined
 >;
 
 /**
 Merge two types recursively into a new type.
 
-Properties set to `undefined` value are skipped
-when `strict` option is set to `true` (default).
+Properties set to `undefined` value are skipped when `strict` option is set to `true` (default).
 
 @example
 ```
@@ -174,9 +173,9 @@ type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;
 @category Object
 */
 export type MergeDeep<
-  Destination,
-  Source,
-  Options extends MergeDeepOptions = {strict: true},
+	Destination,
+	Source,
+	Options extends MergeDeepOptions = {strict: true},
 > = Options['strict'] extends true
-  ? MergeDeepStrict<Destination, Source, Options>
-  : MergeDeepLazy<Destination, Source, Options>;
+	? MergeDeepStrict<Destination, Source, Options>
+	: MergeDeepLazy<Destination, Source, Options>;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,0 +1,92 @@
+type MergeDeepOptions = {
+	strict?: boolean;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+type Unwrap<Type> = Type extends UnknownRecord
+	? {[Key in keyof Type]: Type[Key]}
+	: Type;
+
+type MergeValue<Destination, Source, Key, Options> =
+	Key extends keyof Destination
+		? Key extends keyof Source
+			? Destination[Key] extends UnknownRecord
+				? MergeDeep<Destination[Key], Source[Key], Options>
+				: Source[Key]
+			: never
+		: never;
+
+type Keyof<Destination, Source> = keyof Destination | keyof Source;
+
+type GetValue<
+	Destination,
+	Source,
+	Key extends Keyof<Destination, Source>,
+	Options,
+> = Key extends keyof Source
+	? Source[Key] extends UnknownRecord
+		? MergeValue<Destination, Source, Key, Options>
+		: Source[Key]
+	: Key extends keyof Destination
+	? Destination[Key] | null
+	: never;
+
+type ExtractType<TType, TUnion> = {
+	[Key in keyof TType]-?: TUnion extends TType[Key] ? Key : never;
+}[keyof TType];
+
+type OmitType<TType, TUnion> = Omit<TType, ExtractType<TType, TUnion>>;
+
+type MergeDeepLazy<Destination, Source, Options> = {
+	[Key in Keyof<Destination, Source>]: Unwrap<
+		GetValue<Destination, Source, Key, Options>
+	>;
+};
+
+type MergeDeepStrict<Destination, Source, Options> = OmitType<
+	MergeDeepLazy<Destination, Source, Options>,
+	undefined
+>;
+
+/**
+Merge two types recursively into a new type.
+
+Properties set to `undefined` value are skipped when strict is true (true by default).
+
+@example
+```
+type Foo = {foo: string; bar: {id: string; label: string}};
+type Bar = {foo: number; bar: {id: number; nop: undefined}};
+
+Type FooBar = MergeDeep<Foo, Bar>;
+
+// {
+// 	foo: number;
+// 	bar: {
+// 		id: number;
+// 		label: string;
+// 	}
+// }
+
+Type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;
+
+// {
+// 	foo: number;
+// 	bar: {
+// 		id: number;
+// 		label: string;
+//		nop: undefined;
+// 	}
+// }
+```
+
+@category Object
+*/
+export type MergeDeep<
+	Destination,
+	Source,
+	Options extends MergeDeepOptions = {strict: true},
+> = Options['strict'] extends true
+	? MergeDeepStrict<Destination, Source, Options>
+	: MergeDeepLazy<Destination, Source, Options>;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -11,6 +11,12 @@ export interface MergeDeepOptions {
 
 type UnknownRecord = Record<string, unknown>;
 
+/**
+`Unwrap` is like `Simplify` it flatten the type output to improve type hints shown in editors.
+Unfortunately Simplify does not support the case where the type cannot be flattened.
+
+@see Simplify
+*/
 type Unwrap<Type> = Type extends UnknownRecord
   ? {[Key in keyof Type]: Type[Key]}
   : Type;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -2,45 +2,55 @@ import {ConditionalExcept} from './conditional-except';
 import {AnyArray, AnyRecord} from './internal';
 import {Simplify} from './simplify';
 
-/** Test if one of the two types extends the base type. */
+/**
+Test if one of the two types extends the base type.
+*/
 type isOneExtend<BaseType, FirstType, SecondType> = FirstType extends BaseType
-  ? true
-  : SecondType extends BaseType
-  ? true
-  : false;
+	? true
+	: SecondType extends BaseType
+	? true
+	: false;
 
-/** Test if both types extends the base type. */
+/**
+Test if both types extends the base type.
+*/
 type isBothExtend<BaseType, FirstType, SecondType> = FirstType extends BaseType
-  ? SecondType extends BaseType
-  ? true
-  : false
-  : false;
+	? SecondType extends BaseType
+	? true
+	: false
+	: false;
 
 // Some helpers for readability
 type isOneArray<Destination, Source> = isOneExtend<AnyArray, Destination, Source>;
 type isBothArray<Destination, Source> = isBothExtend<AnyArray, Destination, Source>;
 type isBothRecord<Destination, Source> = isBothExtend<AnyRecord, Destination, Source>;
 
-/** Returns the union of the keys of both types. */
+/**
+Returns the union of the keys of both types.
+*/
 type Keyof<Destination, Source> = keyof Destination | keyof Source;
 
-/** Concat two array. */
+/**
+Concat two array.
+*/
 type ConcatArray<Destination, Source> = Destination extends AnyArray
-  ? Source extends AnyArray
-    ? Array<Destination[number] | Source[number]>
-    : never
-  : never;
+	? Source extends AnyArray
+		? Array<Destination[number] | Source[number]>
+		: never
+	: never;
 
-/** Merge two arrays. */
+/**
+Merge two arrays.
+*/
 type MergeArray<Destination, Source, Options extends MergeDeepOptions> =
-  Destination extends []
-  ? Source // Destination is an empty array, return the source
-  : Source extends []
-  ? Destination // Source is an empty array, return the destination
-  : Options['recurseIntoArrays'] extends true
-  ? ConcatArray<Destination, Source> // Concat the two array
-  // Return the source
-  : Source;
+	Destination extends []
+	? Source // Destination is an empty array, return the source
+	: Source extends []
+	? Destination // Source is an empty array, return the destination
+	: Options['recurseIntoArrays'] extends true
+	? ConcatArray<Destination, Source> // Concat the two array
+	// Return the source
+	: Source;
 
 /**
 Walk through the union of the keys of the two objects and test in which object the properties are defined.
@@ -51,36 +61,40 @@ Walk through the union of the keys of the two objects and test in which object t
 */
 type DoMergeRecord<Destination, Source, Options extends MergeDeepOptions> = {
 	[Key in Keyof<Destination, Source>]:
-    Key extends keyof Source
-    // Source found, check for destination
-    ? Key extends keyof Destination
-    // Both source and destination exists
-    ? MergeDeepOrReturn<Source[Key], Destination[Key], Source[Key], Options>
-    // Only the source exists
-    : Source[Key]
-    // No source, take the destination (this test is useless, but make TS happy, It can never be never)
-    : Key extends keyof Destination ? Destination[Key] : never;
+		Key extends keyof Source
+		// Source found, check for destination
+		? Key extends keyof Destination
+		// Both source and destination exists
+		? MergeDeepOrReturn<Source[Key], Destination[Key], Source[Key], Options>
+		// Only the source exists
+		: Source[Key]
+		// No source, take the destination (this test is useless, but make TS happy, It can never be never)
+		: Key extends keyof Destination ? Destination[Key] : never;
 };
 
-/** Wrapper around `DoMergeRecord` which defines whether or not to keep undefined values. */
+/**
+Wrapper around `DoMergeRecord` which defines whether or not to keep undefined values.
+*/
 type MergeRecord<Destination, Source, Options extends MergeDeepOptions> = Simplify<
-  Options['stripUndefinedValues'] extends true
-    ? ConditionalExcept<DoMergeRecord<Destination, Source, Options>, undefined>
-    : DoMergeRecord<Destination, Source, Options>>;
+	Options['stripUndefinedValues'] extends true
+		? ConditionalExcept<DoMergeRecord<Destination, Source, Options>, undefined>
+		: DoMergeRecord<Destination, Source, Options>>;
 
-/** Try to merge two types recursively into a new type or return the default value. */
+/**
+Try to merge two types recursively into a new type or return the default value.
+*/
 export type MergeDeepOrReturn<
-  DefaultValue,
-  Destination,
-  Source,
-  Options extends MergeDeepOptions,
+	DefaultValue,
+	Destination,
+	Source,
+	Options extends MergeDeepOptions,
 > = isBothArray<Destination, Source> extends true
-    ? MergeArray<Destination, Source, Options>
-    : isOneArray<Destination, Source> extends true
-    ? DefaultValue // Only one array is forbidden
-    : isBothRecord<Destination, Source> extends true
-    ? MergeRecord<Destination, Source, Options>
-    : DefaultValue; // The two base types are not identical
+		? MergeArray<Destination, Source, Options>
+		: isOneArray<Destination, Source> extends true
+		? DefaultValue // Only one array is forbidden
+		: isBothRecord<Destination, Source> extends true
+		? MergeRecord<Destination, Source, Options>
+		: DefaultValue; // The two base types are not identical
 
 /**
 MergeDeep options.
@@ -88,37 +102,37 @@ MergeDeep options.
 @see MergeDeep
 */
 export interface MergeDeepOptions {
-  /**
-	Should recurse into arrays.
+	/**
+	Whether `MergeDeep` should recurse into arrays.
 
-  - When set to `false` arrays are not supported as input and all properties that contain arrays will be replaced from source to destination.
-  - When set to `true` all arrays are concatenated recursively.
+	- When set to `false`, arrays are not supported as input and all properties that contain arrays will be replaced from source to destination.
+	- When set to `true`, all arrays are concatenated recursively.
 
-  @default false
+	@default false
 
-  @example
-  ```
-  type Merged = MergeDeep<[], []>;
-  // never
-
-  type Merged = MergeDeep<[], [], {recurseIntoArrays: true}>;
-  // []
-
-  type Merged = MergeDeep<{items: [1,2,3]}, {items: [4,5,6]}>;
-  // {items: [4,5,6]}
-
-  type Merged = MergeDeep<{items: [1,2,3]}, {items: [4,5,6]}, {recurseIntoArrays: true}>;
-  // {items: [1,2,3,4,5,6]}
+	@example
 	```
-  */
+	type Merged = MergeDeep<[], []>;
+	// never
+
+	type Merged = MergeDeep<[], [], {recurseIntoArrays: true}>;
+	// []
+
+	type Merged = MergeDeep<{items: [1,2,3]}, {items: [4,5,6]}>;
+	// {items: [4,5,6]}
+
+	type Merged = MergeDeep<{items: [1,2,3]}, {items: [4,5,6]}, {recurseIntoArrays: true}>;
+	// {items: [1,2,3,4,5,6]}
+	```
+	*/
 	recurseIntoArrays?: boolean;
 
-  /**
-  Should strip undefined values from the resulting type.
+	/**
+	Strip `undefined` values from the resulting type.
 
-  @default false
-  */
-  stripUndefinedValues?: boolean;
+	@default false
+	*/
+	stripUndefinedValues?: boolean;
 }
 
 /**
@@ -128,15 +142,18 @@ Merge two types recursively into a new type.
 
 @example
 ```
-MergeDeep<[], []>; // never
-MergeDeep<[], [], {recurseIntoArrays: true}>; // []
+MergeDeep<[], []>;
+//=> never
+
+MergeDeep<[], [], {recurseIntoArrays: true}>;
+//=> []
 ```
 
 @category Object
 @category Array
 */
 export type MergeDeep<
-  Destination,
-  Source,
-  Options extends MergeDeepOptions = {},
+	Destination,
+	Source,
+	Options extends MergeDeepOptions = {},
 > = MergeDeepOrReturn<never, Destination, Source, Options>;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -91,7 +91,7 @@ type ArrayMerge<
     ];
 
 /**
-MergE two types recursively into a new type.
+Merge two types recursively into a new type.
 
 Properties set to `undefined` value are skipped
 when `strict` option is set to `true` (default).

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -14,8 +14,8 @@ type MergeValue<Destination, Source, Key, Options> =
       ? Destination[Key] extends UnknownRecord
         ? MergeDeep<Destination[Key], Source[Key], Options>
         : Source[Key]
-      : never
-    : never;
+      : Destination[Key]
+    : Source[Key];
 
 type Keyof<Destination, Source> = keyof Destination | keyof Source;
 
@@ -91,7 +91,7 @@ type ArrayMerge<
     ];
 
 /**
-Merge two types recursively into a new type.
+MergE two types recursively into a new type.
 
 Properties set to `undefined` value are skipped
 when `strict` option is set to `true` (default).

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -101,7 +101,7 @@ when `strict` option is set to `true` (default).
 type Foo = {foo: string; bar: {id: string; label: string}};
 type Bar = {foo: number; bar: {id: number; nop: undefined}};
 
-Type FooBar = MergeDeep<Foo, Bar>;
+type FooBar = MergeDeep<Foo, Bar>;
 
 // {
 // 	foo: number;
@@ -111,7 +111,7 @@ Type FooBar = MergeDeep<Foo, Bar>;
 // 	}
 // }
 
-Type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;
+type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;
 
 // {
 // 	foo: number;

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,15 +1,6 @@
 import {ConditionalExcept} from './conditional-except';
 import {AnyArray, AnyRecord} from './internal';
-
-/**
-Replace by `Simplify` once the folowing PR is merged
-@link https://github.com/sindresorhus/type-fest/pull/414
-*/
-type Unwrap<Type> = Type extends AnyRecord
-	? {[Key in keyof Type]: Type[Key]}
-	: Type;
-
-// Private types
+import {Simplify} from './simplify';
 
 /** Test if one of the two types extends the base type. */
 type isOneExtend<BaseType, FirstType, SecondType> = FirstType extends BaseType
@@ -72,7 +63,7 @@ type DoMergeRecord<Destination, Source, Options extends MergeDeepOptions> = {
 };
 
 /** Wrapper around `DoMergeRecord` which defines whether or not to keep undefined values. */
-type MergeRecord<Destination, Source, Options extends MergeDeepOptions> = Unwrap<
+type MergeRecord<Destination, Source, Options extends MergeDeepOptions> = Simplify<
   Options['stripUndefinedValues'] extends true
     ? ConditionalExcept<DoMergeRecord<Destination, Source, Options>, undefined>
     : DoMergeRecord<Destination, Source, Options>>;
@@ -98,8 +89,6 @@ export type MergeDeepOrReturn<
   : isBothRecord<Destination, Source> extends true
   ? MergeRecord<Destination, Source, Options>
   : DefaultValue; // The two base types are not identical
-
-// Public types
 
 /**
 MergeDeep options.

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -74,21 +74,13 @@ export type MergeDeepOrReturn<
   Destination,
   Source,
   Options extends MergeDeepOptions,
-> = Options['recurseIntoArrays'] extends true
-  // Branch: recurseIntoArrays = true
-  ? isBothArray<Destination, Source> extends true
+> = isBothArray<Destination, Source> extends true
     ? MergeArray<Destination, Source, Options>
     : isOneArray<Destination, Source> extends true
     ? DefaultValue // Only one array is forbidden
     : isBothRecord<Destination, Source> extends true
     ? MergeRecord<Destination, Source, Options>
-    : DefaultValue // The two base types are not identical
-  // Branch: recurseIntoArrays = false
-  : isOneArray<Destination, Source> extends true
-  ? DefaultValue // Array are forbidden
-  : isBothRecord<Destination, Source> extends true
-  ? MergeRecord<Destination, Source, Options>
-  : DefaultValue; // The two base types are not identical
+    : DefaultValue; // The two base types are not identical
 
 /**
 MergeDeep options.
@@ -131,8 +123,6 @@ export interface MergeDeepOptions {
 
 /**
 Merge two types recursively into a new type.
-
-By default arrays are not supported, you have to explicitly enable it with the `recurseIntoArrays` option if you want it.
 
 @see MergeDeepOptions
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -33,8 +33,23 @@ type isBothRecord<Destination, Source> = isBothExtend<AnyRecord, Destination, So
 /** Returns the union of the keys of both types. */
 type Keyof<Destination, Source> = keyof Destination | keyof Source;
 
-/** Merge two arrays... */
-type MergeArray<Destination, Source> = [Destination, Source];
+/** Concat two array. */
+type ConcatArray<Destination, Source> = Destination extends AnyArray
+  ? Source extends AnyArray
+    ? Array<Destination[number] | Source[number]>
+    : never
+  : never;
+
+/** Merge two arrays. */
+type MergeArray<Destination, Source, Options extends MergeDeepOptions> =
+  Destination extends []
+  ? Source // Destination is an empty array, return the source
+  : Source extends []
+  ? Destination // Source is an empty array, return the destination
+  : Options['recurseIntoArrays'] extends true
+  ? ConcatArray<Destination, Source> // Concat the two array
+  // Return the source
+  : Source;
 
 /**
 Walk through the union of the keys of the two objects and test in which object the properties are defined.
@@ -71,7 +86,7 @@ export type MergeDeepOrReturn<
 > = Options['recurseIntoArrays'] extends true
   // Branch: recurseIntoArrays = true
   ? isBothArray<Destination, Source> extends true
-    ? MergeArray<Destination, Source>
+    ? MergeArray<Destination, Source, Options>
     : isOneArray<Destination, Source> extends true
     ? DefaultValue // Only one array is forbidden
     : isBothRecord<Destination, Source> extends true

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -15,7 +15,9 @@ type MergeValue<Destination, Source, Key, Options> =
         ? MergeDeep<Destination[Key], Source[Key], Options>
         : Source[Key]
       : Destination[Key]
-    : Source[Key];
+    : Key extends keyof Source
+      ? Source[Key]
+      : never;
 
 type Keyof<Destination, Source> = keyof Destination | keyof Source;
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,4 +1,5 @@
 import {ConditionalExcept} from './conditional-except';
+import {ArrayHead, ArrayTail} from './internal';
 
 /**
 MergeDeep options.
@@ -70,14 +71,6 @@ type MergeDeepStrict<Destination, Source, Options> = ConditionalExcept<
   MergeDeepLazy<Destination, Source, Options>,
   undefined
 >;
-
-type ArrayHead<TArray> = TArray extends readonly [infer THead, ...unknown[]]
-  ? THead
-  : never;
-
-type ArrayTail<TArray> = TArray extends readonly [unknown, ...infer TTail]
-  ? TTail
-  : [];
 
 type UnknownArray = readonly unknown[];
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -1,5 +1,5 @@
 import {ConditionalExcept} from './conditional-except';
-import {ArrayHead, ArrayTail} from './internal';
+import {FirstArrayElement, ArrayTail} from './internal';
 
 /**
 MergeDeep options.
@@ -113,7 +113,7 @@ type ArrayMergeDeep<
 	: Source extends []
 	? Destination
 	: [
-			ArrayMergeDeepValue<ArrayHead<Destination>, ArrayHead<Source>, Options>,
+			ArrayMergeDeepValue<FirstArrayElement <Destination>, FirstArrayElement <Source>, Options>,
 			...ArrayMergeDeep<ArrayTail<Destination>, ArrayTail<Source>>,
     ];
 

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -112,23 +112,39 @@ type FooBar13 = MergeDeep<Foo12, Bar12, {strict: false}>;
 
 expectAssignable<FooBar13>({foo: 42, bar: true, baz: undefined});
 
-type Foo14 = {'a': [number, {'b': number}, {'d': number}]};
-type Bar14 = {'a': [string, {'c': number}, {'e': number; d: string}]};
+type Foo14 = {name: 'nyan'; level1: {plop: 42}};
+type Bar14 = {level1: {level2: {level3: 42}}};
 
 type FooBar14 = MergeDeep<Foo14, Bar14>;
 
-expectAssignable<FooBar14>({a: ['42', {b: 2, c: 3}, {d: '4', e: 5}]});
+expectAssignable<FooBar14>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
 
-type Foo15 = {name: 'nyan'; level1: {plop: 42}};
-type Bar15 = {level1: {level2: {level3: 42}}};
+type Foo15 = {level1: {level2: {level3: 42}}};
+type Bar15 = {name: 'nyan'; level1: {plop: 42}};
 
 type FooBar15 = MergeDeep<Foo15, Bar15>;
 
 expectAssignable<FooBar15>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
 
-type Foo16 = {level1: {level2: {level3: 42}}};
-type Bar16 = {name: 'nyan'; level1: {plop: 42}};
+// Array
+
+type Foo16 = {'a': [number, {'b': number}, {'d': number}]};
+type Bar16 = {'a': [string, {'c': number}, {'e': number; d: string}]};
 
 type FooBar16 = MergeDeep<Foo16, Bar16>;
 
-expectAssignable<FooBar16>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
+expectAssignable<FooBar16>({a: ['42', {b: 2, c: 3}, {d: '4', e: 5}]});
+
+type Foo17 = [number, {'b': number}, {'d': number}];
+type Bar17 = [string, {'c': number}, {'e': number; d: string}];
+
+type FooBar17 = MergeDeep<Foo17, Bar17>;
+
+expectAssignable<FooBar17>(['42', {b: 2, c: 3}, {d: '4', e: 5}]);
+
+type Foo18 = {'a': [number, {'b': number}, {'d': {life: string}}]};
+type Bar18 = {'a': [string, {'c': number}, {'d': {life: number}}]};
+
+type FooBar18 = MergeDeep<Foo18, Bar18>;
+
+expectAssignable<FooBar18>({a: ['42', {b: 2, c: 3}, {d: {life: 42}}]});

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -3,101 +3,101 @@ import {MergeDeep} from '../index';
 
 // Test MergeDeep inputs
 
-declare const sign1: MergeDeep<{}, {}>; // {}
-declare const sign2: MergeDeep<[], []>; // Never
+declare const signature1: MergeDeep<{}, {}>; // {}
+declare const signature2: MergeDeep<[], []>; // Never
 
-expectNotType<never>(sign1);
-expectType<never>(sign2);
+expectNotType<never>(signature1);
+expectType<never>(signature2);
 
-declare const sign3: MergeDeep<{}, []>; // Never
-declare const sign4: MergeDeep<[], {}>; // Never
+declare const signature3: MergeDeep<{}, []>; // Never
+declare const signature4: MergeDeep<[], {}>; // Never
 
-expectType<never>(sign3);
-expectType<never>(sign4);
+expectType<never>(signature3);
+expectType<never>(signature4);
 
-declare const sign5: MergeDeep<42, {}>; // Never
-declare const sign6: MergeDeep<42, []>; // Never
+declare const signature5: MergeDeep<42, {}>; // Never
+declare const signature6: MergeDeep<42, []>; // Never
 
-expectType<never>(sign5);
-expectType<never>(sign6);
+expectType<never>(signature5);
+expectType<never>(signature6);
 
-declare const sign7: MergeDeep<{}, 42>; // Never
-declare const sign8: MergeDeep<[], 42>; // Never
+declare const signature7: MergeDeep<{}, 42>; // Never
+declare const signature8: MergeDeep<[], 42>; // Never
 
-expectType<never>(sign7);
-expectType<never>(sign8);
+expectType<never>(signature7);
+expectType<never>(signature8);
 
-declare const sign9: MergeDeep<{}, {}, {recurseIntoArrays: true}>; // {}
-declare const sign10: MergeDeep<[], [], {recurseIntoArrays: true}>; // []
+declare const signature9: MergeDeep<{}, {}, {recurseIntoArrays: true}>; // {}
+declare const signature10: MergeDeep<[], [], {recurseIntoArrays: true}>; // []
 
-expectNotType<never>(sign9);
-expectNotType<never>(sign10);
+expectNotType<never>(signature9);
+expectNotType<never>(signature10);
 
-declare const sign11: MergeDeep<{}, [], {recurseIntoArrays: true}>; // Never
-declare const sign12: MergeDeep<[], {}, {recurseIntoArrays: true}>; // Never
+declare const signature11: MergeDeep<{}, [], {recurseIntoArrays: true}>; // Never
+declare const signature12: MergeDeep<[], {}, {recurseIntoArrays: true}>; // Never
 
-expectType<never>(sign11);
-expectType<never>(sign12);
+expectType<never>(signature11);
+expectType<never>(signature12);
 
-declare const sign13: MergeDeep<42, {}, {recurseIntoArrays: true}>; // Never
-declare const sign14: MergeDeep<42, [], {recurseIntoArrays: true}>; // Never
+declare const signature13: MergeDeep<42, {}, {recurseIntoArrays: true}>; // Never
+declare const signature14: MergeDeep<42, [], {recurseIntoArrays: true}>; // Never
 
-expectType<never>(sign13);
-expectType<never>(sign14);
+expectType<never>(signature13);
+expectType<never>(signature14);
 
-declare const sign15: MergeDeep<{}, 42, {recurseIntoArrays: true}>; // Never
-declare const sign16: MergeDeep<[], 42, {recurseIntoArrays: true}>; // Never
+declare const signature15: MergeDeep<{}, 42, {recurseIntoArrays: true}>; // Never
+declare const signature16: MergeDeep<[], 42, {recurseIntoArrays: true}>; // Never
 
-expectType<never>(sign15);
-expectType<never>(sign16);
+expectType<never>(signature15);
+expectType<never>(signature16);
 
 // Test flat plain object
 
-const src1 = {life: 42, name: 'nyan', a: undefined};
-const dest1 = {life: '24', fly: true, b: undefined};
-const merge1 = {...dest1, ...src1};
+const source1 = {life: 42, name: 'nyan', a: undefined};
+const destination1 = {life: '24', fly: true, b: undefined};
+const merge1 = {...destination1, ...source1};
 
-expectType<MergeDeep<typeof dest1, typeof src1>>(merge1);
+expectType<MergeDeep<typeof destination1, typeof source1>>(merge1);
 
 // Test deep plain object
 
-const src2 = {a: 'a', b: src1, c: {d: src1}};
-const dest2 = {a: 'z', b: dest1, c: {d: dest1}};
+const source2 = {a: 'a', b: source1, c: {d: source1}};
+const destination2 = {a: 'z', b: destination1, c: {d: destination1}};
 const merge2 = {a: 'a', b: merge1, c: {d: merge1}};
 
-expectType<MergeDeep<typeof dest2, typeof src2>>(merge2);
+expectType<MergeDeep<typeof destination2, typeof source2>>(merge2);
 
 // Undefied properties must be preserved
 
-const src3 = {a: 'a', c: undefined, e: 42, f: undefined};
-const dest3 = {b: 'b', d: undefined, e: undefined, f: 42};
+const source3 = {a: 'a', c: undefined, e: 42, f: undefined};
+const destination3 = {b: 'b', d: undefined, e: undefined, f: 42};
 
 const merge3 = {a: 'a', b: 'b', c: undefined, d: undefined, e: 42, f: undefined};
-declare const type3: MergeDeep<typeof dest3, typeof src3>;
+declare const type3: MergeDeep<typeof destination3, typeof source3>;
 
 expectType<typeof merge3>(type3);
 
 // Undefied properties must be skipped
 
 const merge4 = {a: 'a', b: 'b', e: 42};
-declare const type4: MergeDeep<typeof dest3, typeof src3, {stripUndefinedValues: true}>;
+declare const type4: MergeDeep<typeof destination3, typeof source3, {stripUndefinedValues: true}>;
 
 expectType<typeof merge4>(type4);
 
 // Should replace arrays
 
-const src5 = {a: 'a', items: ['4', '5', '6']};
-const dest5 = {b: 'b', items: [1, 2, 3]};
+const source5 = {a: 'a', items: ['4', '5', '6']};
+const destination5 = {b: 'b', items: [1, 2, 3]};
 
 const merge5 = {a: 'a', b: 'b', items: ['4', '5', '6']};
-declare const prout5: MergeDeep<typeof dest5, typeof src5>;
+declare const prout5: MergeDeep<typeof destination5, typeof source5>;
 
 expectType<typeof merge5>(prout5);
 
 // Should concat arrays
 
 const merge6 = {a: 'a', b: 'b', items: [1, 2, 3, '4', '5', '6']};
-declare const prout6: MergeDeep<typeof dest5, typeof src5, {recurseIntoArrays: true}>;
+declare const prout6: MergeDeep<typeof destination5, typeof source5, {recurseIntoArrays: true}>;
 
 expectType<typeof merge6>(prout6);
 

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -1,4 +1,4 @@
-import {expectNotType, expectType} from 'tsd';
+import {expectAssignable, expectNotType, expectType} from 'tsd';
 import {MergeDeep} from '../index';
 
 // Test MergeDeep inputs
@@ -73,13 +73,106 @@ const src3 = {a: 'a', c: undefined, e: 42, f: undefined};
 const dest3 = {b: 'b', d: undefined, e: undefined, f: 42};
 
 const merge3 = {a: 'a', b: 'b', c: undefined, d: undefined, e: 42, f: undefined};
-declare const prout3: MergeDeep<typeof dest3, typeof src3>;
+declare const type3: MergeDeep<typeof dest3, typeof src3>;
 
-expectType<typeof merge3>(prout3);
+expectType<typeof merge3>(type3);
 
 // Undefied properties must be skipped
 
 const merge4 = {a: 'a', b: 'b', e: 42};
-declare const prout4: MergeDeep<typeof dest3, typeof src3, {stripUndefinedValues: true}>;
+declare const type4: MergeDeep<typeof dest3, typeof src3, {stripUndefinedValues: true}>;
 
-expectType<typeof merge4>(prout4);
+expectType<typeof merge4>(type4);
+
+// Should replace arrays
+
+const src5 = {a: 'a', items: ['4', '5', '6']};
+const dest5 = {b: 'b', items: [1, 2, 3]};
+
+const merge5 = {a: 'a', b: 'b', items: ['4', '5', '6']};
+declare const prout5: MergeDeep<typeof dest5, typeof src5>;
+
+expectType<typeof merge5>(prout5);
+
+// Should concat arrays
+
+const merge6 = {a: 'a', b: 'b', items: [1, 2, 3, '4', '5', '6']};
+declare const prout6: MergeDeep<typeof dest5, typeof src5, {recurseIntoArrays: true}>;
+
+expectType<typeof merge6>(prout6);
+
+// Test deep object with arrays ans undefined values
+
+type Foo1 = {
+	l0: string;
+	a: string;
+	b: {
+		skipped: undefined;
+		l1: string;
+		x: string;
+		y: {
+			l2: string;
+			u: string;
+			v: string;
+      items: string[];
+		};
+	};
+	q: Date;
+};
+
+type Bar1 = {
+	new: number;
+	a: number;
+	b: {
+		x: number;
+		y: {
+			u: number;
+			v: number;
+			skipped: undefined;
+      items: number[];
+		};
+	};
+	q: {life: 42};
+	skipped: undefined;
+};
+
+expectAssignable<MergeDeep<Foo1, Bar1>>({
+	l0: 'string',
+	a: 42,
+	b: {
+    skipped: undefined,
+    l1: 'string',
+		x: 42,
+		y: {
+			l2: 'string',
+			u: 42,
+			v: 42,
+			skipped: undefined,
+      items: [1, 2, 3],
+		},
+	},
+	q: {
+		life: 42,
+	},
+  skipped: undefined,
+	new: 42,
+});
+
+expectAssignable<MergeDeep<Foo1, Bar1, {stripUndefinedValues: true; recurseIntoArrays: true}>>({
+	l0: 'string',
+	a: 42,
+	b: {
+		l1: 'string',
+		x: 42,
+		y: {
+			l2: 'string',
+			u: 42,
+			v: 42,
+      items: [1, 2, 3, 'a', 'b', 'c'],
+		},
+	},
+	q: {
+		life: 42,
+	},
+	new: 42,
+});

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -66,3 +66,20 @@ const dest2 = {a: 'z', b: dest1, c: {d: dest1}};
 const merge2 = {a: 'a', b: merge1, c: {d: merge1}};
 
 expectType<MergeDeep<typeof dest2, typeof src2>>(merge2);
+
+// Undefied properties must be preserved
+
+const src3 = {a: 'a', c: undefined, e: 42, f: undefined};
+const dest3 = {b: 'b', d: undefined, e: undefined, f: 42};
+
+const merge3 = {a: 'a', b: 'b', c: undefined, d: undefined, e: 42, f: undefined};
+declare const prout3: MergeDeep<typeof dest3, typeof src3>;
+
+expectType<typeof merge3>(prout3);
+
+// Undefied properties must be skipped
+
+const merge4 = {a: 'a', b: 'b', e: 42};
+declare const prout4: MergeDeep<typeof dest3, typeof src3, {stripUndefinedValues: true}>;
+
+expectType<typeof merge4>(prout4);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -118,3 +118,17 @@ type Bar14 = {'a': [string, {'c': number}, {'e': number; d: string}]};
 type FooBar14 = MergeDeep<Foo14, Bar14>;
 
 expectAssignable<FooBar14>({a: ['42', {b: 2, c: 3}, {d: '4', e: 5}]});
+
+type Foo15 = {name: 'nyan'; level1: {plop: 42}};
+type Bar15 = {level1: {level2: {level3: 42}}};
+
+type FooBar15 = MergeDeep<Foo15, Bar15>;
+
+expectAssignable<FooBar15>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
+
+type Foo16 = {level1: {level2: {level3: 42}}};
+type Bar16 = {name: 'nyan'; level1: {plop: 42}};
+
+type FooBar16 = MergeDeep<Foo16, Bar16>;
+
+expectAssignable<FooBar16>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -50,3 +50,19 @@ declare const sign16: MergeDeep<[], 42, {recurseIntoArrays: true}>; // Never
 
 expectType<never>(sign15);
 expectType<never>(sign16);
+
+// Test flat plain object
+
+const src1 = {life: 42, name: 'nyan', a: undefined};
+const dest1 = {life: '24', fly: true, b: undefined};
+const merge1 = {...dest1, ...src1};
+
+expectType<MergeDeep<typeof dest1, typeof src1>>(merge1);
+
+// Test deep plain object
+
+const src2 = {a: 'a', b: src1, c: {d: src1}};
+const dest2 = {a: 'z', b: dest1, c: {d: dest1}};
+const merge2 = {a: 'a', b: merge1, c: {d: merge1}};
+
+expectType<MergeDeep<typeof dest2, typeof src2>>(merge2);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -7,7 +7,7 @@ declare const signature1: MergeDeep<{}, {}>; // {}
 declare const signature2: MergeDeep<[], []>; // Never
 
 expectNotType<never>(signature1);
-expectType<never>(signature2);
+expectNotType<never>(signature2);
 
 declare const signature3: MergeDeep<{}, []>; // Never
 declare const signature4: MergeDeep<[], {}>; // Never

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -1,0 +1,113 @@
+import {expectAssignable} from 'tsd';
+import {MergeDeep} from '../index';
+
+type Foo1 = {foo: string};
+type Bar1 = {foo: number};
+
+expectAssignable<MergeDeep<Foo1, Bar1>>({foo: 42});
+
+type Foo2 = {foo: string; life: string};
+type Bar2 = {foo: number};
+
+expectAssignable<MergeDeep<Foo2, Bar2>>({foo: 42, life: '42'});
+
+type Foo3 = {foo: string};
+type Bar3 = {foo: number; life: number};
+
+expectAssignable<MergeDeep<Foo3, Bar3>>({foo: 42, life: 42});
+
+type Foo4 = {foo: string; bar: undefined};
+type Bar4 = {foo: number};
+
+expectAssignable<MergeDeep<Foo4, Bar4>>({foo: 42});
+
+type Foo5 = {foo: string};
+type Bar5 = {foo: number; bar: undefined};
+
+expectAssignable<MergeDeep<Foo5, Bar5>>({foo: 42});
+
+type Foo6 = {foo: string; bar: {id: string}};
+type Bar6 = {foo: number; bar: {id: number}};
+
+expectAssignable<MergeDeep<Foo6, Bar6>>({foo: 42, bar: {id: 42}});
+
+type Foo7 = {foo: string; bar: {id: string; label: string}};
+type Bar7 = {foo: number; bar: {id: number}};
+
+expectAssignable<MergeDeep<Foo7, Bar7>>({foo: 42, bar: {id: 42, label: 'life'}});
+
+type Foo8 = {foo: string; bar: {id: string}};
+type Bar8 = {foo: number; bar: {id: number; label: string}};
+
+expectAssignable<MergeDeep<Foo8, Bar8>>({foo: 42, bar: {id: 42, label: 'life'}});
+
+type Foo9 = {foo: string; bar: {id: string; label: string}};
+type Bar9 = {foo: number; bar: {id: number; label: undefined}};
+
+expectAssignable<MergeDeep<Foo9, Bar9>>({foo: 42, bar: {id: 42}});
+expectAssignable<MergeDeep<Foo9, Bar9, {strict: false}>>({foo: 42, bar: {id: 42, label: undefined}});
+
+type Foo10 = {foo: string; bar: {id: string; data: {x: number}}};
+type Bar10 = {foo: number; bar: {id: number; data: {y: number}}};
+
+expectAssignable<MergeDeep<Foo10, Bar10>>({foo: 42, bar: {id: 42, data: {x: 1, y: 2}}});
+
+type Foo11 = {
+	l0: string;
+	a: string;
+	b: {
+		skipped: undefined;
+		l1: string;
+		x: string;
+		y: {
+			l2: string;
+			u: string;
+			v: string;
+		};
+	};
+	q: Date;
+};
+
+type Bar11 = {
+	new: number;
+	a: number;
+	b: {
+		x: number;
+		y: {
+			u: number;
+			v: number;
+			skipped: undefined;
+		};
+	};
+	q: {life: 42};
+	skipped: undefined;
+};
+
+expectAssignable<MergeDeep<Foo11, Bar11>>({
+	l0: 'string',
+	a: 42,
+	b: {
+		l1: 'string',
+		x: 42,
+		y: {
+			l2: 'string',
+			u: 42,
+			v: 42,
+		},
+	},
+	q: {
+		life: 42,
+	},
+	new: 42,
+});
+
+type Foo12 = {foo: false; bar: undefined; baz: boolean};
+type Bar12 = {foo: number; bar: true; baz: undefined};
+
+type FooBar12 = MergeDeep<Foo12, Bar12>;
+
+expectAssignable<FooBar12>({foo: 42, bar: true});
+
+type FooBar13 = MergeDeep<Foo12, Bar12, {strict: false}>;
+
+expectAssignable<FooBar13>({foo: 42, bar: true, baz: undefined});

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -1,150 +1,52 @@
-import {expectAssignable} from 'tsd';
+import {expectNotType, expectType} from 'tsd';
 import {MergeDeep} from '../index';
 
-type Foo1 = {foo: string};
-type Bar1 = {foo: number};
+// Test MergeDeep inputs
 
-expectAssignable<MergeDeep<Foo1, Bar1>>({foo: 42});
+declare const sign1: MergeDeep<{}, {}>; // {}
+declare const sign2: MergeDeep<[], []>; // Never
 
-type Foo2 = {foo: string; life: string};
-type Bar2 = {foo: number};
+expectNotType<never>(sign1);
+expectType<never>(sign2);
 
-expectAssignable<MergeDeep<Foo2, Bar2>>({foo: 42, life: '42'});
+declare const sign3: MergeDeep<{}, []>; // Never
+declare const sign4: MergeDeep<[], {}>; // Never
 
-type Foo3 = {foo: string};
-type Bar3 = {foo: number; life: number};
+expectType<never>(sign3);
+expectType<never>(sign4);
 
-expectAssignable<MergeDeep<Foo3, Bar3>>({foo: 42, life: 42});
+declare const sign5: MergeDeep<42, {}>; // Never
+declare const sign6: MergeDeep<42, []>; // Never
 
-type Foo4 = {foo: string; bar: undefined};
-type Bar4 = {foo: number};
+expectType<never>(sign5);
+expectType<never>(sign6);
 
-expectAssignable<MergeDeep<Foo4, Bar4>>({foo: 42});
+declare const sign7: MergeDeep<{}, 42>; // Never
+declare const sign8: MergeDeep<[], 42>; // Never
 
-type Foo5 = {foo: string};
-type Bar5 = {foo: number; bar: undefined};
+expectType<never>(sign7);
+expectType<never>(sign8);
 
-expectAssignable<MergeDeep<Foo5, Bar5>>({foo: 42});
+declare const sign9: MergeDeep<{}, {}, {recurseIntoArrays: true}>; // {}
+declare const sign10: MergeDeep<[], [], {recurseIntoArrays: true}>; // []
 
-type Foo6 = {foo: string; bar: {id: string}};
-type Bar6 = {foo: number; bar: {id: number}};
+expectNotType<never>(sign9);
+expectNotType<never>(sign10);
 
-expectAssignable<MergeDeep<Foo6, Bar6>>({foo: 42, bar: {id: 42}});
+declare const sign11: MergeDeep<{}, [], {recurseIntoArrays: true}>; // Never
+declare const sign12: MergeDeep<[], {}, {recurseIntoArrays: true}>; // Never
 
-type Foo7 = {foo: string; bar: {id: string; label: string}};
-type Bar7 = {foo: number; bar: {id: number}};
+expectType<never>(sign11);
+expectType<never>(sign12);
 
-expectAssignable<MergeDeep<Foo7, Bar7>>({foo: 42, bar: {id: 42, label: 'life'}});
+declare const sign13: MergeDeep<42, {}, {recurseIntoArrays: true}>; // Never
+declare const sign14: MergeDeep<42, [], {recurseIntoArrays: true}>; // Never
 
-type Foo8 = {foo: string; bar: {id: string}};
-type Bar8 = {foo: number; bar: {id: number; label: string}};
+expectType<never>(sign13);
+expectType<never>(sign14);
 
-expectAssignable<MergeDeep<Foo8, Bar8>>({foo: 42, bar: {id: 42, label: 'life'}});
+declare const sign15: MergeDeep<{}, 42, {recurseIntoArrays: true}>; // Never
+declare const sign16: MergeDeep<[], 42, {recurseIntoArrays: true}>; // Never
 
-type Foo9 = {foo: string; bar: {id: string; label: string}};
-type Bar9 = {foo: number; bar: {id: number; label: undefined}};
-
-expectAssignable<MergeDeep<Foo9, Bar9>>({foo: 42, bar: {id: 42}});
-expectAssignable<MergeDeep<Foo9, Bar9, {strict: false}>>({foo: 42, bar: {id: 42, label: undefined}});
-
-type Foo10 = {foo: string; bar: {id: string; data: {x: number}}};
-type Bar10 = {foo: number; bar: {id: number; data: {y: number}}};
-
-expectAssignable<MergeDeep<Foo10, Bar10>>({foo: 42, bar: {id: 42, data: {x: 1, y: 2}}});
-
-type Foo11 = {
-	l0: string;
-	a: string;
-	b: {
-		skipped: undefined;
-		l1: string;
-		x: string;
-		y: {
-			l2: string;
-			u: string;
-			v: string;
-		};
-	};
-	q: Date;
-};
-
-type Bar11 = {
-	new: number;
-	a: number;
-	b: {
-		x: number;
-		y: {
-			u: number;
-			v: number;
-			skipped: undefined;
-		};
-	};
-	q: {life: 42};
-	skipped: undefined;
-};
-
-expectAssignable<MergeDeep<Foo11, Bar11>>({
-	l0: 'string',
-	a: 42,
-	b: {
-		l1: 'string',
-		x: 42,
-		y: {
-			l2: 'string',
-			u: 42,
-			v: 42,
-		},
-	},
-	q: {
-		life: 42,
-	},
-	new: 42,
-});
-
-type Foo12 = {foo: false; bar: undefined; baz: boolean};
-type Bar12 = {foo: number; bar: true; baz: undefined};
-
-type FooBar12 = MergeDeep<Foo12, Bar12>;
-
-expectAssignable<FooBar12>({foo: 42, bar: true});
-
-type FooBar13 = MergeDeep<Foo12, Bar12, {strict: false}>;
-
-expectAssignable<FooBar13>({foo: 42, bar: true, baz: undefined});
-
-type Foo14 = {name: 'nyan'; level1: {plop: 42}};
-type Bar14 = {level1: {level2: {level3: 42}}};
-
-type FooBar14 = MergeDeep<Foo14, Bar14>;
-
-expectAssignable<FooBar14>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
-
-type Foo15 = {level1: {level2: {level3: 42}}};
-type Bar15 = {name: 'nyan'; level1: {plop: 42}};
-
-type FooBar15 = MergeDeep<Foo15, Bar15>;
-
-expectAssignable<FooBar15>({name: 'nyan', level1: {plop: 42, level2: {level3: 42}}});
-
-// Array
-
-type Foo16 = {'a': [number, {'b': number}, {'d': number}]};
-type Bar16 = {'a': [string, {'c': number}, {'e': number; d: string}]};
-
-type FooBar16 = MergeDeep<Foo16, Bar16>;
-
-expectAssignable<FooBar16>({a: ['42', {b: 2, c: 3}, {d: '4', e: 5}]});
-
-type Foo17 = [number, {'b': number}, {'d': number}];
-type Bar17 = [string, {'c': number}, {'e': number; d: string}];
-
-type FooBar17 = MergeDeep<Foo17, Bar17>;
-
-expectAssignable<FooBar17>(['42', {b: 2, c: 3}, {d: '4', e: 5}]);
-
-type Foo18 = {'a': [number, {'b': number}, {'d': {life: string}}]};
-type Bar18 = {'a': [string, {'c': number}, {'d': {life: number}}]};
-
-type FooBar18 = MergeDeep<Foo18, Bar18>;
-
-expectAssignable<FooBar18>({a: ['42', {b: 2, c: 3}, {d: {life: 42}}]});
+expectType<never>(sign15);
+expectType<never>(sign16);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -111,3 +111,10 @@ expectAssignable<FooBar12>({foo: 42, bar: true});
 type FooBar13 = MergeDeep<Foo12, Bar12, {strict: false}>;
 
 expectAssignable<FooBar13>({foo: 42, bar: true, baz: undefined});
+
+type Foo14 = {'a': [number, {'b': number}, {'d': number}]};
+type Bar14 = {'a': [string, {'c': number}, {'e': number; d: string}]};
+
+type FooBar14 = MergeDeep<Foo14, Bar14>;
+
+expectAssignable<FooBar14>({a: ['42', {b: 2, c: 3}, {d: '4', e: 5}]});


### PR DESCRIPTION
Merge two types recursively into a new type.

Properties set to `undefined` value are skipped when `strict` option is set to `true` (default).
Array and plain object properties are merged recursively.

```ts
type Foo = {foo: string; bar: {id: string; label: string}};
type Bar = {foo: number; bar: {id: number; nop: undefined}};

type FooBar = MergeDeep<Foo, Bar>;

// {
// 	foo: number;
// 	bar: {
// 		id: number;
// 		label: string;
// 	}
// }

type FooBarLazy = MergeDeep<Foo, Bar, {strict:false}>;

// {
// 	foo: number;
// 	bar: {
// 		id: number;
// 		label: string;
//		nop: undefined;
// 	}
// }
```

@ilchenkoArtem @sindresorhus `SetProp` is comming soooon!