### PR TITLE
Add index signatures support on `Merge` and improve performances

### DIFF
--- a/source/merge.d.ts
+++ b/source/merge.d.ts
@@ -1,7 +1,6 @@
-import type {Except} from './except';
+import type {OmitIndexSignature} from './omit-index-signature';
+import type {PickIndexSignature} from './pick-index-signature';
 import type {Simplify} from './simplify';
-
-type Merge_<FirstType, SecondType> = Except<FirstType, Extract<keyof FirstType, keyof SecondType>> & SecondType;
 
 /**
 Merge two types into a new type. Keys of the second type overrides keys of the first type.
@@ -10,18 +9,37 @@ Merge two types into a new type. Keys of the second type overrides keys of the f
 ```
 import type {Merge} from 'type-fest';
 
-type Foo = {
-	a: number;
-	b: string;
-};
+interface Foo {
+	[x: string]: unknown;
+	[x: number]: unknown;
+	foo: string;
+	bar: symbol;
+}
 
 type Bar = {
-	b: number;
+	[x: number]: number;
+	[x: symbol]: unknown;
+	bar: Date;
+	baz: boolean;
 };
 
-const ab: Merge<Foo, Bar> = {a: 1, b: 2};
+export type FooBar = Merge<Foo, Bar>;
+// => {
+// 	[x: string]: unknown;
+// 	[x: number]: number;
+// 	[x: symbol]: unknown;
+// 	foo: string;
+// 	bar: Date;
+// 	baz: boolean;
+// }
 ```
 
 @category Object
 */
-export type Merge<FirstType, SecondType> = Simplify<Merge_<FirstType, SecondType>>;
+export type Merge<Destination, Source> = Simplify<{
+	[Key in keyof OmitIndexSignature<Destination & Source>]: Key extends keyof Source
+		? Source[Key]
+		: Key extends keyof Destination
+			? Destination[Key]
+			: never;
+} & PickIndexSignature<Destination & Source>>;

--- a/test-d/merge.ts
+++ b/test-d/merge.ts
@@ -1,4 +1,4 @@
-import {expectAssignable} from 'tsd';
+import {expectAssignable, expectError} from 'tsd';
 import type {Merge} from '../index';
 
 type Foo = {
@@ -12,3 +12,47 @@ type Bar = {
 
 const ab: Merge<Foo, Bar> = {a: 1, b: 2};
 expectAssignable<{a: number; b: number}>(ab);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+interface FooInterface {
+	[x: string]: unknown;
+	[x: number]: unknown;
+	foo: string;
+	bar: symbol;
+}
+
+type BarType = {
+	[x: number]: number;
+	[x: symbol]: boolean;
+	bar: Date;
+	baz: boolean;
+};
+
+type FooBar = Merge<FooInterface, BarType>;
+
+const fooBar: FooBar = {
+	'foo-string': 'foo',
+	42: 24,
+	[Symbol(42)]: true,
+	foo: 'foo',
+	bar: new Date(),
+	baz: true,
+};
+
+expectAssignable<{
+	[x: string]: unknown;
+	[x: number]: number;
+	[x: symbol]: boolean;
+	foo: string;
+	bar: Date;
+	baz: boolean;
+}>(fooBar);
+
+declare function setFooBar(fooBar: FooBar): void;
+
+expectError(setFooBar({
+	[Symbol(42)]: 'life',
+	foo: 'foo',
+	bar: new Date(),
+	baz: true,
+}));


### PR DESCRIPTION
This PR adds support for index signatues requested in #382 and by the way it improves performance by reducing the number of instantiations by ~4 times #304.

Fix #304 
Fix #382 