### PR TITLE
Add `GlobalThis` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,5 +101,6 @@ export type {Get} from './source/get';
 export type {LastArrayElement} from './source/last-array-element';
 
 // Miscellaneous
+export type {GlobalThis} from './source/global-this';
 export type {PackageJson} from './source/package-json';
 export type {TsConfigJson} from './source/tsconfig-json';

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,7 @@ Click the type names for complete docs.
 
 ### Miscellaneous
 
+- [`GlobalThis`](source/global-this.d.ts) - Declare locally scoped properties on `globalThis`.
 - [`PackageJson`](source/package-json.d.ts) - Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). It also includes support for [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) and [Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/).
 - [`TsConfigJson`](source/tsconfig-json.d.ts) - Type for [TypeScript's `tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 

--- a/source/global-this.d.ts
+++ b/source/global-this.d.ts
@@ -1,0 +1,21 @@
+/**
+Declare locally scoped properties on `globalThis`.
+
+When defining a global variable in a declaration file is inappropriate, it can be helpful to define a `type` or `interface` (say `ExtraGlobals`) with the global variable and then cast `globalThis` via code like `globalThis as unknown as ExtraGlobals`.
+
+Instead of casting through `unknown`, you can update your `type` or `interface` to extend `GlobalThis` and then directly cast `globalThis`.
+
+@example
+```
+import type {GlobalThis} from 'type-fest';
+
+type ExtraGlobals = GlobalThis & {
+	readonly GLOBAL_TOKEN: string;
+};
+
+(globalThis as ExtraGlobals).GLOBAL_TOKEN;
+```
+
+@category Type
+*/
+export type GlobalThis = typeof globalThis;

--- a/test-d/global-this.ts
+++ b/test-d/global-this.ts
@@ -1,0 +1,14 @@
+import {expectType} from 'tsd';
+import type {GlobalThis} from '../index';
+
+type ExtraProps = GlobalThis & {
+	readonly GLOBAL_TOKEN: string;
+};
+
+// Verify `globalThis` can be cast to a type which extends `GlobalThis`.
+expectType<string>((globalThis as ExtraProps).GLOBAL_TOKEN);
+
+// Verify that object literals cannot be cast to a type which extends `GlobalThis`.
+declare function consumeExtraProps(extraProps: ExtraProps): void;
+// @ts-expect-error
+consumeExtraProps(({something: 'value'}) as ExtraProps);


### PR DESCRIPTION
This type is for times when you need to access non-standard properties off of ~`window`, `self`, or~ `globalThis`. For example:

```ts
import type {GlobalThis} from 'type-fest';

interface ExtraProps extends GlobalThis {
  readonly GLOBAL_TOKEN: string;
}

const extraProps = globalThis as ExtraProps;
verifyToken(extraProps.GLOBAL_TOKEN);
```

---

Normally, you would define a declaration file to add global variables.

This change permits introducing global symbols in a more targeted manner.

---

Note: In the test, it seems like `expectError` should work here rather than using `@ts-expect-error` but, unfortunately, it does not.

---

I'd be happy to hear other suggestions on supporting this use case!