### PR TITLE
`Stringified`: Use correct correct expectation in test

### DIFF
--- a/test-d/stringified.ts
+++ b/test-d/stringified.ts
@@ -1,4 +1,4 @@
-import {expectNotAssignable, expectType} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Stringified} from '../index';
 
 declare const stringified: Stringified<{a: number; b: string}>;
@@ -9,4 +9,4 @@ type Car = {
 	speed: number;
 };
 expectNotAssignable<Stringified<Car>>({model: 'Foo', speed: 101});
-expectType<Stringified<Car>>({model: 'Foo', speed: '101'});
+expectAssignable<Stringified<Car>>({model: 'Foo', speed: '101'});


### PR DESCRIPTION
In the test, `{model: 'Foo', speed: '101'}` is a stricter type than `{model: string, speed: string}` so `expectAssignable` is more appropriate.