### PR TITLE
Jsonify correctness

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,4 +1,5 @@
 import type {JsonPrimitive, JsonValue} from './basic';
+import { TypedArray } from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...args: any[]) => any) | undefined | symbol;
@@ -70,6 +71,8 @@ type Jsonify<T> =
 			: T extends Number ? number
 			: T extends String ? string
 			: T extends Boolean ? boolean
+			: T extends Map<any, any> | Set<any> ? {}
+			: T extends TypedArray ? {[key: string]: number}
 			: T extends Array<infer U>
 				? Array<Jsonify<U extends NotJsonable ? null : U>> // It's an array: recursive call for its children
 				: T extends object

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,5 +1,5 @@
 import type {JsonPrimitive, JsonValue} from './basic';
-import { TypedArray } from './typed-array';
+import {TypedArray} from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...args: any[]) => any) | undefined | symbol;
@@ -72,7 +72,7 @@ type Jsonify<T> =
 			: T extends String ? string
 			: T extends Boolean ? boolean
 			: T extends Map<any, any> | Set<any> ? {}
-			: T extends TypedArray ? {[key: string]: number}
+			: T extends TypedArray ? Record<string, number>
 			: T extends Array<infer U>
 				? Array<Jsonify<U extends NotJsonable ? null : U>> // It's an array: recursive call for its children
 				: T extends object

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,14 +1,7 @@
 import type {JsonPrimitive, JsonValue} from './basic';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
