### PR TITLE
Fix `Includes` null includes undefined

### DIFF
--- a/source/includes.d.ts
+++ b/source/includes.d.ts
@@ -15,8 +15,8 @@ type hasRed<array extends any[]> = Includes<array, 'red'>;
 @category Array
 */
 export type Includes<Value extends readonly any[], Item> =
-	IsEqual<Value[0], Item> extends true
-		? true
-		: Value extends [Value[0], ...infer rest]
-			? Includes<rest, Item>
-			: false;
+	Value extends readonly [Value[0], ...infer rest]
+		? IsEqual<Value[0], Item> extends true
+			? true
+			: Includes<rest, Item>
+		: false;

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -32,6 +32,12 @@ expectType<false>(objectIncludes);
 const objectIncludesPass: Includes<[{a: 1}], {a: 1}> = true;
 expectType<true>(objectIncludesPass);
 
+const nullIncludesUndefined: Includes<[null], undefined> = false;
+expectType<false>(nullIncludesUndefined);
+
+const nullIncludesNullPass: Includes<[null], null> = true;
+expectType<true>(nullIncludesNullPass);
+
 declare const anything: any;
 
 expectError<Includes>(anything);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
I modified what passes when null includes undefined.