### PR TITLE
fix: Jsonify example used JsonValue but did not import

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -35,7 +35,7 @@ An interface cannot be structurally compared to `JsonValue` because an interface
 
 @example
 ```
-import type {Jsonify} from 'type-fest';
+import type {Jsonify, JsonValue} from 'type-fest';
 
 interface Geometry {
 	type: 'Point' | 'Polygon';


### PR DESCRIPTION
As title said, this PR just update comment of Jsonify.