### PR TITLE
Add screaming snake case support to `DelimiterCase` and `SplitIncludingDelimiters`

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,11 +1,10 @@
 import type {UpperCaseCharacters, WordSeparators} from '../source/internal';
 
-/**
-Unlike a simpler split, this one includes the delimiter splitted on in the resulting array literal. This is to enable splitting on, for example, upper-case characters.
+// Transforms a string that is fully uppercase into a fully lowercase version. Needed to add support for SCREMAING_SNAKE_CASE, see https://github.com/sindresorhus/type-fest/issues/385
+type UpperCaseToLowerCase<T extends string> = T extends Uppercase<T> ? Lowercase<T> : T;
 
-@category Template literal
-*/
-export type SplitIncludingDelimiters<Source extends string, Delimiter extends string> =
+// This implemntation does not supports SCREMAING_SNAKE_CASE, it used internaly by `SplitIncludingDelimiters`.
+type SplitIncludingDelimiters_<Source extends string, Delimiter extends string> =
 	Source extends '' ? [] :
 	Source extends `${infer FirstPart}${Delimiter}${infer SecondPart}` ?
 	(
@@ -18,6 +17,13 @@ export type SplitIncludingDelimiters<Source extends string, Delimiter extends st
 			: never
 	) :
 	[Source];
+
+/**
+Unlike a simpler split, this one includes the delimiter splitted on in the resulting array literal. This is to enable splitting on, for example, upper-case characters.
+
+@category Template literal
+*/
+export type SplitIncludingDelimiters<Source extends string, Delimiter extends string> = SplitIncludingDelimiters_<UpperCaseToLowerCase<Source>, Delimiter>;
 
 /**
 Format a specific part of the splitted string literal that `StringArrayToDelimiterCase<>` fuses together, ensuring desired casing.

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -8,6 +8,8 @@ const splitFromComplexCamel: SplitIncludingDelimiters<'fooBarAbc123', WordSepara
 expectType<['foo', 'B', 'ar', 'A', 'bc123']>(splitFromComplexCamel);
 const splitFromWordSeparators: SplitIncludingDelimiters<'foo-bar_car far', WordSeparators> = ['foo', '-', 'bar', '_', 'car', ' ', 'far'];
 expectType<['foo', '-', 'bar', '_', 'car', ' ', 'far']>(splitFromWordSeparators);
+const splitFromScreamingSnakeCase: SplitIncludingDelimiters<'FOO_BAR', WordSeparators | UpperCaseCharacters> = ['foo', '_', 'bar'];
+expectType<['foo', '_', 'bar']>(splitFromScreamingSnakeCase);
 
 // DelimiterCase
 const delimiterFromCamel: DelimiterCase<'fooBar', '#'> = 'foo#bar';
@@ -48,6 +50,9 @@ expectType<'foo####bar'>(delimiterFromRepeatedSeparators);
 
 const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
 expectType<string>(delimiterFromString);
+
+const delimiterFromScreamingSnake: DelimiterCase<'FOO_BAR', '#'> = 'foo#bar';
+expectType<'foo#bar'>(delimiterFromScreamingSnake);
 
 // Verifying example
 type OddCasedProperties<T> = {


### PR DESCRIPTION
Fixes #385

// @younho9 
