### PR TITLE
`PackageJson`: strict check for `imports`

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -240,7 +240,7 @@ declare namespace PackageJson {
 	Import map entries of a module, optionally with conditions.
 	*/
 	export type Imports = { // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
-		[key: string]: string | {[key in ExportCondition]: Exports};
+		[key: `#${string}`]: string | {[key in ExportCondition]: Exports};
 	};
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -53,6 +53,8 @@ expectAssignable<
 string
 >>
 >(packageJson.cpu);
+expectAssignable<PackageJson.Imports>({'#unicorn': 'unicorn'});
+expectNotAssignable<PackageJson.Imports>({unicorn: 'unicorn'});
 expectType<boolean | undefined>(packageJson.preferGlobal);
 expectType<boolean | undefined>(packageJson.private);
 expectType<PackageJson.PublishConfig | undefined>(packageJson.publishConfig);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Refs:

- [Node.js docs - Subpath imports](https://nodejs.org/api/packages.html#subpath-imports)


Entries in the "imports" field must always start with `#` to ensure they are disambiguated from external package specifiers.
