### PR TITLE
Update require-at-least-one.d.ts

### DIFF
--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -10,7 +10,6 @@ import type {RequireAtLeastOne} from 'type-fest';
 type Responder = {
 	text?: () => string;
 	json?: () => string;
-
 	secure?: boolean;
 };
 


### PR DESCRIPTION
Remove unnecessary empty line.

That empty line does not exist in similar examples like [require-all-or-none](https://github.com/sindresorhus/type-fest/blob/main/source/require-all-or-none.d.ts#L16) and [require-exactly-one](https://github.com/sindresorhus/type-fest/blob/main/source/require-exactly-one.d.ts#L17).

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
