### PR TITLE
Handle CamelCase with non-literal strings

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -74,5 +74,7 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 @category Template literal
 */
 export type CamelCase<Type, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Type extends string
-	? Uncapitalize<CamelCaseFromArray<SplitWords<Type extends Uppercase<Type> ? Lowercase<Type> : Type>, Options>>
+	? string extends Type
+		? Type
+		: Uncapitalize<CamelCaseFromArray<SplitWords<Type extends Uppercase<Type> ? Lowercase<Type> : Type>, Options>>
 	: Type;

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -75,3 +75,6 @@ expectType<CamelCase<'fooBARBiz', {preserveConsecutiveUppercase: false}>>('fooBa
 
 expectType<CamelCase<'foo BAR-Biz_BUZZ'>>('fooBARBizBUZZ');
 expectType<CamelCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('fooBarBizBuzz');
+
+expectType<CamelCase<string>>('string' as string);
+expectType<CamelCase<string, {preserveConsecutiveUppercase: false}>>('string' as string);


### PR DESCRIPTION
Fixes #513
Fixes #475 

Hi there! I appreciate this library helping us handle a lot of common TypeScript operations!
Recently I encountered an issue and would like to propose a solution to that.

I'm using `CamelCasedPropertiesDeep` to transform the object's keys to camel case, with some of the proproties are just normal `Record<string, ObjectType>`.
In runtime, I have done an extra handling to prevent transforming in that layer. However, the type definition does not match this handling. I get `{ '': TransformedObjectType }` in the type, but I was expecting `{ [x: string]: TransformedObjectType }`.

I found that the cause was that currently `CamelCase<string>` is evaluated to `''`.

Therefore, I'd like to suggest a way to handle it and support my use case.

My suggestion is adding another branch of conditional type checking if `string extends Type`, and only proceed to the main transforming logic if it is not.
I hope this makes sense and would love to hear back from you if it is not handling enough.
Thank you!