### PR TITLE
Add `ConditionalPickDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ export {AsyncReturnType} from './source/async-return-type';
 export {ConditionalExcept} from './source/conditional-except';
 export {ConditionalKeys} from './source/conditional-keys';
 export {ConditionalPick} from './source/conditional-pick';
+export {ConditionalPickDeep, ConditionalPickDeepOptions} from './source/conditional-pick-deep';
 export {UnionToIntersection} from './source/union-to-intersection';
 export {Stringified} from './source/stringified';
 export {FixedLengthArray} from './source/fixed-length-array';

--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ Click the type names for complete docs.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.
+- [`ConditionalPickDeep`](source/conditional-pick-deep.d.ts) - Like `ConditionalPick` except that it selects the properties deeply.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Like `Omit` except it removes properties from a shape where the values extend the given `Condition` type.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`LiteralToPrimitive`](source/literal-to-primitive.d.ts) - Convert a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types) to the [primitive type](source/primitive.d.ts) it belongs to.

--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -24,7 +24,7 @@ ConditionalPickDeep options.
 */
 export interface ConditionalPickDeepOptions {
 	/**
-	Define the condition assertion mode.
+	The condition assertion mode.
 
 	@default 'extends'
 	*/
@@ -32,7 +32,7 @@ export interface ConditionalPickDeepOptions {
 }
 
 /**
-Pick keys recursively from the shape that matches the given `Condition`.
+Pick keys recursively from the shape that matches the given condition.
 
 @see ConditionalPick
 
@@ -41,22 +41,22 @@ Pick keys recursively from the shape that matches the given `Condition`.
 import type {ConditionalPickDeep} from 'type-fest';
 
 type StringPick = ConditionalPickDeep<Example, string>;
-// => {a: string; c: {d: string}}
+//=> {a: string; c: {d: string}}
 
 type StringPickOptional = ConditionalPickDeep<Example, string | undefined>;
-// => {a: string; c: {d: string; e: {f?: string}}}
+//=> {a: string; c: {d: string; e: {f?: string}}}
 
 type StringPickOptionalOnly = ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
-// => {c: {e: {f?: string}}}
+//=> {c: {e: {f?: string}}}
 
 type BooleanPick = ConditionalPickDeep<Example, boolean | undefined>;
-// => {c: {e: {g?: boolean}; j: boolean}}
+//=> {c: {e: {g?: boolean}; j: boolean}}
 
 type NumberPick = ConditionalPickDeep<Example, number>;
-// => {}
+//=> {}
 
 type StringOrBooleanPick = ConditionalPickDeep<Example, string | boolean>;
-// => {
+//=> {
 // 	a: string;
 // 	b: string | boolean;
 // 	c: {
@@ -67,7 +67,7 @@ type StringOrBooleanPick = ConditionalPickDeep<Example, string | boolean>;
 // }
 
 type StringOrBooleanPickOnly = ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
-// => {b: string | boolean; c: {e: {h: string | boolean}}}
+//=> {b: string | boolean; c: {e: {h: string | boolean}}}
 ```
 
 @category Object

