### PR TITLE
jsonify: add jump to definition and `any` support

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -143,3 +143,44 @@ export type UndefinedToOptional<T extends object> = Simplify<
 	[Key in keyof Pick<T, FilterOptionalKeys<T>>]?: Exclude<T[Key], undefined>;
 }
 >;
+
+// Returns `never` if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
+type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
+	? never
+	: Type[Key] extends symbol
+		? never
+		: [(...args: any[]) => any] extends [Type[Key]]
+			? never
+			: Key;
+
+/**
+Returns the required keys.
+*/
+type FilterDefinedKeys<T extends object> = Exclude<
+{
+	[Key in keyof T]: IsAny<T[Key]> extends true
+		? Key
+		: undefined extends T[Key]
+			? never
+			: T[Key] extends undefined
+				? never
+				: BaseKeyFilter<T, Key>;
+}[keyof T],
+undefined
+>;
+
+/**
+Returns the optional keys.
+*/
+type FilterOptionalKeys<T extends object> = Exclude<
+{
+	[Key in keyof T]: IsAny<T[Key]> extends true
+		? never
+		: undefined extends T[Key]
+			? T[Key] extends undefined
+				? never
+				: BaseKeyFilter<T, Key>
+			: never;
+}[keyof T],
+undefined
+>;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -114,4 +114,4 @@ Returns a boolean for whether the the type is `any`.
 
 @link https://stackoverflow.com/a/49928360/1490091
 */
-type IsAny<T> = 0 extends 1 & T ? true : false;
+export type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -108,3 +108,10 @@ export type IsUpperCase<T extends string> = T extends Uppercase<T> ? true : fals
 Returns a boolean for whether the string is numeric.
 */
 export type IsNumeric<T extends string> = T extends `${number}` ? true : false;
+
+/**
+Returns a boolean for whether the the type is any.
+
+@link https://stackoverflow.com/a/49928360/1490091
+*/
+type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -1,4 +1,5 @@
 import type {Primitive} from './primitive';
+import type {Simplify} from './simplify';
 
 /**
 Returns a boolean for whether the two given types are equal.
@@ -115,3 +116,30 @@ Returns a boolean for whether the the type is `any`.
 @link https://stackoverflow.com/a/49928360/1490091
 */
 export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+For an object T, if it has any properties that are a union with `undefined`, make those into optional properties instead.
