### PR TITLE
Make TupleToUnion support T[] instead of just tuples

### DIFF
--- a/source/tuple-to-union.d.ts
+++ b/source/tuple-to-union.d.ts
@@ -48,4 +48,4 @@ type NumberBool = typeof numberBool[number];
 
 @category Array
 */
-export type TupleToUnion<ArrayType> = ArrayType extends readonly [infer Head, ...(infer Rest)] ? Head | TupleToUnion<Rest> : never;
+export type TupleToUnion<ArrayType> = ArrayType extends readonly unknown[] ? ArrayType[number] : never;

--- a/test-d/tuple-to-union.ts
+++ b/test-d/tuple-to-union.ts
@@ -24,3 +24,12 @@ expectType<'c'>(c);
 
 declare const notAnArray: TupleToUnion<[]>;
 expectType<never>(notAnArray);
+
+declare const worksWithArrays: TupleToUnion<Array<string | number>>;
+expectType<string | number>(worksWithArrays);
+
+declare const resolvesToNeverForNonArrays: TupleToUnion<string | number>;
+expectType<never>(resolvesToNeverForNonArrays);
+
+declare const infiniteRestArgs: TupleToUnion<[string, ...number[]]>;
+expectType<string | number>(infiniteRestArgs);


### PR DESCRIPTION
This implementation is no longer recursive which may be more performant. It also works with arrays whereas the previous implementation only worked with tuples.

In addition, it also resolves an issue where infinite tuples were not supported. Previously, `TupleToUnion<[string, ...number[]]>` resolved to `string` and now it correctly resolves to `string | number`.