--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -40,6 +40,21 @@ Pick keys recursively from the shape that matches the given condition.
 ```
 import type {ConditionalPickDeep} from 'type-fest';
 
+interface Example {
+	a: string;
+	b: string | boolean;
+	c: {
+		d: string;
+		e: {
+			f?: string;
+			g?: boolean;
+			h: string | boolean;
+			i: boolean | bigint;
+		};
+		j: boolean;
+	};
+}
+
 type StringPick = ConditionalPickDeep<Example, string>;
 //=> {a: string; c: {d: string}}
 
@@ -61,7 +76,9 @@ type StringOrBooleanPick = ConditionalPickDeep<Example, string | boolean>;
 // 	b: string | boolean;
 // 	c: {
 // 		d: string;
-// 		e: {h: string | boolean};
+// 		e: {
+// 			h: string | boolean
+// 		};
 // 		j: boolean;
 // 	};
 // }

--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -1,0 +1,85 @@
+import type {Opaque} from './opaque';
+import type {IsEqual} from './internal';
+import type {ConditionalExcept} from './conditional-except';
+import type {ConditionalSimplifyDeep} from './conditional-simplify';
+
+/**
+Used to mark properties that should be excluded.
+*/
+type ConditionalPickDeepSymbol = Opaque<symbol, 'conditional-pick-deep-symbol'>;
+
+/**
+Assert the condition according to the {@link ConditionalPickDeepOptions.condition|condition} option.
+*/
+type AssertCondition<Type, Condition, Options extends ConditionalPickDeepOptions> = Options['condition'] extends 'equality'
+	? IsEqual<Type, Condition>
+	: Type extends Condition
+	? true
+	: false;
+
+/**
+ConditionalPickDeep options.
+
+@see ConditionalPickDeep
+*/
+export interface ConditionalPickDeepOptions {
+	/**
+	Define the condition assertion mode.
+
+	@default 'extends'
+	*/
+	condition?: 'extends' | 'equality';
+}
+
+/**
+Pick keys recursively from the shape that matches the given `Condition`.
+
+@see ConditionalPick
+
+@example
+```
+import type {ConditionalPickDeep} from 'type-fest';
+
+type StringPick = ConditionalPickDeep<Example, string>;
+// => {a: string; c: {d: string}}
+
+type StringPickOptional = ConditionalPickDeep<Example, string | undefined>;
+// => {a: string; c: {d: string; e: {f?: string}}}
+
+type StringPickOptionalOnly = ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
+// => {c: {e: {f?: string}}}
+
+type BooleanPick = ConditionalPickDeep<Example, boolean | undefined>;
+// => {c: {e: {g?: boolean}; j: boolean}}
+
+type NumberPick = ConditionalPickDeep<Example, number>;
+// => {}
+
+type StringOrBooleanPick = ConditionalPickDeep<Example, string | boolean>;
+// => {
+// 	a: string;
+// 	b: string | boolean;
+// 	c: {
+// 		d: string;
+// 		e: {h: string | boolean};
+// 		j: boolean;
+// 	};
+// }
+
+type StringOrBooleanPickOnly = ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
+// => {b: string | boolean; c: {e: {h: string | boolean}}}
+```
+
+@category Object
+*/
+export type ConditionalPickDeep<
+	Type,
+	Condition,
+	Options extends ConditionalPickDeepOptions = {},
+> = ConditionalSimplifyDeep<ConditionalExcept<{
+	[Key in keyof Type]: AssertCondition<Type[Key], Condition, Options> extends true
+		? Type[Key]
+		: Type[Key] extends object
+		? ConditionalPickDeep<Type[Key], Condition, Options>
+		: ConditionalPickDeepSymbol;
+}, (ConditionalPickDeepSymbol | undefined) | Record<PropertyKey, never>>>;

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -1,0 +1,46 @@
+import {expectType} from 'tsd';
+import type {ConditionalPickDeep} from '../index';
+
+interface Example {
+	a: string;
+	b: string | boolean;
+	c: {
+		d: string;
+		e: {
+			f?: string;
+			g?: boolean;
+			h: string | boolean;
+			i: boolean | bigint;
+		};
+		j: boolean;
+	};
+}
+
+declare const stringPick: ConditionalPickDeep<Example, string>;
+expectType<{a: string; c: {d: string}}>(stringPick);
+
+declare const stringPickOptional: ConditionalPickDeep<Example, string | undefined>;
+expectType<{a: string; c: {d: string; e: {f?: string}}}>(stringPickOptional);
+
+declare const stringPickOptionalOnly: ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
+expectType<{c: {e: {f?: string}}}>(stringPickOptionalOnly);
+
+declare const booleanPick: ConditionalPickDeep<Example, boolean | undefined>;
+expectType<{c: {e: {g?: boolean}; j: boolean}}>(booleanPick);
+
+declare const numberPick: ConditionalPickDeep<Example, number>;
+expectType<{}>(numberPick);
+
+declare const stringOrBooleanPick: ConditionalPickDeep<Example, string | boolean>;
+expectType<{
+	a: string;
+	b: string | boolean;
+	c: {
+		d: string;
+		e: {h: string | boolean};
+		j: boolean;
+	};
+}>(stringOrBooleanPick);
+
+declare const stringOrBooleanPickOnly: ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
+expectType<{b: string | boolean; c: {e: {h: string | boolean}}}>(stringOrBooleanPickOnly);


### PR DESCRIPTION
Fixes #438

```ts
import type {ConditionalPickDeep} from 'type-fest';

type StringPick = ConditionalPickDeep<Example, string>;
// => {a: string; c: {d: string}}

type StringPickOptional = ConditionalPickDeep<Example, string | undefined>;
// => {a: string; c: {d: string; e: {f?: string}}}

type StringPickOptionalOnly = ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
// => {c: {e: {f?: string}}}

type BooleanPick = ConditionalPickDeep<Example, boolean | undefined>;
// => {c: {e: {g?: boolean}; j: boolean}}

type NumberPick = ConditionalPickDeep<Example, number>;
// => {}

type StringOrBooleanPick = ConditionalPickDeep<Example, string | boolean>;
// => {
// 	a: string;
// 	b: string | boolean;
// 	c: {
// 		d: string;
// 		e: {h: string | boolean};
// 		j: boolean;
// 	};
// }

type StringOrBooleanPickOnly = ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
// => {b: string | boolean; c: {e: {h: string | boolean}}}
```