### PR TITLE
Add `Jsonify` support for optional object keys

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -62,7 +62,7 @@ const timeJson = JSON.parse(JSON.stringify(time)) as Jsonify<typeof time>;
 
 @category JSON
 */
-type Jsonify<T> =
+export type Jsonify<T> =
 	// Check if there are any non-JSONable types represented in the union.
 	// Note: The use of tuples in this first condition side-steps distributive conditional types
 	// (see https://github.com/microsoft/TypeScript/issues/29368#issuecomment-453529532)

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,5 +1,5 @@
 import type {JsonPrimitive, JsonValue} from './basic';
-import type {Finite, NegativeInfinity, PositiveInfinity} from './numeric';
+import type {NegativeInfinity, PositiveInfinity} from './numeric';
 import type {TypedArray} from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,6 +1,6 @@
 import type {JsonPrimitive, JsonValue} from './basic';
-import {Finite, NegativeInfinity, PositiveInfinity} from './numeric';
-import {TypedArray} from './typed-array';
+import type {Finite, NegativeInfinity, PositiveInfinity} from './numeric';
+import type {TypedArray} from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...args: any[]) => any) | undefined | symbol;

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -235,5 +235,41 @@ declare const jsonifiedOptionalTypeUnion: Jsonify<OptionalTypeUnion>;
 declare const jsonifiedNonOptionalTypeUnion: Jsonify<NonOptionalTypeUnion>;
 
 expectType<{a?: string}>(jsonifiedOptionalPrimitive);
-expectType<{a?: never}>(jsonifiedOptionalTypeUnion);
-expectType<{a: never}>(jsonifiedNonOptionalTypeUnion);
+expectType<{}>(jsonifiedOptionalTypeUnion);
+expectType<{a?: string}>(jsonifiedNonOptionalTypeUnion);
+
+// Test for 'Jsonify support for optional object keys, unserializable object values' #424
+// See https://github.com/sindresorhus/type-fest/issues/424
+type AppData = {
+	// Should be kept
+	requiredString: string;
+	requiredUnion: number | boolean;
+
+	// Should be kept and set to optional
+	optionalString?: string;
+	optionalUnion?: number | string;
+	optionalStringUndefined: string | undefined;
+	optionalUnionUndefined: number | string | undefined;
+
+	// Should be omitted
+	requiredFunction: () => any;
+	optionalFunction?: () => any;
+	requiredFunctionUnion: string | (() => any);
+	optionalFunctionUnion?: string | (() => any);
+	optionalFunctionUndefined: (() => any) | undefined;
+	optionalFunctionUnionUndefined: string | (() => any) | undefined;
+};
+
+type ExpectedAppDataJson = {
+	requiredString: string;
+	requiredUnion: number | boolean;
+
+	optionalString?: string;
+	optionalUnion?: string | number;
+	optionalStringUndefined?: string;
+	optionalUnionUndefined?: string | number;
+};
+
+declare const response: Jsonify<AppData>;
+
+expectType<ExpectedAppDataJson>(response);


### PR DESCRIPTION
This PR adds support for optional object keys

Related to #424 
