### PR TITLE
Add Node 19 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 19
           - 18
           - 16
           - 14


### PR DESCRIPTION
Adding [the new Node 19](https://nodejs.org/en/blog/announcements/v19-release-announce/) to the CI matrix so that we always test on the latest Node in addition to the current/future LTS releases.

We'll remove this when Node 20 is released and Node 19 thus is no longer supported.