### PR TITLE
Add `TupleToUnion` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ export {HasOptionalKeys} from './source/has-optional-keys';
 export {RequiredKeysOf} from './source/required-keys-of';
 export {HasRequiredKeys} from './source/has-required-keys';
 export {Spread} from './source/spread';
+export {TupleToUnion} from './source/tuple-to-union';
 
 // Template literal types
 export {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,7 @@ Click the type names for complete docs.
 - [`MultidimensionalArray`](source/multidimensional-array.d.ts) - Create a type that represents a multidimensional array of the given type and dimensions.
 - [`MultidimensionalReadonlyArray`](source/multidimensional-readonly-array.d.ts) - Create a type that represents a multidimensional readonly array of the given type and dimensions.
 - [`ReadonlyTuple`](source/readonly-tuple.d.ts) - Create a type that represents a read-only tuple of the given type and length.
+- [`TupleToUnion`](source/tuple-to-union.d.ts) - Convert a tuple into a union type of its elements.
 
 ### Numeric
 

--- a/source/tuple-to-union.d.ts
+++ b/source/tuple-to-union.d.ts
@@ -26,6 +26,26 @@ function verifyRequestBody(body: unknown): body is RequestBody {
 }
 ```
 
+Alternatively, you may use `typeof destinations[number]`. If `destinations` is a tuple, there is no difference. However if `destinations` is a string, the resulting type will the union of the characters in the string. Other types of `destinations` may result in a compile error. In comparison, TupleToUnion will return `never` if a tuple is not provided.
+
+@example
+```
+const destinations = ['a', 'b', 'c'] as const;
+
+type Destination = typeof destinations[number];
+//=> 'a' | 'b' | 'c'
+
+const erroringType = new Set(['a', 'b', 'c']);
+
+type ErroringType = typeof erroringType[number];
+//=> Type 'Set<string>' has no matching index signature for type 'number'. ts(2537)
+
+const numberBool: { [n: number]: boolean } = { 1: true };
+
+type NumberBool = typeof numberBool[number];
+//=> boolean
+```
+
 @category Array
 */
 export type TupleToUnion<ArrayType> = ArrayType extends readonly [infer Head, ...(infer Rest)] ? Head | TupleToUnion<Rest> : never;

--- a/source/tuple-to-union.d.ts
+++ b/source/tuple-to-union.d.ts
@@ -1,0 +1,29 @@
+/**
+Convert a tuple into a union type of its elements.
+
+This can be useful when you have a fixed set of allowed values and want a type defining only the allowed values, but do not want to repeat yourself.
+
+@example
+```
+import type {TupleToUnion} from 'type-fest';
+
+const destinations = ['a', 'b', 'c'] as const;
+type Destination = TupleToUnion<typeof destinations>;
+//=> 'a' | 'b' | 'c'
+
+function verifyDestination(destination: unknown): destination is Destination {
+	return destinations.includes(destination as any);
+}
+
+type RequestBody = {
+	deliverTo: Destination;
+};
+function verifyReqBody(body: unknown): body is RequestBody {
+	const deliverTo = (body as any).deliverTo
+	return typeof body === 'object' && body !== null && verifyDestination(deliverTo)
+}
+```
+
+@category Array
+*/
+export type TupleToUnion<ArrayType> = ArrayType extends readonly [infer Head, ...(infer Rest)] ? Head | TupleToUnion<Rest> : never;

--- a/source/tuple-to-union.d.ts
+++ b/source/tuple-to-union.d.ts
@@ -8,6 +8,7 @@ This can be useful when you have a fixed set of allowed values and want a type d
 import type {TupleToUnion} from 'type-fest';
 
 const destinations = ['a', 'b', 'c'] as const;
+
 type Destination = TupleToUnion<typeof destinations>;
 //=> 'a' | 'b' | 'c'
 
@@ -18,9 +19,10 @@ function verifyDestination(destination: unknown): destination is Destination {
 type RequestBody = {
 	deliverTo: Destination;
 };
-function verifyReqBody(body: unknown): body is RequestBody {
-	const deliverTo = (body as any).deliverTo
-	return typeof body === 'object' && body !== null && verifyDestination(deliverTo)
+
+function verifyRequestBody(body: unknown): body is RequestBody {
+	const deliverTo = (body as any).deliverTo;
+	return typeof body === 'object' && body !== null && verifyDestination(deliverTo);
 }
 ```
 

--- a/test-d/tuple-to-union.ts
+++ b/test-d/tuple-to-union.ts
@@ -1,0 +1,26 @@
+import {expectAssignable, expectNotType, expectType} from 'tsd';
+import type {TupleToUnion} from '../index';
+
+const options = ['a', 'b', 'c'] as const;
+type Options = TupleToUnion<typeof options>;
+
+const a: Options = 'a';
+expectAssignable<Options>(a);
+expectType<'a'>(a);
+expectNotType<'b'>(a);
+expectNotType<'c'>(a);
+
+const b: Options = 'b';
+expectAssignable<Options>(b);
+expectNotType<'a'>(b);
+expectType<'b'>(b);
+expectNotType<'c'>(b);
+
+const c: Options = 'c';
+expectAssignable<Options>(c);
+expectNotType<'a'>(c);
+expectNotType<'b'>(c);
+expectType<'c'>(c);
+
+declare const notAnArray: TupleToUnion<[]>;
+expectType<never>(notAnArray);


### PR DESCRIPTION
This type makes it easy to define an array of allowed values, and then use that same list in a type union.  All without needing to repeat the allowed values.