### PR TITLE
Revert `Simplify` to v2.15.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,16 +45,16 @@ export {Jsonify} from './source/jsonify';
 export {Schema} from './source/schema';
 export {LiteralToPrimitive} from './source/literal-to-primitive';
 export {
-  PositiveInfinity,
-  NegativeInfinity,
-  Finite,
-  Integer,
-  Float,
-  NegativeFloat,
-  Negative,
-  NonNegative,
-  NegativeInteger,
-  NonNegativeInteger,
+	PositiveInfinity,
+	NegativeInfinity,
+	Finite,
+	Integer,
+	Float,
+	NegativeFloat,
+	Negative,
+	NonNegative,
+	NegativeInteger,
+	NonNegativeInteger,
 } from './source/numeric';
 export {StringKeyOf} from './source/string-key-of';
 export {Exact} from './source/exact';

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,21 +40,21 @@ export {Entry} from './source/entry';
 export {Entries} from './source/entries';
 export {SetReturnType} from './source/set-return-type';
 export {Asyncify} from './source/asyncify';
-export {Simplify, SimplifyOptions} from './source/simplify';
+export {Simplify} from './source/simplify';
 export {Jsonify} from './source/jsonify';
 export {Schema} from './source/schema';
 export {LiteralToPrimitive} from './source/literal-to-primitive';
 export {
-	PositiveInfinity,
-	NegativeInfinity,
-	Finite,
-	Integer,
-	Float,
-	NegativeFloat,
-	Negative,
-	NonNegative,
-	NegativeInteger,
-	NonNegativeInteger,
+  PositiveInfinity,
+  NegativeInfinity,
+  Finite,
+  Integer,
+  Float,
+  NegativeFloat,
+  Negative,
+  NonNegative,
+  NegativeInteger,
+  NonNegativeInteger,
 } from './source/numeric';
 export {StringKeyOf} from './source/string-key-of';
 export {Exact} from './source/exact';

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -1,24 +1,4 @@
 /**
-@see Simplify
-*/
-export interface SimplifyOptions {
-	/**
-	Do the simplification recursively.
-
-	@default false
-	*/
-	deep?: boolean;
-}
-
-// Flatten a type without worrying about the result.
-type Flatten<
-	AnyType,
-	Options extends SimplifyOptions = {},
-> = Options['deep'] extends true
-	? {[KeyType in keyof AnyType]: Simplify<AnyType[KeyType], Options>}
-	: {[KeyType in keyof AnyType]: AnyType[KeyType]};
-
-/**
 Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 
 @example
@@ -75,9 +55,4 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @category Object
 */
-export type Simplify<
-	AnyType,
-	Options extends SimplifyOptions = {},
-> = Flatten<AnyType> extends AnyType
-	? Flatten<AnyType, Options>
-	: AnyType;
+export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]};

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -42,3 +42,26 @@ expectType<SomeInterfaceAsTypeWrittenByHand>(valueAsInterface);
 expectAssignable<Record<string, unknown>>(valueAsLiteral);
 expectAssignable<Record<string, unknown>>(valueAsSimplifiedInterface);
 expectNotAssignable<Record<string, unknown>>(valueAsInterface); // Index signature is missing in interface
+
+// The following tests should be fixed once we have determined the cause of the bug reported in https://github.com/sindresorhus/type-fest/issues/436
+
+// // Should return the original type if it is not simplifiable, like a function.
+// type SomeFunction = (type: string) => string;
+// expectType<Simplify<SomeFunction>>((type: string) => type);
+
+// class SomeClass {
+// 	id: string;
+
+// 	private readonly code: number;
+
+// 	constructor() {
+// 		this.id = 'some-class';
+// 		this.code = 42;
+// 	}
+
+// 	someMethod() {
+// 		return this.code;
+// 	}
+// }
+
+// expectType<Simplify<SomeClass>>(new SomeClass());

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -2,13 +2,13 @@ import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Simplify} from '../index';
 
 type PositionProps = {
-  top: number;
-  left: number;
+	top: number;
+	left: number;
 };
 
 type SizeProps = {
-  width: number;
-  height: number;
+	width: number;
+	height: number;
 };
 
 // Flatten the type output to improve type hints shown in editors.
