### PR TITLE
Update tests to use `expectNotAssignable` where appropriate

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -6,7 +6,7 @@
 - Please help review the other open pull requests. If there are no open pull requests, provide some feedback on some of the open issues.
 - Create a new file in the `test-d` directory and write at least one type test.
 	- See the other tests for inspiration.
-	- If it makes sense, also write a negative test using [`expectError()`](https://github.com/SamVerschueren/tsd#expecterrorfunction).
+	- If it makes sense, also write a negative test using [`expectNotAssignable()`](https://github.com/SamVerschueren/tsd#expectnotassignabletexpression-any) or, to test other diagnostics, [`expectError()`](https://github.com/SamVerschueren/tsd#expecterrort--anyexpression-t).
 - Don't use one-character type names like `T` and `U`. Use descriptive names. See the existing types for inspiration.
 - Write a good documentation comment that includes:
 	- Write a short and clear description of what the type does.

--- a/test-d/async-return-type.ts
+++ b/test-d/async-return-type.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {AsyncReturnType} from '../index';
 
 async function asyncFunction(): Promise<number> {
@@ -10,5 +10,5 @@ type Value = AsyncReturnType<typeof asyncFunction>;
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 asyncFunction().then(value => {
 	expectType<Value>(value);
-	expectError<string>(value);
+	expectNotAssignable<string>(value);
 });

--- a/test-d/conditional-simplify.ts
+++ b/test-d/conditional-simplify.ts
@@ -1,4 +1,4 @@
-import {expectError, expectType} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {ConditionalSimplify, ConditionalSimplifyDeep} from '../source/conditional-simplify';
 
 type Position = {top: number; left: number};
@@ -21,7 +21,7 @@ type SimplifiedFunctionPass = ConditionalSimplify<SomeFunction, Function>; // Re
 declare const simplifiedFunctionFail: SimplifiedFunctionFail;
 declare const simplifiedFunctionPass: SimplifiedFunctionPass;
 
-expectError<SomeFunction>(simplifiedFunctionFail);
+expectNotAssignable<SomeFunction>(simplifiedFunctionFail);
 expectType<SomeFunction>(simplifiedFunctionPass);
 
 // Should simplify interface deeply.
@@ -55,7 +55,7 @@ type MovableNodeSimplifiedPass = ConditionalSimplifyDeep<MovableCollection, Func
 declare const movableNodeSimplifiedFail: MovableNodeSimplifiedFail;
 declare const movableNodeSimplifiedPass: MovableNodeSimplifiedPass;
 
-expectError<MovableCollection>(movableNodeSimplifiedFail);
+expectNotAssignable<MovableCollection>(movableNodeSimplifiedFail);
 expectType<MovableCollection>(movableNodeSimplifiedPass);
 
 const movablePosition = {

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -40,16 +40,16 @@ expectType<true>(nullIncludesNullPass);
 
 declare const anything: any;
 
-// Verify incorrect usages of Includes produces an error.
+// Verify that incorrect usage of `Includes` produces an error.
 
-// Missing all generic params.
+// Missing all generic parameters.
 expectError<Includes>(anything);
 
-// Missing Item generic param
+// Missing `Item` generic parameter.
 expectError<Includes<['my', 'array', 'has', 'stuff']>>(anything);
 
-// Value generic param is a string not an array.
+// Value generic parameter is a string not an array.
 expectError<Includes<'why a string?', 5>>(anything);
 
-// Value generic param is an object not an array.
+// Value generic parameter is an object not an array.
 expectError<Includes<{key: 'value'}, 7>>(anything);

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -40,10 +40,16 @@ expectType<true>(nullIncludesNullPass);
 
 declare const anything: any;
 
+// Verify incorrect usages of Includes produces an error.
+
+// Missing all generic params.
 expectError<Includes>(anything);
 
+// Missing Item generic param
 expectError<Includes<['my', 'array', 'has', 'stuff']>>(anything);
 
+// Value generic param is a string not an array.
 expectError<Includes<'why a string?', 5>>(anything);
 
+// Value generic param is an object not an array.
 expectError<Includes<{key: 'value'}, 7>>(anything);

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -1,4 +1,4 @@
-import {expectError, expectType} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {Join} from '../index';
 
 // General use.
@@ -8,16 +8,16 @@ const generalTestVariantOnlyNumbers: Join<[1, 2, 3], '.'> = '1.2.3';
 expectType<'foo.0.baz'>(generalTestVariantMixed);
 expectType<'1.2.3'>(generalTestVariantOnlyNumbers);
 expectType<'foo.bar.baz'>(generalTestVariantOnlyStrings);
-expectError<'foo'>(generalTestVariantOnlyStrings);
-expectError<'foo.bar'>(generalTestVariantOnlyStrings);
-expectError<'foo.bar.ham'>(generalTestVariantOnlyStrings);
+expectNotAssignable<'foo'>(generalTestVariantOnlyStrings);
+expectNotAssignable<'foo.bar'>(generalTestVariantOnlyStrings);
+expectNotAssignable<'foo.bar.ham'>(generalTestVariantOnlyStrings);
 
 // Empty string delimiter.
 const emptyDelimiter: Join<['foo', 'bar', 'baz'], ''> = 'foobarbaz';
 expectType<'foobarbaz'>(emptyDelimiter);
-expectError<'foo.bar.baz'>(emptyDelimiter);
+expectNotAssignable<'foo.bar.baz'>(emptyDelimiter);
 
 // Empty input.
 const emptyInput: Join<[], '.'> = '';
 expectType<''>(emptyInput);
-expectError<'foo'>(emptyInput);
+expectNotAssignable<'foo'>(emptyInput);

--- a/test-d/merge-exclusive.ts
+++ b/test-d/merge-exclusive.ts
@@ -1,4 +1,4 @@
-import {expectError, expectAssignable} from 'tsd';
+import {expectNotAssignable, expectAssignable} from 'tsd';
 import type {MergeExclusive} from '../index';
 
 type BaseOptions = {
@@ -25,4 +25,4 @@ expectAssignable<{option?: string; exclusive1?: string; exclusive2: number}>(
 	exclusiveVariation2,
 );
 
-expectError<Options>({exclusive1: true, exclusive2: 1});
+expectNotAssignable<Options>({exclusive1: true, exclusive2: 1});

--- a/test-d/opaque.ts
+++ b/test-d/opaque.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectError, expectNotType} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectNotType} from 'tsd';
 import type {Opaque, UnwrapOpaque} from '../index';
 
 type Value = Opaque<number, 'Value'>;
@@ -10,7 +10,7 @@ const value: Value = 2 as Value;
 expectAssignable<number>(value);
 
 // You cannot modify an opaque value.
-expectError<Value>(value + 2);
+expectNotAssignable<Value>(value + 2);
 
 type WithoutToken = Opaque<number>;
 expectAssignable<WithoutToken>(2 as WithoutToken);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {Schema} from '../index';
 
 const foo = {
@@ -46,9 +46,9 @@ const fooSchema: FooSchema = {
 	},
 };
 
-expectError<FooSchema>(foo);
-expectError<FooSchema>({key: 'value'});
-expectError<FooSchema>(new Date());
+expectNotAssignable<FooSchema>(foo);
+expectNotAssignable<FooSchema>({key: 'value'});
+expectNotAssignable<FooSchema>(new Date());
 expectType<FooOption>(fooSchema.baz);
 
 const barSchema = fooSchema.bar as Schema<typeof foo['bar'], FooOption>;
@@ -102,7 +102,7 @@ const complexFoo: ComplexSchema = {
 	},
 };
 
-expectError<ComplexSchema>(foo);
+expectNotAssignable<ComplexSchema>(foo);
 expectType<ComplexOption>(complexFoo.baz);
 
 const complexBarSchema = complexFoo.bar as Schema<typeof foo['bar'], ComplexOption>;

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {SetNonNullable} from '../index';
 
 // Update one possibly undefined key and one possibly null key to non-nullable.
@@ -15,4 +15,4 @@ expectType<{a: number; b?: string}>(variation3);
 
 // Fail if type changes even if non-nullable is right.
 declare const variation4: SetNonNullable<{a: number; b: string | undefined}, 'b'>;
-expectError<{a: string; b: string}>(variation4);
+expectNotAssignable<{a: string; b: string}>(variation4);

--- a/test-d/set-optional.ts
+++ b/test-d/set-optional.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {SetOptional} from '../index';
 
 // Update one required and one optional to optional.
@@ -15,4 +15,4 @@ expectType<{a?: number; b?: string; c?: boolean}>(variation3);
 
 // Fail if type changes even if optional is right.
 declare const variation4: SetOptional<{a: number; b?: string; c: boolean}, 'b' | 'c'>;
-expectError<{a: boolean; b?: string; c?: boolean}>(variation4);
+expectNotAssignable<{a: boolean; b?: string; c?: boolean}>(variation4);

--- a/test-d/set-required.ts
+++ b/test-d/set-required.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {SetRequired} from '../index';
 
 // Update one required and one optional to required.
@@ -15,4 +15,4 @@ expectType<{a: number; b: string; c: boolean}>(variation3);
 
 // Fail if type changes even if optional is right.
 declare const variation4: SetRequired<{a?: number; b: string; c?: boolean}, 'b' | 'c'>;
-expectError<{a?: boolean; b: string; c: boolean}>(variation4);
+expectNotAssignable<{a?: boolean; b: string; c: boolean}>(variation4);

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectError, expectNotAssignable, expectType} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Simplify} from '../index';
 
 type PositionProps = {
@@ -51,7 +51,7 @@ type SimplifiedFunction = Simplify<SomeFunction>; // Return '{}' expected 'SomeF
 
 declare const someFunction: SimplifiedFunction;
 
-expectError<SomeFunction>(someFunction);
+expectNotAssignable<SomeFunction>(someFunction);
 
 // // Should return the original type if it is not simplifiable, like a function.
 // type SomeFunction = (type: string) => string;

--- a/test-d/stringified.ts
+++ b/test-d/stringified.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {Stringified} from '../index';
 
 declare const stringified: Stringified<{a: number; b: string}>;
@@ -8,5 +8,5 @@ type Car = {
 	model: string;
 	speed: number;
 };
-expectError<Stringified<Car>>({model: 'Foo', speed: 101});
+expectNotAssignable<Stringified<Car>>({model: 'Foo', speed: 101});
 expectType<Stringified<Car>>({model: 'Foo', speed: '101'});

--- a/test-d/value-of.ts
+++ b/test-d/value-of.ts
@@ -1,12 +1,12 @@
-import {expectType, expectError, expectAssignable} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {ValueOf} from '../index';
 
 const value: ValueOf<{a: 1; b: 2; c: 3}> = 3;
 const valueRestricted: ValueOf<{a: 1; b: 2; c: 3}, 'a'> = 1;
 
 expectAssignable<1 | 2 | 3>(value);
-expectError<4>(value);
+expectNotAssignable<4>(value);
 
 expectType<1>(valueRestricted);
-expectError<2>(valueRestricted);
-expectError<4>(valueRestricted);
+expectNotAssignable<2>(valueRestricted);
+expectNotAssignable<4>(valueRestricted);

--- a/test-d/writable.ts
+++ b/test-d/writable.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectNotAssignable, expectType} from 'tsd';
 import type {Writable} from '../index';
 
 type Foo = {
@@ -25,4 +25,4 @@ expectType<{a: number; b: string; c: boolean}>(variation3);
 
 // Check if type changes raise an error even if readonly and writable are applied correctly.
 declare const variation4: Writable<{readonly a: number; b: string; readonly c: boolean}, 'b' | 'c'>;
-expectError<{readonly a: boolean; b: string; c: boolean}>(variation4);
+expectNotAssignable<{readonly a: boolean; b: string; c: boolean}>(variation4);


### PR DESCRIPTION
Specifically, current tests frequently use `expectError` when `expectNotAssignable` would have been more appropriate.

Also updates the `includes.ts` test to have explanatory comments for its `expectError` usage.

Lastly, updates the contributing doc to suggest `expectNotAssignable` first + updates links.