### PR TITLE
Add array/tuple support to `Spread`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ Click the type names for complete docs.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.
-- [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects using the spread operator.
+- [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread operator.
 
 ### JSON
 

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ Click the type names for complete docs.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.
-- [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread operator.
+- [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread syntax.
 
 ### JSON
 

--- a/source/spread.d.ts
+++ b/source/spread.d.ts
@@ -21,7 +21,7 @@ type SpreadTupleOrArray<
 type Spreadable = object | TupleOrArray;
 
 /**
-Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread operator.
+Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread syntax.
 
 @example
 ```

--- a/source/spread.d.ts
+++ b/source/spread.d.ts
@@ -2,7 +2,7 @@ import type {Except} from './except';
 import type {RequiredKeysOf} from './required-keys-of';
 import type {Simplify} from './simplify';
 
-type Spread_<FirstType extends object, SecondType extends object> = {
+type SpreadObject<FirstType extends object, SecondType extends object> = {
 	[Key in keyof FirstType]: Key extends keyof SecondType
 		? FirstType[Key] | Required<SecondType>[Key]
 		: FirstType[Key];
@@ -10,6 +10,15 @@ type Spread_<FirstType extends object, SecondType extends object> = {
 	SecondType,
 	RequiredKeysOf<SecondType> | Exclude<keyof SecondType, keyof FirstType>
 >;
+
+type TupleOrArray = readonly [...unknown[]];
+
+type SpreadTupleOrArray<
+	FirstType extends TupleOrArray,
+	SecondType extends TupleOrArray,
+> = Array<FirstType[number] | SecondType[number]>;
+
+type Spreadable = object | TupleOrArray;
 
 /**
 Mimic the type inferred by TypeScript when merging two objects using the spread operator.
@@ -46,9 +55,31 @@ const baz = (argument: FooBar) => {
 baz(fooBar);
 ```
 
+@example
+```
+import type {Spread} from 'type-fest';
+
+const foo = [1, 2, 3];
+const bar = ['4', '5', '6'];
+
+const fooBar = [...foo, ...bar];
+type FooBar = Spread<typeof foo, typeof bar>;
+// FooBar = (string | number)[]
+
+const baz = (argument: FooBar) => {
+	// Do something
+};
+
+baz(fooBar);
+```
+
 @category Object
 */
 export type Spread<
-    FirstType extends object,
-    SecondType extends object,
-> = Simplify<Spread_<FirstType, SecondType>>;
+    FirstType extends Spreadable,
+    SecondType extends Spreadable,
+> = FirstType extends TupleOrArray
+	? SecondType extends TupleOrArray
+		? SpreadTupleOrArray<FirstType, SecondType>
+		: Simplify<SpreadObject<FirstType, SecondType>>
+	: Simplify<SpreadObject<FirstType, SecondType>>;

--- a/source/spread.d.ts
+++ b/source/spread.d.ts
@@ -21,7 +21,7 @@ type SpreadTupleOrArray<
 type Spreadable = object | TupleOrArray;
 
 /**
-Mimic the type inferred by TypeScript when merging two objects using the spread operator.
+Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread operator.
 
 @example
 ```

--- a/test-d/spread.ts
+++ b/test-d/spread.ts
@@ -42,3 +42,42 @@ const bar: Bar = {
 const foobar = {...foo, ...bar};
 
 expectType<FooBar>(foobar);
+
+const arrayFoo = [1, 2, 3];
+const arrayBar = [4, 5, 6];
+
+const arrayFooBar = [...arrayFoo, ...arrayBar]; // -> number[]
+type ArrayFooBar = Spread<typeof arrayFoo, typeof arrayBar>;
+
+expectType<ArrayFooBar>(arrayFooBar);
+expectType<number[]>(arrayFooBar);
+
+const stringArray = ['4', '5', '6'];
+
+const mixedArrayFooBar = [...arrayFoo, ...stringArray]; // -> (string | number)[]
+type MixedArrayFooBar = Spread<typeof arrayFoo, typeof stringArray>;
+
+expectType<MixedArrayFooBar>(mixedArrayFooBar);
+expectType<Array<string | number>>(mixedArrayFooBar);
+
+const tupleFoo: [1, 2, 3] = [1, 2, 3];
+const tupleBar: [4, 5, 6] = [4, 5, 6];
+
+const tupleFooBar = [...tupleFoo, ...tupleBar]; // -> (1 | 2 | 3 | 4 | 5 | 6)[]
+type TupleFooBar = Spread<typeof tupleFoo, typeof tupleBar>;
+
+expectType<TupleFooBar>(tupleFooBar);
+expectType<Array<1 | 2 | 3 | 4 | 5 | 6>>(tupleFooBar);
+
+const arrayTupleFooBar = [...arrayFoo, ...tupleBar]; // -> number[]
+type ArrayTupleFooBar = Spread<typeof arrayFoo, typeof tupleBar>;
+
+expectType<ArrayTupleFooBar>(arrayTupleFooBar);
+expectType<number[]>(arrayTupleFooBar);
+
+const tupleArrayFooBar = [...tupleFoo, ...arrayBar]; // -> number[]
+type TupleArrayFooBar = Spread<typeof tupleFoo, typeof arrayBar>;
+
+expectType<TupleArrayFooBar>(tupleArrayFooBar);
+expectType<number[]>(tupleArrayFooBar);
+

--- a/test-d/spread.ts
+++ b/test-d/spread.ts
@@ -46,7 +46,7 @@ expectType<FooBar>(foobar);
 const arrayFoo = [1, 2, 3];
 const arrayBar = [4, 5, 6];
 
-const arrayFooBar = [...arrayFoo, ...arrayBar]; // -> number[]
+const arrayFooBar = [...arrayFoo, ...arrayBar]; //=> number[]
 type ArrayFooBar = Spread<typeof arrayFoo, typeof arrayBar>;
 
 expectType<ArrayFooBar>(arrayFooBar);
@@ -54,7 +54,7 @@ expectType<number[]>(arrayFooBar);
 
 const stringArray = ['4', '5', '6'];
 
-const mixedArrayFooBar = [...arrayFoo, ...stringArray]; // -> (string | number)[]
+const mixedArrayFooBar = [...arrayFoo, ...stringArray]; //=> (string | number)[]
 type MixedArrayFooBar = Spread<typeof arrayFoo, typeof stringArray>;
 
 expectType<MixedArrayFooBar>(mixedArrayFooBar);
@@ -63,21 +63,20 @@ expectType<Array<string | number>>(mixedArrayFooBar);
 const tupleFoo: [1, 2, 3] = [1, 2, 3];
 const tupleBar: [4, 5, 6] = [4, 5, 6];
 
-const tupleFooBar = [...tupleFoo, ...tupleBar]; // -> (1 | 2 | 3 | 4 | 5 | 6)[]
+const tupleFooBar = [...tupleFoo, ...tupleBar]; //=> (1 | 2 | 3 | 4 | 5 | 6)[]
 type TupleFooBar = Spread<typeof tupleFoo, typeof tupleBar>;
 
 expectType<TupleFooBar>(tupleFooBar);
 expectType<Array<1 | 2 | 3 | 4 | 5 | 6>>(tupleFooBar);
 
-const arrayTupleFooBar = [...arrayFoo, ...tupleBar]; // -> number[]
+const arrayTupleFooBar = [...arrayFoo, ...tupleBar]; //=> number[]
 type ArrayTupleFooBar = Spread<typeof arrayFoo, typeof tupleBar>;
 
 expectType<ArrayTupleFooBar>(arrayTupleFooBar);
 expectType<number[]>(arrayTupleFooBar);
 
-const tupleArrayFooBar = [...tupleFoo, ...arrayBar]; // -> number[]
+const tupleArrayFooBar = [...tupleFoo, ...arrayBar]; //=> number[]
 type TupleArrayFooBar = Spread<typeof tupleFoo, typeof arrayBar>;
 
 expectType<TupleArrayFooBar>(tupleArrayFooBar);
 expectType<number[]>(tupleArrayFooBar);
-


### PR DESCRIPTION
This PR add array and tuple support to `Spread`. 
@sindresorhus  I need it for https://github.com/sindresorhus/type-fest/pull/408 ;)