### PR TITLE
Property missing in interface

### DIFF
--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -29,7 +29,6 @@ const userMaskSettings: UserMask = {
 		firstname: 'show',
 		lastname: 'mask',
 	},
-	phoneNumbers: 'mask',
 	created: 'show',
 	active: 'show',
 	passwordHash: 'hide',


### PR DESCRIPTION
Remove `phoneNumbers` property from example code, since it's not present in the `User` interface and would fail to be assigned.