@@ -16,15 +16,15 @@ const flattenProps = {top: 120, left: 240, width: 480, height: 600};
 expectType<Simplify<PositionProps & SizeProps>>(flattenProps);
 
 interface SomeInterface {
-  foo: number;
-  bar?: string;
-  baz: number | undefined;
+	foo: number;
+	bar?: string;
+	baz: number | undefined;
 }
 
 type SomeInterfaceAsTypeWrittenByHand = {
-  foo: number;
-  bar?: string;
-  baz: number | undefined;
+	foo: number;
+	bar?: string;
+	baz: number | undefined;
 };
 
 const valueAsLiteral = {foo: 123, bar: 'hello', baz: 456};

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -2,13 +2,13 @@ import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Simplify} from '../index';
 
 type PositionProps = {
-	top: number;
-	left: number;
+  top: number;
+  left: number;
 };
 
 type SizeProps = {
-	width: number;
-	height: number;
+  width: number;
+  height: number;
 };
 
 // Flatten the type output to improve type hints shown in editors.
@@ -16,15 +16,15 @@ const flattenProps = {top: 120, left: 240, width: 480, height: 600};
 expectType<Simplify<PositionProps & SizeProps>>(flattenProps);
 
 interface SomeInterface {
-	foo: number;
-	bar?: string;
-	baz: number | undefined;
+  foo: number;
+  bar?: string;
+  baz: number | undefined;
 }
 
 type SomeInterfaceAsTypeWrittenByHand = {
-	foo: number;
-	bar?: string;
-	baz: number | undefined;
+  foo: number;
+  bar?: string;
+  baz: number | undefined;
 };
 
 const valueAsLiteral = {foo: 123, bar: 'hello', baz: 456};
@@ -42,45 +42,3 @@ expectType<SomeInterfaceAsTypeWrittenByHand>(valueAsInterface);
 expectAssignable<Record<string, unknown>>(valueAsLiteral);
 expectAssignable<Record<string, unknown>>(valueAsSimplifiedInterface);
 expectNotAssignable<Record<string, unknown>>(valueAsInterface); // Index signature is missing in interface
-
-// Should return the original type if it is not simplifiable, like a function.
-type SomeFunction = (type: string) => string;
-expectType<Simplify<SomeFunction>>((type: string) => type);
-
-class SomeClass {
-	id: string;
-
-	private readonly code: number;
-
-	constructor() {
-		this.id = 'some-class';
-		this.code = 42;
-	}
-
-	someMethod() {
-		return this.code;
-	}
-}
-
-expectType<Simplify<SomeClass>>(new SomeClass());
-
-// Test deep option
-// This is mostly visual, move the mouse over "expectAssignable" to see the result.
-type PositionAndSize = PositionProps & SizeProps;
-
-interface Node {
-	parent: PositionAndSize;
-	child: {
-		parent: PositionAndSize;
-	};
-}
-
-const node = {
-	parent: flattenProps,
-	child: {
-		parent: flattenProps,
-	},
-};
-
-expectAssignable<Simplify<Node>>(node);
-expectAssignable<Simplify<Node, {deep: true}>>(node);

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
+import {expectAssignable, expectError, expectNotAssignable, expectType} from 'tsd';
 import type {Simplify} from '../index';
 
 type PositionProps = {
@@ -44,6 +44,13 @@ expectAssignable<Record<string, unknown>>(valueAsSimplifiedInterface);
 expectNotAssignable<Record<string, unknown>>(valueAsInterface); // Index signature is missing in interface
 
 // The following tests should be fixed once we have determined the cause of the bug reported in https://github.com/sindresorhus/type-fest/issues/436
+
+type SomeFunction = (type: string) => string;
+type SimplifiedFunction = Simplify<SomeFunction>; // Return '{}' expected 'SomeFunction'
+
+declare const someFunction: SimplifiedFunction;
+
+expectError<SomeFunction>(someFunction);
 
 // // Should return the original type if it is not simplifiable, like a function.
 // type SomeFunction = (type: string) => string;


### PR DESCRIPTION
Revert `Simplify` to v2.15.1 due to breaking change introduced in v2.16.0 #436