### PR TITLE
feat(jsonify): do not reduce tuples to arrays

### DIFF
--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -186,6 +186,12 @@ expectType<string>(stringJson);
 declare const booleanJson: Jsonify<typeof boolean>;
 expectType<boolean>(booleanJson);
 
+declare const tupleJson: Jsonify<[string, Date]>;
+expectType<[string, string]>(tupleJson);
+
+declare const tupleRestJson: Jsonify<[string, ...Date[]]>;
+expectType<[string, ...string[]]>(tupleRestJson);
+
 // BigInt fails JSON.stringify
 declare const bigInt: Jsonify<bigint>;
 expectType<never>(bigInt);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
Tuples are kind of nice, would be a shame to reduce them to generic arrays when `Jsonify`ing.
Also refactored a bit, moved instanced 'primitives' under `object` case
