### PR TITLE
Update Opaque test to not need @ts-expect-error

### DIFF
--- a/test-d/opaque.ts
+++ b/test-d/opaque.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable, expectNotType} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectNotType, expectType} from 'tsd';
 import type {Opaque, UnwrapOpaque} from '../index';
 
 type Value = Opaque<number, 'Value'>;
@@ -15,11 +15,16 @@ expectNotAssignable<Value>(value + 2);
 type WithoutToken = Opaque<number>;
 expectAssignable<WithoutToken>(2 as WithoutToken);
 
-// @ts-expect-error
+// Verify Opaque's Token can be the parent type itself.
 type Person = {
 	id: Opaque<number, Person>;
 	name: string;
 };
+const person = {
+	id: 42 as Opaque<number, Person>,
+	name: 'Arthur',
+};
+expectType<Person>(person);
 
 // Failing test for https://github.com/sindresorhus/type-fest/issues/108
 // Use `Opaque` value as `Record` index type.
@@ -27,17 +32,15 @@ type UUID = Opaque<string, 'UUID'>;
 type NormalizedDictionary<T> = Record<UUID, T>;
 type Foo = {bar: string};
 
-const userEntities: NormalizedDictionary<Foo> = {
-	// @ts-expect-error
+const userEntities = {
 	'7dd4a16e-d5ee-454c-b1d0-71e23d9fa70b': {bar: 'John'},
 	'6ce31270-31eb-4a72-a9bf-43192d4ab436': {bar: 'Doe'},
-};
+} as NormalizedDictionary<Foo>;
 
 const johnsId = '7dd4a16e-d5ee-454c-b1d0-71e23d9fa70b' as UUID;
 
-// @ts-expect-error
 const userJohn = userEntities[johnsId];
-/// expectType<Foo>(userJohn);
+expectType<Foo>(userJohn);
 
 // Remove tag from opaque value.
 // Note: This will simply return number as type.


### PR DESCRIPTION
When attempting to get these tests running in our environment, we ran into some issues with the `@ts-expect-error` instances in `test-d/opaque.ts` causing issues.

This update simply updates the code to not need them. For example, in the case of unused types or variables, use them.