### PR TITLE
`Merge`: Fix index signature type overwrite

### DIFF
--- a/source/merge.d.ts
+++ b/source/merge.d.ts
@@ -2,6 +2,15 @@ import type {OmitIndexSignature} from './omit-index-signature';
 import type {PickIndexSignature} from './pick-index-signature';
 import type {EnforceOptional} from './enforce-optional';
 
+// Merges two objects without worrying about index signatures or optional keys.
+type SimpleMerge<Destination, Source> = {
+	[Key in keyof Destination | keyof Source]: Key extends keyof Source
+		? Source[Key]
+		: Key extends keyof Destination
+			? Destination[Key]
+			: never;
+};
+
 /**
 Merge two types into a new type. Keys of the second type overrides keys of the first type.
 
@@ -36,10 +45,6 @@ export type FooBar = Merge<Foo, Bar>;
 
 @category Object
 */
-export type Merge<Destination, Source> = EnforceOptional<{
-	[Key in keyof OmitIndexSignature<Destination> | keyof OmitIndexSignature<Source>]: Key extends keyof Source
-		? Source[Key]
-		: Key extends keyof Destination
-			? Destination[Key]
-			: never;
-} & PickIndexSignature<Destination> & PickIndexSignature<Source>>;
+export type Merge<Destination, Source> = EnforceOptional<
+SimpleMerge<PickIndexSignature<Destination>, PickIndexSignature<Source>>
+& SimpleMerge<OmitIndexSignature<Destination>, OmitIndexSignature<Source>>>;

--- a/test-d/merge.ts
+++ b/test-d/merge.ts
@@ -104,3 +104,33 @@ expectType<{
 	f?: number;
 	g: undefined;
 }>(fooBarWithOptionalKeys);
+
+// Checks that an indexed key type can be overwritten.
+type FooWithIndexSignature = {
+	[x: string]: unknown;
+	[x: number]: boolean;
+	[x: symbol]: number;
+	foo: boolean;
+	fooBar: boolean;
+};
+
+type BarWithIndexSignatureOverwrite = {
+	[x: string]: number | string | boolean;
+	[x: number]: number | string;
+	[x: symbol]: symbol;
+	bar: string;
+	fooBar: string;
+};
+
+type FooBarWithIndexSignature = Merge<FooWithIndexSignature, BarWithIndexSignatureOverwrite>;
+
+declare const fooBarWithIndexSignature: FooBarWithIndexSignature;
+
+expectType<{
+	[x: string]: string | number | boolean;
+	[x: number]: string | number;
+	[x: symbol]: symbol;
+	foo: boolean;
+	bar: string;
+	fooBar: string;
+}>(fooBarWithIndexSignature);


### PR DESCRIPTION
Same as #456 but for index signatures.
