### PR TITLE
Update `Except` test to adhere to noPropertyAccessFromIndexSignature

### DIFF
--- a/test-d/except.ts
+++ b/test-d/except.ts
@@ -13,4 +13,5 @@ type Example = {
 
 const test: Except<Example, 'bar'> = {foo: 123, bar: 'asdf'};
 expectType<number>(test.foo);
-expectType<unknown>(test.bar);
+// eslint-disable-next-line @typescript-eslint/dot-notation
+expectType<unknown>(test['bar']);


### PR DESCRIPTION
When building `test-d/except.ts`, the final `test.bar` access in the test does not build in the event that the `tsc` flag `noPropertyAccessFromIndexSignature` is enabled.

The fix is to access the property using bracket notation (oddly, `@typescript-eslint/dot-notation` seems wrong here)