### PR TITLE
Support condition object in `PackageJson` `exports` array

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -223,15 +223,17 @@ declare namespace PackageJson {
 		string
 	>;
 
+	type ExportConditions = {[condition in ExportCondition]: Exports};
+
 	/**
 	Entry points of a module, optionally with conditions and subpath exports.
 	*/
 	export type Exports =
 	| null
 	| string
-	| string[]
-	| {[key in ExportCondition]: Exports}
-	| {[key: string]: Exports}; // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
+	| (string | ExportConditions)[]
+	| ExportConditions
+	| {[path: string]: Exports}; // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
 
 	/**
 	Import map entries of a module, optionally with conditions.

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -231,7 +231,7 @@ declare namespace PackageJson {
 	export type Exports =
 	| null
 	| string
-	| (string | ExportConditions)[]
+	| Array<string | ExportConditions>
 	| ExportConditions
 	| {[path: string]: Exports}; // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
 


### PR DESCRIPTION
Supporting condition objects in export arrays

```json5
{
  "name": "a-package",
  "exports": [
    { "condition": "./file-a" },
    "./file-b"
  ]
}
```