### PR TITLE
Tweak documentation/comments/organization to mention npm workspaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -237,7 +237,7 @@ Click the type names for complete docs.
 ### Miscellaneous
 
 - [`GlobalThis`](source/global-this.d.ts) - Declare locally scoped properties on `globalThis`.
-- [`PackageJson`](source/package-json.d.ts) - Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). It also includes support for [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) and [Yarn Workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/).
+- [`PackageJson`](source/package-json.d.ts) - Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-json-file). It also includes support for [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
 - [`TsConfigJson`](source/tsconfig-json.d.ts) - Type for [TypeScript's `tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 
 ## Declined types

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -294,7 +294,7 @@ declare namespace PackageJson {
 	};
 
 	/**
-	An alternative configuration for Yarn workspaces.
+	An alternative configuration for workspaces.
 	*/
 	export type WorkspaceConfig = {
 		/**
@@ -305,7 +305,8 @@ declare namespace PackageJson {
 		/**
 		Designed to solve the problem of packages which break when their `node_modules` are moved to the root workspace directory - a process known as hoisting. For these packages, both within your workspace, and also some that have been installed via `node_modules`, it is important to have a mechanism for preventing the default Yarn workspace behavior. By adding workspace pattern strings here, Yarn will resume non-workspace behavior for any package which matches the defined patterns.
 
-		[Read more](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)
+		[Supported](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) by Yarn.
+		[Not supported](https://github.com/npm/rfcs/issues/287) by npm.
 		*/
 		nohoist?: WorkspacePattern[];
 	};
@@ -322,15 +323,6 @@ declare namespace PackageJson {
 	type WorkspacePattern = string;
 
 	export type YarnConfiguration = {
-		/**
-		Used to configure [Yarn workspaces](https://classic.yarnpkg.com/docs/workspaces/).
-
-		Workspaces allow you to manage multiple packages within the same repository in such a way that you only need to run `yarn install` once to install all of them in a single pass.
-
-		Please note that the top-level `private` property of `package.json` **must** be set to `true` in order to use workspaces.
-		*/
-		workspaces?: WorkspacePattern[] | WorkspaceConfig;
-
 		/**
 		If your package only allows one version of a given dependency, and you’d like to enforce the same behavior as `yarn install --flat` on the command-line, set this to `true`.
 
@@ -624,6 +616,15 @@ declare namespace PackageJson {
 			*/
 			url: string;
 		};
+
+		/**
+		Used to configure [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) / [Yarn workspaces](https://classic.yarnpkg.com/docs/workspaces/).
+
+		Workspaces allow you to manage multiple packages within the same repository in such a way that you only need to run your install command once in order to install all of them in a single pass.
+
+		Please note that the top-level `private` property of `package.json` **must** be set to `true` in order to use workspaces.
+		*/
+		workspaces?: WorkspacePattern[] | WorkspaceConfig;
 	}
 
 	/**


### PR DESCRIPTION
* Link to both [npm Workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) and [Yarn Workspaces](https://classic.yarnpkg.com/docs/workspaces/).
* Mention that `nohoist` is [supported](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) by Yarn, but [not supported](https://github.com/npm/rfcs/issues/287) by npm.
* Move `workspaces` type from `YarnConfiguration` to `PackageJsonStandard` since it's supported by both npm and yarn now. There should be no behavior change from the resulting `PackageJson` type. The `YarnConfiguration` type has a potentially breaking change but I'm not sure that's considered a public type?

Fixes #510 (although nothing was actually broken to my knowledge, the resulting `PackageJson` type is the same).

Follow-up to the original change to add `workspaces` in #77.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