+
+@example
+```
+type User = {
+	firstName: string;
+	lastName: string | undefined;
+};
+
+type OptionalizedUser = UndefinedToOptional<User>;
+//=> {
+// 	firstName: string;
+// 	lastName?: string;
+// }
+```
+*/
+export type UndefinedToOptional<T extends object> = Simplify<
+{
+	// Property is not a union with `undefined`, keep it as-is.
+	[Key in keyof Pick<T, FilterDefinedKeys<T>>]: T[Key];
+} & {
+	// Property _is_ a union with defined value. Set as optional (via `?`) and remove `undefined` from the union.
+	[Key in keyof Pick<T, FilterOptionalKeys<T>>]?: Exclude<T[Key], undefined>;
+}
+>;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -110,7 +110,7 @@ Returns a boolean for whether the string is numeric.
 export type IsNumeric<T extends string> = T extends `${number}` ? true : false;
 
 /**
-Returns a boolean for whether the the type is any.
+Returns a boolean for whether the the type is `any`.
 
 @link https://stackoverflow.com/a/49928360/1490091
 */

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -30,7 +30,7 @@ type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
 			: Key;
 
 /**
- * Returns the required keys.
+Returns the required keys.
  */
 type FilterDefinedKeys<T extends object> = Exclude<
 {

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,9 +1,9 @@
-import type { JsonPrimitive, JsonValue } from "./basic";
-import type { EmptyObject } from "./empty-object";
-import type { Merge } from "./merge";
-import type { NegativeInfinity, PositiveInfinity } from "./numeric";
-import type { Simplify } from "./simplify";
-import type { TypedArray } from "./typed-array";
+import type {JsonPrimitive, JsonValue} from './basic';
+import type {EmptyObject} from './empty-object';
+import type {Merge} from './merge';
+import type {NegativeInfinity, PositiveInfinity} from './numeric';
+import type {Simplify} from './simplify';
+import type {TypedArray} from './typed-array';
 
 /*
  * `any` is the only type that can let you equate `0` with `1`
@@ -18,18 +18,18 @@ type NotJsonable = ((...args: any[]) => any) | undefined | symbol;
 type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
 	? never
 	: Type[Key] extends symbol
-	? never
-	: [(...args: any[]) => any] extends [Type[Key]]
-	? never
-	: Key;
+		? never
+		: [(...args: any[]) => any] extends [Type[Key]]
+			? never
+			: Key;
 
 // Returns keys that are jsonable, have jsonable properties, and are required.
 type RequiredKeysFilter<Type, Key extends keyof Type> = {
 	[Key in keyof Type]: IsAny<Type[Key]> extends true
 		? Key
 		: undefined extends Type[Key]
-		? never
-		: BaseKeyFilter<Type, Key>;
+			? never
+			: BaseKeyFilter<Type, Key>;
 }[keyof Type];
 
 // Returns keys that are jsonable, have jsonable properties, and are optional.
@@ -37,10 +37,10 @@ type OptionalKeysFilter<Type, Key extends keyof Type> = {
 	[Key in keyof Type]: IsAny<Type[Key]> extends true
 		? never
 		: undefined extends Type[Key]
-		? Type[Key] extends undefined
-			? never
-			: BaseKeyFilter<Type, Key>
-		: never;
+			? Type[Key] extends undefined
+				? never
+				: BaseKeyFilter<Type, Key>
+			: never;
 }[keyof Type];
 
 /**
@@ -106,38 +106,38 @@ export type Jsonify<T> = IsAny<T> extends true
 	// Note: The use of tuples in this first condition side-steps distributive conditional types
 	// (see https://github.com/microsoft/TypeScript/issues/29368#issuecomment-453529532)
 	[Extract<T, NotJsonable | bigint>] extends [never]
-	? T extends PositiveInfinity | NegativeInfinity
-		? null
-		: T extends JsonPrimitive
-		? T // Primitive is acceptable
-		: T extends object
-		? // Any object with toJSON is special case
-		  T extends { toJSON(): infer J }
-			? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
-				? J // Then T is Jsonable and its Jsonable value is J
-				: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
-			: // Instanced primitives are objects
-			T extends Number
-			? number
-			: T extends String
-			? string
-			: T extends Boolean
-			? boolean
-			: T extends Map<any, any> | Set<any>
-			? EmptyObject
-			: T extends TypedArray
-			? Record<string, number>
-			: T extends any[]
-			? { [I in keyof T]: T[I] extends NotJsonable ? null : Jsonify<T[I]> }
-			: Simplify<
-					{
-						[Key in keyof Pick<T, RequiredKeysFilter<T, Key>>]: Jsonify<T[Key]>;
-					} & {
-						[Key in keyof Pick<T, OptionalKeysFilter<T, Key>>]?: Jsonify<
-							Exclude<T[Key], undefined>
-						>;
-					}
-			  >
-		: // Recursive call for its children
-		  never // Otherwise any other non-object is removed
-	: never; // Otherwise non-JSONable type union was found not empty
+		? T extends PositiveInfinity | NegativeInfinity
+			? null
+			: T extends JsonPrimitive
+				? T // Primitive is acceptable
+				: T extends object
+					? // Any object with toJSON is special case
+					T extends {toJSON(): infer J}
+						? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
+							? J // Then T is Jsonable and its Jsonable value is J
+							: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
+						: // Instanced primitives are objects
+						T extends Number
+							? number
+							: T extends String
+								? string
+								: T extends Boolean
+									? boolean
+									: T extends Map<any, any> | Set<any>
+										? EmptyObject
+										: T extends TypedArray
+											? Record<string, number>
+											: T extends any[]
+												? {[I in keyof T]: T[I] extends NotJsonable ? null : Jsonify<T[I]>}
+												: Simplify<
+												{
+													[Key in keyof Pick<T, RequiredKeysFilter<T, Key>>]: Jsonify<T[Key]>;
+												} & {
+													[Key in keyof Pick<T, OptionalKeysFilter<T, Key>>]?: Jsonify<
+													Exclude<T[Key], undefined>
+													>;
+												}
+												>
+					: // Recursive call for its children
+					never // Otherwise any other non-object is removed
+		: never; // Otherwise non-JSONable type union was found not empty

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,6 +1,6 @@
 import type {JsonPrimitive, JsonValue} from './basic';
 import type {EmptyObject} from './empty-object';
-import type {IsAny} from './internal';
+import type {IsAny, UndefinedToOptional} from './internal';
 import type {NegativeInfinity, PositiveInfinity} from './numeric';
 import type {Simplify} from './simplify';
 import type {TypedArray} from './typed-array';
@@ -62,33 +62,6 @@ type FilterOptionalKeys<T extends object> = Exclude<
 			: never;
 }[keyof T],
 undefined
->;
-
-/**
-For an object T, if it has any properties that are a union with `undefined`, make those into optional properties instead.
-
-@example
-```
-type User = {
-	firstName: string;
-	lastName: string | undefined;
-}
-
-type OptionalizedUser = UndefinedToOptional<User>
-// => {
-// 	firstName: string;
-// 	lastName?: string;
-// }
-```
-*/
-type UndefinedToOptional<T extends object> = Simplify<
-{
-	// Property is not a union with `undefined`, keep as-is
-	[Key in keyof Pick<T, FilterDefinedKeys<T>>]: T[Key];
-} & {
-	// Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
-	[Key in keyof Pick<T, FilterOptionalKeys<T>>]?: Exclude<T[Key], undefined>;
-}
 >;
 
 /**

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -31,7 +31,7 @@ type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
 
 /**
 Returns the required keys.
- */
+*/
 type FilterDefinedKeys<T extends object> = Exclude<
 {
 	[Key in keyof T]: IsAny<T[Key]> extends true
@@ -78,7 +78,7 @@ type OptionalizedUser = UndefinedToOptional<User>
 // 	lastName?: string;
 // }
 ```
- */
+*/
 type UndefinedToOptional<T extends object> = Simplify<
 {
 	// Property is not a union with `undefined`, keep as-is

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -2,7 +2,6 @@ import type {JsonPrimitive, JsonValue} from './basic';
 import type {EmptyObject} from './empty-object';
 import type {IsAny, UndefinedToOptional} from './internal';
 import type {NegativeInfinity, PositiveInfinity} from './numeric';
-import type {Simplify} from './simplify';
 import type {TypedArray} from './typed-array';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -41,13 +41,13 @@ type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
  */
 type FilterDefinedKeys<TObject extends object> = Exclude<
 {
-	[TKey in keyof TObject]: IsAny<TObject[TKey]> extends true
-		? TKey
-		: undefined extends TObject[TKey]
+	[Key in keyof TObject]: IsAny<TObject[Key]> extends true
+		? Key
+		: undefined extends TObject[Key]
 			? never
-			: TObject[TKey] extends undefined
+			: TObject[Key] extends undefined
 				? never
-				: BaseKeyFilter<TObject, TKey>;
+				: BaseKeyFilter<TObject, Key>;
 }[keyof TObject],
 undefined
 >;
@@ -57,12 +57,12 @@ undefined
  */
 type FilterOptionalKeys<TObject extends object> = Exclude<
 {
-	[TKey in keyof TObject]: IsAny<TObject[TKey]> extends true
+	[Key in keyof TObject]: IsAny<TObject[Key]> extends true
 		? never
-		: undefined extends TObject[TKey]
-			? TObject[TKey] extends undefined
+		: undefined extends TObject[Key]
+			? TObject[Key] extends undefined
 				? never
-				: BaseKeyFilter<TObject, TKey>
+				: BaseKeyFilter<TObject, Key>
 			: never;
 }[keyof TObject],
 undefined

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -17,13 +17,13 @@ type FilterJsonableKeys<T extends object> = {
 }[keyof T];
 
 /**
-JSON serialize objects (not including arrays) and classes
+JSON serialize objects (not including arrays) and classes.
 */
 type JsonifyObject<T extends object> = {
 	[Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };
 
-// Returns never if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
+// Returns `never` if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
 type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
 	? never
 	: Type[Key] extends symbol
@@ -65,8 +65,7 @@ undefined
 >;
 
 /**
-For an object T, if it has any properties that are a union with `undefined`,
-make those into optional properties instead.
+For an object T, if it has any properties that are a union with `undefined`, make those into optional properties instead.
 
 @example
 ```

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -16,6 +16,9 @@ type FilterJsonableKeys<T extends object> = {
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
 }[keyof T];
 
+/**
+JSON serialize objects (not including arrays) and classes
+*/
 type JsonifyObject<T extends object> = {
 	[Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -22,47 +22,6 @@ type JsonifyObject<T extends object> = {
 	[Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };
 
-// Returns `never` if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
-type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
-	? never
-	: Type[Key] extends symbol
-		? never
-		: [(...args: any[]) => any] extends [Type[Key]]
-			? never
-			: Key;
-
-/**
-Returns the required keys.
-*/
-type FilterDefinedKeys<T extends object> = Exclude<
-{
-	[Key in keyof T]: IsAny<T[Key]> extends true
-		? Key
-		: undefined extends T[Key]
-			? never
-			: T[Key] extends undefined
-				? never
-				: BaseKeyFilter<T, Key>;
-}[keyof T],
-undefined
->;
-
-/**
-Returns the optional keys.
-*/
-type FilterOptionalKeys<T extends object> = Exclude<
-{
-	[Key in keyof T]: IsAny<T[Key]> extends true
-		? never
-		: undefined extends T[Key]
-			? T[Key] extends undefined
-				? never
-				: BaseKeyFilter<T, Key>
-			: never;
-}[keyof T],
-undefined
->;
-
 /**
 Transform a type to one that is assignable to the `JsonValue` type.
 

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -15,7 +15,7 @@ type NotJsonable = ((...args: any[]) => any) | undefined | symbol;
 
 /** JSON serialize [tuples](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) */
 type JsonifyTuple<T extends [unknown, ...unknown[]]> = {
-	[k in keyof T]: T[k] extends NotJsonable ? null : Jsonify<T[k]>;
+	[Key in keyof T]: T[Key] extends NotJsonable ? null : Jsonify<T[Key]>;
 };
 
 type FilterJsonableKeys<T extends object> = {
@@ -24,7 +24,7 @@ type FilterJsonableKeys<T extends object> = {
 
 /** JSON serialize objects (not including arrays) and classes */
 type JsonifyObject<T extends object> = {
-	[k in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[k]>;
+	[Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };
 
 // Returns never if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
@@ -80,7 +80,7 @@ type UndefinedToOptional<T extends object> = Simplify<
 	[Key in keyof Pick<T, FilterDefinedKeys<T>>]: T[Key];
 } & {
 	// Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
-	[k in keyof Pick<T, FilterOptionalKeys<T>>]?: Exclude<T[k], undefined>;
+	[Key in keyof Pick<T, FilterOptionalKeys<T>>]?: Exclude<T[Key], undefined>;
 }
 >;
 

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -1,4 +1,5 @@
-type IsAny<T> = 0 extends (1 & T) ? true : false; // https://stackoverflow.com/a/49928360/3406963
+import type {IsAny} from './internal';
+
 type IsNever<T> = [T] extends [never] ? true : false;
 type IsUnknown<T> = IsNever<T> extends false ? T extends unknown ? unknown extends T ? IsAny<T> extends false ? true : false : false : false : false;
 

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 // TODO: Convert the `interface`'s to `type`s.
-import { expectAssignable, expectNotAssignable, expectType } from "tsd";
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {
 	EmptyObject,
 	Jsonify,
 	JsonValue,
 	NegativeInfinity,
 	PositiveInfinity,
-} from "..";
+} from '..';
 
 interface A {
 	a: number;
@@ -51,19 +51,19 @@ declare const w: W; // Not assignable to JsonValue because a function is not val
 expectAssignable<JsonValue>(null);
 expectAssignable<JsonValue>(false);
 expectAssignable<JsonValue>(0);
-expectAssignable<JsonValue>("");
+expectAssignable<JsonValue>('');
 expectAssignable<JsonValue>([]);
 expectAssignable<JsonValue>({});
 expectAssignable<JsonValue>([0]);
-expectAssignable<JsonValue>({ a: 0 });
+expectAssignable<JsonValue>({a: 0});
 expectAssignable<JsonValue>(a);
 expectAssignable<JsonValue>(b);
-expectAssignable<JsonValue>({ a: { b: true, c: {} }, d: [{}, 2, "hi"] });
-expectAssignable<JsonValue>([{}, { a: "hi" }, null, 3]);
+expectAssignable<JsonValue>({a: {b: true, c: {}}, d: [{}, 2, 'hi']});
+expectAssignable<JsonValue>([{}, {a: 'hi'}, null, 3]);
 
 expectNotAssignable<JsonValue>(new Date());
 expectNotAssignable<JsonValue>([new Date()]);
-expectNotAssignable<JsonValue>({ a: new Date() });
+expectNotAssignable<JsonValue>({a: new Date()});
 expectNotAssignable<JsonValue>(v);
 expectNotAssignable<JsonValue>(x);
 expectNotAssignable<JsonValue>(y);
@@ -74,12 +74,12 @@ expectNotAssignable<JsonValue>(5 as number | undefined);
 
 // TODO: Convert this to a `type`.
 interface Geometry {
-	type: "Point" | "Polygon";
+	type: 'Point' | 'Polygon';
 	coordinates: [number, number];
 }
 
 const point: Geometry = {
-	type: "Point",
+	type: 'Point',
 	coordinates: [1, 1],
 };
 
@@ -104,11 +104,11 @@ expectAssignable<string>(parsedStringifiedX.a);
 
 class NonJsonWithToJSON {
 	public fixture = new Map<string, number>([
-		["a", 1],
-		["b", 2],
+		['a', 1],
+		['b', 2],
 	]);
 
-	public toJSON(): { fixture: Array<[string, number]> } {
+	public toJSON(): {fixture: Array<[string, number]>} {
 		return {
 			fixture: [...this.fixture.entries()],
 		};
@@ -125,35 +125,35 @@ class NonJsonWithToJSONWrapper {
 	public override = 42;
 
 	public toJSON() {
-		const stringOverride = "override";
+		const stringOverride = 'override';
 
 		return {
 			override: stringOverride,
 			inner: this.inner,
-			innerDeep: { inner: this.inner },
+			innerDeep: {inner: this.inner},
 		};
 	}
 }
 
 expectNotAssignable<JsonValue>(new NonJsonWithToJSONWrapper());
 
-type InnerFixture = { fixture: Array<[string, number]> };
+type InnerFixture = {fixture: Array<[string, number]>};
 
 expectType<{
 	override: string;
 	inner: InnerFixture;
-	innerDeep: { inner: InnerFixture };
+	innerDeep: {inner: InnerFixture};
 }>({} as Jsonify<NonJsonWithToJSONWrapper>);
 
 class NonJsonWithInvalidToJSON {
 	public fixture = new Map<string, number>([
-		["a", 1],
-		["b", 2],
+		['a', 1],
+		['b', 2],
 	]);
 
 	// This is intentionally invalid `.toJSON()`.
 	// It is invalid because the result is not assignable to `JsonValue`.
-	public toJSON(): { fixture: Map<string, number> } {
+	public toJSON(): {fixture: Map<string, number>} {
 		return {
 			fixture: this.fixture,
 		};
@@ -199,23 +199,23 @@ declare const objectValueUndefined: Jsonify<{
 	keep: string;
 	undefined: typeof undefined;
 }>;
-expectType<{ keep: string }>(objectValueUndefined);
+expectType<{keep: string}>(objectValueUndefined);
 
-declare const objectValueFn: Jsonify<{ keep: string; fn: typeof fn }>;
-expectType<{ keep: string }>(objectValueFn);
+declare const objectValueFn: Jsonify<{keep: string; fn: typeof fn}>;
+expectType<{keep: string}>(objectValueFn);
 
 declare const objectValueSymbol: Jsonify<{
 	keep: string;
 	symbol: typeof symbol;
 }>;
-expectType<{ keep: string }>(objectValueSymbol);
+expectType<{keep: string}>(objectValueSymbol);
 
 // Symbol keys are filtered
 declare const objectKeySymbol: Jsonify<{
 	[key: typeof symbol]: number;
 	keep: string;
 }>;
-expectType<{ keep: string }>(objectKeySymbol);
+expectType<{keep: string}>(objectKeySymbol);
 
 // Number, String and Boolean values are turned into primitive counterparts
 declare const number: Number;
@@ -257,7 +257,7 @@ expectAssignable<Jsonify<typeof map>>({});
 
 // Regression test for https://github.com/sindresorhus/type-fest/issues/466
 expectNotAssignable<Jsonify<typeof map>>(42);
-expectNotAssignable<Jsonify<typeof map>>({ foo: 42 });
+expectNotAssignable<Jsonify<typeof map>>({foo: 42});
 
 declare const set: Set<string>;
 declare const setJson: Jsonify<typeof set>;
@@ -266,7 +266,7 @@ expectAssignable<Jsonify<typeof set>>({});
 
 // Regression test for https://github.com/sindresorhus/type-fest/issues/466
 expectNotAssignable<Jsonify<typeof set>>(42);
-expectNotAssignable<Jsonify<typeof set>>({ foo: 42 });
+expectNotAssignable<Jsonify<typeof set>>({foo: 42});
 
 // Positive and negative Infinity, NaN and null are turned into null
 // NOTE: NaN is not detectable in TypeScript, so it is not tested; see https://github.com/sindresorhus/type-fest/issues/406
@@ -294,9 +294,9 @@ declare const jsonifiedOptionalPrimitive: Jsonify<OptionalPrimitive>;
 declare const jsonifiedOptionalTypeUnion: Jsonify<OptionalTypeUnion>;
 declare const jsonifiedNonOptionalTypeUnion: Jsonify<NonOptionalTypeUnion>;
 
-expectType<{ a?: string }>(jsonifiedOptionalPrimitive);
+expectType<{a?: string}>(jsonifiedOptionalPrimitive);
 expectType<{}>(jsonifiedOptionalTypeUnion);
-expectType<{ a?: string }>(jsonifiedNonOptionalTypeUnion);
+expectType<{a?: string}>(jsonifiedNonOptionalTypeUnion);
 
 // Test for 'Jsonify support for optional object keys, unserializable object values' #424
 // See https://github.com/sindresorhus/type-fest/issues/424
@@ -339,9 +339,7 @@ expectType<any>({} as Jsonify<any>);
 declare const objectWithAnyProperty: Jsonify<{
 	a: any;
 }>;
-expectType<{ a: any }>(objectWithAnyProperty);
+expectType<{a: any}>(objectWithAnyProperty);
 
-declare const objectWithAnyProperties: Jsonify<{
-	[key: string]: any;
-}>;
-expectType<{ [key: string]: any }>(objectWithAnyProperties);
+declare const objectWithAnyProperties: Jsonify<Record<string, any>>;
+expectType<Record<string, any>>(objectWithAnyProperties);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 // TODO: Convert the `interface`'s to `type`s.
-import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
-import type {EmptyObject, Jsonify, JsonValue, NegativeInfinity, PositiveInfinity} from '..';
+import { expectAssignable, expectNotAssignable, expectType } from "tsd";
+import type {
+	EmptyObject,
+	Jsonify,
+	JsonValue,
+	NegativeInfinity,
+	PositiveInfinity,
+} from "..";
 
 interface A {
 	a: number;
@@ -45,19 +51,19 @@ declare const w: W; // Not assignable to JsonValue because a function is not val
 expectAssignable<JsonValue>(null);
 expectAssignable<JsonValue>(false);
 expectAssignable<JsonValue>(0);
-expectAssignable<JsonValue>('');
+expectAssignable<JsonValue>("");
 expectAssignable<JsonValue>([]);
 expectAssignable<JsonValue>({});
 expectAssignable<JsonValue>([0]);
-expectAssignable<JsonValue>({a: 0});
+expectAssignable<JsonValue>({ a: 0 });
 expectAssignable<JsonValue>(a);
 expectAssignable<JsonValue>(b);
-expectAssignable<JsonValue>({a: {b: true, c: {}}, d: [{}, 2, 'hi']});
-expectAssignable<JsonValue>([{}, {a: 'hi'}, null, 3]);
+expectAssignable<JsonValue>({ a: { b: true, c: {} }, d: [{}, 2, "hi"] });
+expectAssignable<JsonValue>([{}, { a: "hi" }, null, 3]);
 
 expectNotAssignable<JsonValue>(new Date());
 expectNotAssignable<JsonValue>([new Date()]);
-expectNotAssignable<JsonValue>({a: new Date()});
+expectNotAssignable<JsonValue>({ a: new Date() });
 expectNotAssignable<JsonValue>(v);
 expectNotAssignable<JsonValue>(x);
 expectNotAssignable<JsonValue>(y);
@@ -68,12 +74,12 @@ expectNotAssignable<JsonValue>(5 as number | undefined);
 
 // TODO: Convert this to a `type`.
 interface Geometry {
-	type: 'Point' | 'Polygon';
+	type: "Point" | "Polygon";
 	coordinates: [number, number];
 }
 
 const point: Geometry = {
-	type: 'Point',
+	type: "Point",
 	coordinates: [1, 1],
 };
 
@@ -97,9 +103,12 @@ expectAssignable<JsonValue>(parsedStringifiedX);
 expectAssignable<string>(parsedStringifiedX.a);
 
 class NonJsonWithToJSON {
-	public fixture = new Map<string, number>([['a', 1], ['b', 2]]);
+	public fixture = new Map<string, number>([
+		["a", 1],
+		["b", 2],
+	]);
 
-	public toJSON(): {fixture: Array<[string, number]>} {
+	public toJSON(): { fixture: Array<[string, number]> } {
 		return {
 			fixture: [...this.fixture.entries()],
 		};
@@ -116,32 +125,35 @@ class NonJsonWithToJSONWrapper {
 	public override = 42;
 
 	public toJSON() {
-		const stringOverride = 'override';
+		const stringOverride = "override";
 
 		return {
 			override: stringOverride,
 			inner: this.inner,
-			innerDeep: {inner: this.inner},
+			innerDeep: { inner: this.inner },
 		};
 	}
 }
 
 expectNotAssignable<JsonValue>(new NonJsonWithToJSONWrapper());
 
-type InnerFixture = {fixture: Array<[string, number]>};
+type InnerFixture = { fixture: Array<[string, number]> };
 
 expectType<{
 	override: string;
 	inner: InnerFixture;
-	innerDeep: {inner: InnerFixture};
+	innerDeep: { inner: InnerFixture };
 }>({} as Jsonify<NonJsonWithToJSONWrapper>);
 
 class NonJsonWithInvalidToJSON {
-	public fixture = new Map<string, number>([['a', 1], ['b', 2]]);
+	public fixture = new Map<string, number>([
+		["a", 1],
+		["b", 2],
+	]);
 
 	// This is intentionally invalid `.toJSON()`.
 	// It is invalid because the result is not assignable to `JsonValue`.
-	public toJSON(): {fixture: Map<string, number>} {
+	public toJSON(): { fixture: Map<string, number> } {
 		return {
 			fixture: this.fixture,
 		};
@@ -183,18 +195,27 @@ declare const arrayMemberSymbol: Jsonify<Array<typeof symbol>>;
 expectType<null[]>(arrayMemberSymbol);
 
 // When used in object values, these keys are filtered
-declare const objectValueUndefined: Jsonify<{keep: string; undefined: typeof undefined}>;
-expectType<{keep: string}>(objectValueUndefined);
+declare const objectValueUndefined: Jsonify<{
+	keep: string;
+	undefined: typeof undefined;
+}>;
+expectType<{ keep: string }>(objectValueUndefined);
 
-declare const objectValueFn: Jsonify<{keep: string; fn: typeof fn}>;
-expectType<{keep: string}>(objectValueFn);
+declare const objectValueFn: Jsonify<{ keep: string; fn: typeof fn }>;
+expectType<{ keep: string }>(objectValueFn);
 
-declare const objectValueSymbol: Jsonify<{keep: string; symbol: typeof symbol}>;
-expectType<{keep: string}>(objectValueSymbol);
+declare const objectValueSymbol: Jsonify<{
+	keep: string;
+	symbol: typeof symbol;
+}>;
+expectType<{ keep: string }>(objectValueSymbol);
 
 // Symbol keys are filtered
-declare const objectKeySymbol: Jsonify<{[key: typeof symbol]: number; keep: string}>;
-expectType<{keep: string}>(objectKeySymbol);
+declare const objectKeySymbol: Jsonify<{
+	[key: typeof symbol]: number;
+	keep: string;
+}>;
+expectType<{ keep: string }>(objectKeySymbol);
 
 // Number, String and Boolean values are turned into primitive counterparts
 declare const number: Number;
@@ -236,7 +257,7 @@ expectAssignable<Jsonify<typeof map>>({});
 
 // Regression test for https://github.com/sindresorhus/type-fest/issues/466
 expectNotAssignable<Jsonify<typeof map>>(42);
-expectNotAssignable<Jsonify<typeof map>>({foo: 42});
+expectNotAssignable<Jsonify<typeof map>>({ foo: 42 });
 
 declare const set: Set<string>;
 declare const setJson: Jsonify<typeof set>;
@@ -245,7 +266,7 @@ expectAssignable<Jsonify<typeof set>>({});
 
 // Regression test for https://github.com/sindresorhus/type-fest/issues/466
 expectNotAssignable<Jsonify<typeof set>>(42);
-expectNotAssignable<Jsonify<typeof set>>({foo: 42});
+expectNotAssignable<Jsonify<typeof set>>({ foo: 42 });
 
 // Positive and negative Infinity, NaN and null are turned into null
 // NOTE: NaN is not detectable in TypeScript, so it is not tested; see https://github.com/sindresorhus/type-fest/issues/406
@@ -273,9 +294,9 @@ declare const jsonifiedOptionalPrimitive: Jsonify<OptionalPrimitive>;
 declare const jsonifiedOptionalTypeUnion: Jsonify<OptionalTypeUnion>;
 declare const jsonifiedNonOptionalTypeUnion: Jsonify<NonOptionalTypeUnion>;
 
-expectType<{a?: string}>(jsonifiedOptionalPrimitive);
+expectType<{ a?: string }>(jsonifiedOptionalPrimitive);
 expectType<{}>(jsonifiedOptionalTypeUnion);
-expectType<{a?: string}>(jsonifiedNonOptionalTypeUnion);
+expectType<{ a?: string }>(jsonifiedNonOptionalTypeUnion);
 
 // Test for 'Jsonify support for optional object keys, unserializable object values' #424
 // See https://github.com/sindresorhus/type-fest/issues/424
@@ -312,3 +333,15 @@ type ExpectedAppDataJson = {
 declare const response: Jsonify<AppData>;
 
 expectType<ExpectedAppDataJson>(response);
+
+expectType<any>({} as Jsonify<any>);
+
+declare const objectWithAnyProperty: Jsonify<{
+	a: any;
+}>;
+expectType<{ a: any }>(objectWithAnyProperty);
+
+declare const objectWithAnyProperties: Jsonify<{
+	[key: string]: any;
+}>;
+expectType<{ [key: string]: any }>(objectWithAnyProperties);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 // TODO: Convert the `interface`'s to `type`s.
 import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
-import type {
-	EmptyObject,
-	Jsonify,
-	JsonValue,
-	NegativeInfinity,
-	PositiveInfinity,
-} from '..';
+import type {EmptyObject, Jsonify, JsonValue, NegativeInfinity, PositiveInfinity} from '..';
 
 interface A {
 	a: number;
@@ -103,10 +97,7 @@ expectAssignable<JsonValue>(parsedStringifiedX);
 expectAssignable<string>(parsedStringifiedX.a);
 
 class NonJsonWithToJSON {
-	public fixture = new Map<string, number>([
-		['a', 1],
-		['b', 2],
-	]);
+	public fixture = new Map<string, number>([['a', 1], ['b', 2]]);
 
 	public toJSON(): {fixture: Array<[string, number]>} {
 		return {
@@ -146,10 +137,7 @@ expectType<{
 }>({} as Jsonify<NonJsonWithToJSONWrapper>);
 
 class NonJsonWithInvalidToJSON {
-	public fixture = new Map<string, number>([
-		['a', 1],
-		['b', 2],
-	]);
+	public fixture = new Map<string, number>([['a', 1], ['b', 2]]);
 
 	// This is intentionally invalid `.toJSON()`.
 	// It is invalid because the result is not assignable to `JsonValue`.
@@ -195,26 +183,17 @@ declare const arrayMemberSymbol: Jsonify<Array<typeof symbol>>;
 expectType<null[]>(arrayMemberSymbol);
 
 // When used in object values, these keys are filtered
-declare const objectValueUndefined: Jsonify<{
-	keep: string;
-	undefined: typeof undefined;
-}>;
+declare const objectValueUndefined: Jsonify<{keep: string; undefined: typeof undefined}>;
 expectType<{keep: string}>(objectValueUndefined);
 
 declare const objectValueFn: Jsonify<{keep: string; fn: typeof fn}>;
 expectType<{keep: string}>(objectValueFn);
 
-declare const objectValueSymbol: Jsonify<{
-	keep: string;
-	symbol: typeof symbol;
-}>;
+declare const objectValueSymbol: Jsonify<{keep: string; symbol: typeof symbol}>;
 expectType<{keep: string}>(objectValueSymbol);
 
 // Symbol keys are filtered
-declare const objectKeySymbol: Jsonify<{
-	[key: typeof symbol]: number;
-	keep: string;
-}>;
+declare const objectKeySymbol: Jsonify<{[key: typeof symbol]: number; keep: string}>;
 expectType<{keep: string}>(objectKeySymbol);
 
 // Number, String and Boolean values are turned into primitive counterparts


### PR DESCRIPTION
These changes are upstreamed from [work I did for tRPC](https://github.com/trpc/trpc/pull/3261) and [Remix](https://github.com/remix-run/remix/pull/4689).

For data inferred from `Jsonify`, properties do not have jump to definition. This is because key remapping which breaks jump to definition support for TS (see https://github.com/microsoft/TypeScript/issues/47813). I changed it to use a different strategy for filtering that keeps jump to definition.

I also added support for the `any` type, previously `Jsonify<any>` was `never` and other variations of that were incorrect too.

I refactored the implementation because the previous one did not flow well with these changes.

cc @MichaelDeBoey