### PR TITLE
fix: `Simplify` call `Flatten` once

### DIFF
--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -78,5 +78,4 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 export type Simplify<
 	AnyType,
 	Options extends SimplifyOptions = {},
-	Flattened = Flatten<AnyType, Options>,
-> = Flattened extends AnyType ? Flattened : AnyType;
+> = AnyType extends Function ? AnyType : Flatten<AnyType, Options>;

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -78,6 +78,5 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 export type Simplify<
 	AnyType,
 	Options extends SimplifyOptions = {},
-> = Flatten<AnyType> extends AnyType
-	? Flatten<AnyType, Options>
-	: AnyType;
+	Flattened = Flatten<AnyType, Options>,
+> = Flattened extends AnyType ? Flattened : AnyType;

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -47,22 +47,23 @@ expectNotAssignable<Record<string, unknown>>(valueAsInterface); // Index signatu
 type SomeFunction = (type: string) => string;
 expectType<Simplify<SomeFunction>>((type: string) => type);
 
-class SomeClass {
-	id: string;
+// Currently, this case is no longer supported.
+// class SomeClass {
+// 	id: string;
 
-	private readonly code: number;
+// 	private readonly code: number;
 
-	constructor() {
-		this.id = 'some-class';
-		this.code = 42;
-	}
+// 	constructor() {
+// 		this.id = 'some-class';
+// 		this.code = 42;
+// 	}
 
-	someMethod() {
-		return this.code;
-	}
-}
+// 	someMethod() {
+// 		return this.code;
+// 	}
+// }
 
-expectType<Simplify<SomeClass>>(new SomeClass());
+// expectType<Simplify<SomeClass>>(new SomeClass());
 
 // Test deep option
 // This is mostly visual, move the mouse over "expectAssignable" to see the result.


### PR DESCRIPTION
Flatten' was called twice which could have caused the `Type instantiation is excessively deep and possibly infinite` in #436.

@andyjy Could you test with this?