### PR TITLE
feat: Add `packageManager` field to `PackageJson` type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -623,6 +623,16 @@ declare namespace PackageJson {
 		};
 	}
 
+	/**
+	Type for [`package.json` file used by the Node.js runtime](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions).
+	 */
+	export interface NodeJsStandard {
+		/**
+		Package manager is expected to be used when working on the current project.
+		*/
+		packageManager?: string;
+	}
+
 	export interface PublishConfig {
 		/**
 		Additional, less common properties from the [npm docs on `publishConfig`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig).
@@ -656,6 +666,7 @@ Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-j
 @category File
 */
 export type PackageJson =
+PackageJson.NodeJsStandard &
 PackageJson.PackageJsonStandard &
 PackageJson.NonStandardEntryPoints &
 PackageJson.TypeScriptConfiguration &

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -631,7 +631,7 @@ declare namespace PackageJson {
 		Defines which package manager is expected to be used when working on the current project. It can set to any of the [supported package managers](https://nodejs.org/api/corepack.html#supported-package-managers), and will ensure that your teams use the exact same package manager versions without having to install anything else than Node.js.
 
 		__This field is currently experimental and needs to be opted-in; check the [Corepack](https://nodejs.org/api/corepack.html) page for details about the procedure.__
-		
+
 		@example
 		```json
 		{

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -625,10 +625,19 @@ declare namespace PackageJson {
 
 	/**
 	Type for [`package.json` file used by the Node.js runtime](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions).
-	 */
+	*/
 	export interface NodeJsStandard {
 		/**
-		Package manager is expected to be used when working on the current project.
+		Defines which package manager is expected to be used when working on the current project. It can set to any of the [supported package managers](https://nodejs.org/api/corepack.html#supported-package-managers), and will ensure that your teams use the exact same package manager versions without having to install anything else than Node.js.
+
+		__This field is currently experimental and needs to be opted-in; check the [Corepack](https://nodejs.org/api/corepack.html) page for details about the procedure.__
+		
+		@example
+		```json
+		{
+			"packageManager": "<package manager name>@<version>"
+		}
+		```
 		*/
 		packageManager?: string;
 	}

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -16,6 +16,7 @@ expectType<PackageJson.Person[] | undefined>(packageJson.contributors);
 expectType<PackageJson.Person[] | undefined>(packageJson.maintainers);
 expectType<string[] | undefined>(packageJson.files);
 expectType<string | undefined>(packageJson.main);
+expectType<string | undefined>(packageJson.packageManager);
 expectType<string | Partial<Record<string, string>> | undefined>(packageJson.bin);
 expectType<string | undefined>(packageJson.types);
 expectType<string | undefined>(packageJson.typings);


### PR DESCRIPTION
Related issues: nothing

I added new field, `packageManager`, to `package-json.d.ts`.
https://nodejs.org/api/packages.html#packagemanager

**Notes**

- `packageManager` is a field defined in Node.js doc but not npm doc. `package-json.d.ts` has `PackageJsonStandard` interface, but not `NodeJsStandard` interface.
- I created `NodeJsStandard` interface and add `packageManager` field only. If we follow Node.js spec, it should have `name`, `main`, `type`,  `exports` and `imports`, but I didn't add because `PackageJsonStandard` already has them and it's redundant.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
