### PR TITLE
make Join work with const tuple values

### DIFF
--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -21,13 +21,13 @@ const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 @category Template literal
 */
 export type Join<
-	Strings extends Array<string | number>,
+	Strings extends Readonly<Array<string | number>>,
 	Delimiter extends string,
 > = Strings extends []
 	? ''
 	: Strings extends [string | number]
 		? `${Strings[0]}`
-		: Strings extends [
+		: Strings extends readonly [
 			string | number,
 			...infer Rest extends Array<string | number>,
 		]

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -21,3 +21,14 @@ expectNotAssignable<'foo.bar.baz'>(emptyDelimiter);
 const emptyInput: Join<[], '.'> = '';
 expectType<''>(emptyInput);
 expectNotAssignable<'foo'>(emptyInput);
+
+// Typeof of const tuple
+const tuple = ['foo', 'bar', 'baz'] as const;
+const joinedTuple: Join<typeof tuple, ','> = 'foo,bar,baz';
+expectType<'foo,bar,baz'>(joinedTuple);
+
+// Typeof of string[]
+const stringArray = ['foo', 'bar', 'baz'];
+const joinedStringArray: Join<typeof stringArray, ','> = '';
+expectType<string>(joinedStringArray);
+expectNotAssignable<'foo,bar,baz'>(joinedStringArray);


### PR DESCRIPTION
Make `Join` type work by passing a type of a const value.

Use case:

```ts
const columns = ["id", "name"] as const;  
const toSelectQuery = <T extends readonly string[]>(columns: T): Join<T, ","> => {
  return columns.join(",") as Join<T, ",">;
}
const query = toSelectQuery(columns); // "id,name"
```

Sadly, when passing arguments as literals you still have to cast as const explicitly:

```ts
const query = toSelectQuery(["id", "name"] as const); // "id,name"
```

That will not be necessary in TS@5.0 by using a [const modifier](https://github.com/microsoft/TypeScript/pull/51865), see [playground](https://www.staging-typescript.org/play?ts=5.0.0-dev.20221225#code/FAAhFMA8AcHsCcAuJEE9rhAKVgSwHYA8wAkAMqLwEDmAzhJIuPgCb3zgCGLs+ANqhAAKWpRogAPiHwBXALYAjcPACUAbQC6AGlIARcH1xzcTeAyat6oqvmo6AfCAC8ICjbrnmbEJtIB+EAByQNIALlcxW3ooC281a3EpWUVlDVISAIADABIAbzcaWjUABg0AX0z08IKoz0sQDm5eAR90kgTbSWl5JXgdEgGAOmGCADNlEAAlcFE67wBBeHhOVEIO6i7k3vt+kjSBjJAc-Mi6EvK8-UNjUzK8nAJCadEtECujE2V7Crbw9YBuYCgEAAY14szBfHk+HoLjUACJcCx4a94fhOHJwPCNCBOPQwTDEP8wMCCbNELAyAZwCDEABFGTKQQuQhk5AAFTm7C4PH4gnWmnsQkh0No4XZKnCDyI7NRWnhjicjlywLAHEQMng+FBsChchhgwAVnh8EIUfCVLj6NLCLKQOb7ICwGVSeDkABHRnwZkoSnU2kMpnC3WilTEgD04ftSK06Mx8NdhJAnqZACZnL6qXwafSvaghAikSj7XGsRowyBI9GWLGMVigA).