### PR TITLE
Add TypeScript canary on cron job that tests on `typescript@next`

### DIFF
--- a/.github/workflows/ts-canary.yml
+++ b/.github/workflows/ts-canary.yml
@@ -1,0 +1,24 @@
+name: TypeScript Canary
+
+on:
+  schedule:
+    - cron: '15 21 * * 4'
+
+jobs:
+  types:
+    name: TypeScript ${{ matrix.typescript-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript-version:
+          - 'next'
+          - 'latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm install typescript@${{ matrix.typescript-version }}
+      - run: npx tsc

--- a/.github/workflows/ts-canary.yml
+++ b/.github/workflows/ts-canary.yml
@@ -1,10 +1,8 @@
 name: TypeScript Canary
-
 on:
   schedule:
-    # Randomly generated weekly time: Every Thursday at 21.15
+    # Every Thursday at 21.15
     - cron: '15 21 * * 4'
-
 jobs:
   types:
     name: TypeScript ${{ matrix.typescript-version }}
@@ -13,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         typescript-version:
-          - 'next'
-          - 'latest'
+          - next
+          - latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/ts-canary.yml
+++ b/.github/workflows/ts-canary.yml
@@ -2,6 +2,7 @@ name: TypeScript Canary
 
 on:
   schedule:
+    # Randomly generated weekly time: Every Thursday at 21.15
     - cron: '15 21 * * 4'
 
 jobs:


### PR DESCRIPTION
As TS has a tendency to break in one way or another on new releases we should try to catch that early, and one way to do that is to run automated canary tests against the nightly `typescript@next` and the `typescript@latest`

This way we can catch regressions early and notify the TS team about them early.

I have made used of this in some of my modules, which has helped catch some regressions early. See eg: https://github.com/voxpelli/pony-cause/blob/main/.github/workflows/ts.yml

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
