### PR TITLE
fix(readonly-deep): make arrays immutable (not just readonly deep)

### DIFF
--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -63,9 +63,11 @@ type ReadonlySetDeep<ItemType> = {} & Readonly<ReadonlySet<ReadonlyDeep<ItemType
 /**
 Same as `ReadonlyDeep`, but accepts only `object`s as inputs. Internal helper for `ReadonlyDeep`.
 */
-type ReadonlyObjectDeep<ObjectType extends object> = {
-	readonly [KeyType in keyof ObjectType]: ReadonlyDeep<ObjectType[KeyType]>
-};
+type ReadonlyObjectDeep<ObjectType extends object> =
+	ObjectType extends readonly unknown[]
+		// Only apply the array fix to arrays to prevent potential issues.
+		? {readonly [KeyType in keyof (ObjectType & {})]: ReadonlyDeep<ObjectType[KeyType]>;}
+		: {readonly [KeyType in keyof ObjectType]: ReadonlyDeep<ObjectType[KeyType]>;};
 
 /**
 Test if the given function has multiple call signatures.

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -61,18 +61,18 @@ expectType<Date>(readonlyData.date);
 expectType<RegExp>(readonlyData.regExp);
 expectType<Readonly<ReadonlyMap<string, string>>>(readonlyData.map);
 expectType<Readonly<ReadonlySet<string>>>(readonlyData.set);
-expectType<readonly string[]>(readonlyData.array);
-expectType<readonly ['foo']>(readonlyData.tuple);
+expectType<ReadonlyObjectDeep<string[]>>(readonlyData.array);
+expectType<ReadonlyObjectDeep<['foo']>>(readonlyData.tuple);
 expectType<Readonly<ReadonlyMap<string, string>>>(readonlyData.readonlyMap);
 expectType<Readonly<ReadonlySet<string>>>(readonlyData.readonlySet);
-expectType<readonly string[]>(readonlyData.readonlyArray);
-expectType<readonly ['foo']>(readonlyData.readonlyTuple);
+expectType<ReadonlyObjectDeep<readonly string[]>>(readonlyData.readonlyArray);
+expectType<ReadonlyObjectDeep<readonly ['foo']>>(readonlyData.readonlyTuple);
 expectError(readonlyData.readonlyArray.every = () => true);
 expectError(readonlyData.readonlyTuple.every = () => true);
 
 expectType<((foo: number) => string) & ReadonlyObjectDeep<Namespace>>(readonlyData.namespace);
 expectType<string>(readonlyData.namespace(1));
-expectType<readonly boolean[]>(readonlyData.namespace.baz);
+expectType<ReadonlyObjectDeep<boolean[]>>(readonlyData.namespace.baz);
 
 // These currently aren't readonly due to TypeScript limitations.
 // @see https://github.com/microsoft/TypeScript/issues/29732

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -67,6 +67,8 @@ expectType<Readonly<ReadonlyMap<string, string>>>(readonlyData.readonlyMap);
 expectType<Readonly<ReadonlySet<string>>>(readonlyData.readonlySet);
 expectType<readonly string[]>(readonlyData.readonlyArray);
 expectType<readonly ['foo']>(readonlyData.readonlyTuple);
+expectError(readonlyData.readonlyArray.every = () => true);
+expectError(readonlyData.readonlyTuple.every = () => true);
 
 expectType<((foo: number) => string) & ReadonlyObjectDeep<Namespace>>(readonlyData.namespace);
 expectType<string>(readonlyData.namespace(1));


### PR DESCRIPTION
This PR essentially makes it so that `ReadonlyDeep<T[]>` returns `Readonly<readonly T[]>` instead of just `readonly T[]` (like how `Set` and `Map` are handled).

However, as TypeScript handles arrays "specially" a small work around is needed to make `Readonly<readonly T[]>` actually work as expected.