### PR TITLE
Replace `BigInt` with `bigint`

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -66,7 +66,7 @@ type Jsonify<T> =
 	// Check if there are any non-JSONable types represented in the union.
 	// Note: The use of tuples in this first condition side-steps distributive conditional types
 	// (see https://github.com/microsoft/TypeScript/issues/29368#issuecomment-453529532)
-	[Extract<T, NotJsonable | BigInt>] extends [never]
+	[Extract<T, NotJsonable | bigint>] extends [never]
 		? T extends PositiveInfinity | NegativeInfinity ? null
 		: T extends JsonPrimitive
 			? T // Primitive is acceptable

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -187,7 +187,7 @@ declare const booleanJson: Jsonify<typeof boolean>;
 expectType<boolean>(booleanJson);
 
 // BigInt fails JSON.stringify
-declare const bigInt: Jsonify<BigInt>;
+declare const bigInt: Jsonify<bigint>;
 expectType<never>(bigInt);
 
 declare const int8Array: Int8Array;


### PR DESCRIPTION
`BigInt` targets the object, like `String`, it should've been `bigint`
