### PR TITLE
Add a `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# @voxpelli contributed the casing helpers and thus knows a lot about them
+*case*.ts @voxpelli


### PR DESCRIPTION
In an attempt to become a better co-maintainer I'm adding myself as a code-owner for the casing related files.

This is not intended on making me own these and require me to approve anything. Its only to ensure that I get pinged on all such PR:s and can chime in.

I also created a `component:casing` label that I'll try to track a bit closer than the repository in general.