-type NotJsonable = ((...args: any[]) => any) | undefined;
-
-// Note: Handles special case where Arrays with `undefined` are transformed to `'null'` by `JSON.stringify()`
-// Only use with array members
-type JsonifyArrayMember<T> =
-	T extends undefined ?
-		null | Exclude<T, undefined> :
-		Jsonify<T>;
+type NotJsonable = ((...args: any[]) => any) | undefined | symbol;
 
 /**
 Transform a type to one that is assignable to the `JsonValue` type.
@@ -71,16 +64,23 @@ type Jsonify<T> =
 	// Check if there are any non-JSONable types represented in the union.
 	// Note: The use of tuples in this first condition side-steps distributive conditional types
 	// (see https://github.com/microsoft/TypeScript/issues/29368#issuecomment-453529532)
-	[Extract<T, NotJsonable>] extends [never]
+	[Extract<T, NotJsonable | BigInt>] extends [never]
 		? T extends JsonPrimitive
 			? T // Primitive is acceptable
+			: T extends Number ? number
+			: T extends String ? string
+			: T extends Boolean ? boolean
 			: T extends Array<infer U>
-				? Array<JsonifyArrayMember<U>> // It's an array: recursive call for its children
+				? Array<Jsonify<U extends NotJsonable ? null : U>> // It's an array: recursive call for its children
 				: T extends object
 					? T extends {toJSON(): infer J}
 						? (() => J) extends (() => JsonValue) // Is J assignable to JsonValue?
 							? J // Then T is Jsonable and its Jsonable value is J
 							: never // Not Jsonable because its toJSON() method does not return JsonValue
-						: {[P in keyof T]: Jsonify<Required<T>[P]>} // It's an object: recursive call for its children
+						: {[P in keyof T as P extends symbol
+							? never
+							: T[P] extends NotJsonable
+							? never
+							: P]: Jsonify<Required<T>[P]>} // It's an object: recursive call for its children
 					: never // Otherwise any other non-object is removed
 		: never; // Otherwise non-JSONable type union was found not empty

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,4 +1,5 @@
 import type {JsonPrimitive, JsonValue} from './basic';
+import {Finite, NegativeInfinity, PositiveInfinity} from './numeric';
 import {TypedArray} from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
@@ -66,7 +67,8 @@ type Jsonify<T> =
 	// Note: The use of tuples in this first condition side-steps distributive conditional types
 	// (see https://github.com/microsoft/TypeScript/issues/29368#issuecomment-453529532)
 	[Extract<T, NotJsonable | BigInt>] extends [never]
-		? T extends JsonPrimitive
+		? T extends PositiveInfinity | NegativeInfinity ? null
+		: T extends JsonPrimitive
 			? T // Primitive is acceptable
 			: T extends Number ? number
 			: T extends String ? string

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -34,6 +34,8 @@ You can't pass a `bigint` as they are already guaranteed to be finite.
 
 Use-case: Validating and documenting parameters.
 
+Note: This can't detect `NaN`, please upvote [this issue](https://github.com/microsoft/TypeScript/issues/28682) if you want to have this type as a built-in in TypeScript.
+
 @example
 ```
 import type {Finite} from 'type-fest';

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -212,20 +212,14 @@ interface OptionalTypeUnion {
 	a?: string | (() => any);
 }
 
-interface OptionalFunction {
-	a?: () => any;
-}
-
 interface NonOptionalTypeUnion {
 	a: string | undefined;
 }
 
 declare const jsonifiedOptionalPrimitive: Jsonify<OptionalPrimitive>;
 declare const jsonifiedOptionalTypeUnion: Jsonify<OptionalTypeUnion>;
-declare const jsonifiedOptionalFunction: Jsonify<OptionalFunction>;
 declare const jsonifiedNonOptionalTypeUnion: Jsonify<NonOptionalTypeUnion>;
 
 expectType<{a?: string}>(jsonifiedOptionalPrimitive);
 expectType<{a?: never}>(jsonifiedOptionalTypeUnion);
-expectType<{a?: never}>(jsonifiedOptionalFunction);
 expectType<{a: never}>(jsonifiedNonOptionalTypeUnion);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -190,6 +190,18 @@ expectType<boolean>(booleanJson);
 declare const bigInt: Jsonify<BigInt>;
 expectType<never>(bigInt);
 
+declare const int8Array: Int8Array;
+declare const int8ArrayJson: Jsonify<typeof int8Array>
+expectType<{[key: string]: number}>(int8ArrayJson);
+
+declare const map: Map<string, number>
+declare const mapJson: Jsonify<typeof map>
+expectType<{}>(mapJson);
+
+declare const set: Set<string>
+declare const setJson: Jsonify<typeof set>
+expectType<{}>(setJson);
+
 // Positive and negative Infinity, NaN and null are turned into null
 // declare const positiveInf: PositiveInfinity
 // expectNotAssignable<JsonValue>(positiveInf)

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -191,15 +191,15 @@ declare const bigInt: Jsonify<BigInt>;
 expectType<never>(bigInt);
 
 declare const int8Array: Int8Array;
-declare const int8ArrayJson: Jsonify<typeof int8Array>
-expectType<{[key: string]: number}>(int8ArrayJson);
+declare const int8ArrayJson: Jsonify<typeof int8Array>;
+expectType<Record<string, number>>(int8ArrayJson);
 
-declare const map: Map<string, number>
-declare const mapJson: Jsonify<typeof map>
+declare const map: Map<string, number>;
+declare const mapJson: Jsonify<typeof map>;
 expectType<{}>(mapJson);
 
-declare const set: Set<string>
-declare const setJson: Jsonify<typeof set>
+declare const set: Set<string>;
+declare const setJson: Jsonify<typeof set>;
 expectType<{}>(setJson);
 
 // Positive and negative Infinity, NaN and null are turned into null

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -124,71 +124,71 @@ expectNotAssignable<JsonValue>(nonJsonWithInvalidToJSON);
 expectNotAssignable<JsonValue>(nonJsonWithInvalidToJSON.toJSON());
 
 // Not jsonable types; these types behave differently when used as plain values, as members of arrays and as values of objects
-declare const undef: undefined
-expectNotAssignable<JsonValue>(undef);
+declare const undefined: undefined;
+expectNotAssignable<JsonValue>(undefined);
 
 declare const fn: (_: any) => void;
 expectNotAssignable<JsonValue>(fn);
 
-declare const sym: symbol
-expectNotAssignable<JsonValue>(sym);
+declare const symbol: symbol;
+expectNotAssignable<JsonValue>(symbol);
 
 // Plain values fail JSON.stringify()
-declare const plainUndef: Jsonify<typeof undef>
-expectType<never>(plainUndef)
+declare const plainUndefined: Jsonify<typeof undefined>;
+expectType<never>(plainUndefined);
 
-declare const plainFn: Jsonify<typeof fn>
-expectType<never>(plainFn)
+declare const plainFn: Jsonify<typeof fn>;
+expectType<never>(plainFn);
 
-declare const plainSym: Jsonify<typeof sym>
-expectType<never>(plainSym)
+declare const plainSymbol: Jsonify<typeof symbol>;
+expectType<never>(plainSymbol);
 
 // Array members become null
-declare const arrayMemberUndef: Jsonify<typeof undef[]>
-expectType<null[]>(arrayMemberUndef)
+declare const arrayMemberUndefined: Jsonify<Array<typeof undefined>>;
+expectType<null[]>(arrayMemberUndefined);
 
-declare const arrayMemberFn: Jsonify<typeof fn[]>
-expectType<null[]>(arrayMemberFn)
+declare const arrayMemberFn: Jsonify<Array<typeof fn>>;
+expectType<null[]>(arrayMemberFn);
 
-declare const arrayMemberSym: Jsonify<typeof sym[]>
-expectType<null[]>(arrayMemberSym)
+declare const arrayMemberSymbol: Jsonify<Array<typeof symbol>>;
+expectType<null[]>(arrayMemberSymbol);
 
 // When used in object values, these keys are filtered
-declare const objectValueUndef: Jsonify<{ keep: string, undef: typeof undef }>
-expectType<{ keep: string }>(objectValueUndef)
+declare const objectValueUndefined: Jsonify<{keep: string; undefined: typeof undefined}>;
+expectType<{keep: string}>(objectValueUndefined);
 
-declare const objectValueFn: Jsonify<{ keep: string, fn: typeof fn }>
-expectType<{ keep: string }>(objectValueFn)
+declare const objectValueFn: Jsonify<{keep: string; fn: typeof fn}>;
+expectType<{keep: string}>(objectValueFn);
 
-declare const objectValueSym: Jsonify<{ keep: string, sym: typeof sym }>
-expectType<{ keep: string }>(objectValueSym)
+declare const objectValueSymbol: Jsonify<{keep: string; symbol: typeof symbol}>;
+expectType<{keep: string}>(objectValueSymbol);
 
-// symbol keys are filtered
-declare const objectKeySym: Jsonify<{ [key: typeof sym]: number, keep: string }>
-expectType<{ keep: string }>(objectKeySym)
+// Symbol keys are filtered
+declare const objectKeySymbol: Jsonify<{[key: typeof symbol]: number; keep: string}>;
+expectType<{keep: string}>(objectKeySymbol);
 
 // Number, String and Boolean values are turned into primitive counterparts
-declare const num: Number
-expectNotAssignable<JsonValue>(num)
+declare const number: Number;
+expectNotAssignable<JsonValue>(number);
 
-declare const str: String
-expectNotAssignable<JsonValue>(str)
+declare const string: String;
+expectNotAssignable<JsonValue>(string);
 
-declare const bool: Boolean
-expectNotAssignable<JsonValue>(bool)
+declare const boolean: Boolean;
+expectNotAssignable<JsonValue>(boolean);
 
-declare const numJson: Jsonify<typeof num>
-expectType<number>(numJson)
+declare const numberJson: Jsonify<typeof number>;
+expectType<number>(numberJson);
 
-declare const strJson: Jsonify<typeof str>
-expectType<string>(strJson)
+declare const stringJson: Jsonify<typeof string>;
+expectType<string>(stringJson);
 
-declare const boolJson: Jsonify<typeof bool>
-expectType<boolean>(boolJson)
+declare const booleanJson: Jsonify<typeof boolean>;
+expectType<boolean>(booleanJson);
 
 // BigInt fails JSON.stringify
-declare const bigInt: Jsonify<BigInt>
-expectType<never>(bigInt)
+declare const bigInt: Jsonify<BigInt>;
+expectType<never>(bigInt);
 
 // Positive and negative Infinity, NaN and null are turned into null
 // declare const positiveInf: PositiveInfinity

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
-import type {Jsonify, JsonValue} from '..';
+import type {Jsonify, JsonValue, NegativeInfinity, PositiveInfinity} from '..';
 
 interface A {
 	a: number;
@@ -203,17 +203,13 @@ declare const setJson: Jsonify<typeof set>;
 expectType<{}>(setJson);
 
 // Positive and negative Infinity, NaN and null are turned into null
-// declare const positiveInf: PositiveInfinity
-// expectNotAssignable<JsonValue>(positiveInf)
-// declare const positiveInfJson: Jsonify<typeof positiveInf>
-// expectType<null>(positiveInfJson)
-// declare const negativeInf: NegativeInfinity
-// expectNotAssignable<JsonValue>(negativeInf)
-// declare const negativeInfJson: Jsonify<typeof negativeInf>
-// expectType<null>(negativeInfJson)
 // NOTE: NaN is not detectable in TypeScript, so it is not tested; see https://github.com/sindresorhus/type-fest/issues/406
-// declare const nan: NaN
-// expectNotAssignable<JsonValue>(nan)
+declare const positiveInfinity: PositiveInfinity;
+declare const positiveInfJson: Jsonify<typeof positiveInfinity>;
+expectType<null>(positiveInfJson);
+declare const negativeInf: NegativeInfinity;
+declare const negativeInfJson: Jsonify<typeof negativeInf>;
+expectType<null>(negativeInfJson);
 
 // Test that optional type members are not discarded wholesale.
 interface OptionalPrimitive {


### PR DESCRIPTION
This is my first attempt at fixing Jsonify problems I mentioned in #407.

I started with tests first, then proceeded to fix those tests. Tests are based on [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description) and [my own tests](https://gist.github.com/frontsideair/dfd696bc927514ba4a78e1c5ed4acd1c#file-jsonify-spec-ts).

I had to delete a faulty test case, where an object had a function value. The spec tells that those entries are omitted from the output.

I checked the validity of the types with the provided `test` script. It also output a lot of lint warnings that were there before I picked it up, so I left them alone. I can fix those errors if you want me to, but it will end up destroying the git blame.

I'm not sure if I documented everything I did as best as I could, since this was a first attempt. I can fix anything where you thing it needs more explanation.

I also commented out the Infinity and NaN checks. Infinity is detectable with this library, but it seemed like a minor edge case. NaN is not detectable as far as I can understand, see #406.

Also missing is `TypedArray`s. I'm not sure how to approach them, any guidance is welcome, or we can get this merged and leave it as future work.

I can also add a warning about NaNs in the readme, or leave it as future work as well.

Sorry for a lot of text, I just wanted to cover everything.

---

Fixes #407