### PR TITLE
Fix `DelimiterCase` regression after TS 4.8

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -88,7 +88,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 @category Change case
 @category Template literal
 */
-export type DelimiterCase<Value, Delimiter extends string> = Value extends string
+export type DelimiterCase<Value, Delimiter extends string> = string extends Value ? Value : Value extends string
 	? StringArrayToDelimiterCase<
 	SplitIncludingDelimiters<Value, WordSeparators | UpperCaseCharacters>,
 	true,

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -48,9 +48,8 @@ expectType<'##very#prefixed'>(delimiterFromDoublePrefixedKebab);
 const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'> = 'foo####bar';
 expectType<'foo####bar'>(delimiterFromRepeatedSeparators);
 
-// TODO: Fails after TS 4.8.
-// const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
-// expectType<string>(delimiterFromString);
+const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
+expectType<string>(delimiterFromString);
 
 const delimiterFromScreamingSnake: DelimiterCase<'FOO_BAR', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromScreamingSnake);


### PR DESCRIPTION
Fix the test that didn't pass after TS 4.8. 