### PR TITLE
Fix `PackageJson` and `JsonObject` types

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -19,7 +19,7 @@ This type can be useful to enforce some input to be JSON-compatible or as a supe
 
 @category JSON
 */
-export type JsonObject = {[Key in string]?: JsonValue};
+export type JsonObject = {[Key in string]: JsonValue} & {[Key in string]?: JsonValue | undefined};
 
 /**
 Matches a JSON array.

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -1,4 +1,5 @@
 import type {LiteralUnion} from './literal-union';
+import type {JsonObject, JsonValue} from './basic';
 
 declare namespace PackageJson {
 	/**
@@ -27,7 +28,7 @@ declare namespace PackageJson {
 		};
 
 	export type DirectoryLocations = {
-		[directoryType: string]: unknown;
+		[directoryType: string]: JsonValue | undefined;
 
 		/**
 		Location for executable scripts. Sugar to generate entries in the `bin` property by walking the folder.
@@ -483,7 +484,7 @@ declare namespace PackageJson {
 		/**
 		Is used to set configuration parameters used in package scripts that persist across upgrades.
 		*/
-		config?: Record<string, unknown>;
+		config?: JsonObject;
 
 		/**
 		The dependencies of the package.
@@ -648,7 +649,7 @@ declare namespace PackageJson {
 		/**
 		Additional, less common properties from the [npm docs on `publishConfig`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig).
 		*/
-		[additionalProperties: string]: unknown;
+		[additionalProperties: string]: JsonValue | undefined;
 
 		/**
 		When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set `--access=public`. The only valid values for access are public and restricted. Unscoped packages always have an access level of public.
@@ -677,6 +678,7 @@ Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-j
 @category File
 */
 export type PackageJson =
+JsonObject &
 PackageJson.NodeJsStandard &
 PackageJson.PackageJsonStandard &
 PackageJson.NonStandardEntryPoints &

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -26,7 +26,7 @@ expectType<{type: string; url: string; directory?: string} | string | undefined>
 	packageJson.repository,
 );
 expectType<PackageJson.Scripts | undefined>(packageJson.scripts);
-expectType<Record<string, unknown> | undefined>(packageJson.config);
+expectType<JsonObject | undefined>(packageJson.config);
 expectType<PackageJson.Dependency | undefined>(packageJson.dependencies);
 expectType<PackageJson.Dependency | undefined>(packageJson.devDependencies);
 expectType<PackageJson.Dependency | undefined>(
@@ -95,3 +95,16 @@ expectAssignable<JsonObject>({});
 expectAssignable<JsonObject>({bugs: 42});
 expectAssignable<JsonObject>({bugs: [42]});
 expectAssignable<JsonObject>({bugs: {life: 42}});
+
+// `PackageJson` should be a valid `JsonObject`.
+// See https://github.com/sindresorhus/type-fest/issues/79
+type UnknownRecord = Record<string, unknown>;
+
+const unknownRecord: UnknownRecord = {};
+const jsonObject: JsonObject = {};
+
+expectAssignable<UnknownRecord>(packageJson);
+expectNotAssignable<PackageJson>(unknownRecord);
+
+expectAssignable<PackageJson>(jsonObject);
+expectAssignable<JsonObject>(packageJson);

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -1,5 +1,5 @@
-import {expectType, expectAssignable, expectNotAssignable} from 'tsd';
-import type {PackageJson, LiteralUnion} from '../index';
+import {expectType, expectAssignable, expectNotAssignable, expectError} from 'tsd';
+import type {PackageJson, LiteralUnion, JsonObject} from '../index';
 
 const packageJson: PackageJson = {};
 
@@ -81,4 +81,17 @@ expectAssignable<typeof packageJson['typesVersions']>({
 	'<4': undefined,
 });
 
-expectNotAssignable<Record<string, unknown>>(packageJson);
+// Must reject an object that contains properties with `undefined` values.
+// See https://github.com/sindresorhus/type-fest/issues/272
+declare function setConfig(config: JsonObject): void;
+
+expectError(setConfig({bugs: undefined}));
+expectError(setConfig({bugs: {life: undefined}}));
+
+expectNotAssignable<JsonObject>({bugs: undefined});
+expectNotAssignable<JsonObject>({bugs: {life: undefined}});
+
+expectAssignable<JsonObject>({});
+expectAssignable<JsonObject>({bugs: 42});
+expectAssignable<JsonObject>({bugs: [42]});
+expectAssignable<JsonObject>({bugs: {life: 42}});


### PR DESCRIPTION
This PR fix #272 and fix #79