### PR TITLE
Add missing ES2022 to CompilerOptions.target

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -52,6 +52,7 @@ declare namespace TsConfigJson {
 			| 'ES2019'
 			| 'ES2020'
 			| 'ES2021'
+			| 'ES2022'
 			| 'ESNext'
 			// Lowercase alternatives
 			| 'es3'
@@ -64,6 +65,7 @@ declare namespace TsConfigJson {
 			| 'es2019'
 			| 'es2020'
 			| 'es2021'
+			| 'es2022'
 			| 'esnext';
 
 		export type Lib =

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectType} from 'tsd';
 import type {TsConfigJson} from '../index';
 
 const tsConfig: TsConfigJson = {};
@@ -11,37 +11,3 @@ expectType<string[] | undefined>(tsConfig.files);
 expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
-
-// Testing compilerOptions#target
-type TargetOption = NonNullable<TsConfigJson.CompilerOptions['target']>;
-type TargetOptionMap = {
-	[ K in TargetOption ]: TargetOption
-};
-
-expectAssignable<TargetOptionMap>({
-	ES3: 'ES3',
-	ES5: 'ES5',
-	ES6: 'ES6',
-	ES2015: 'ES2015',
-	ES2016: 'ES2016',
-	ES2017: 'ES2017',
-	ES2018: 'ES2018',
-	ES2019: 'ES2019',
-	ES2020: 'ES2020',
-	ES2021: 'ES2021',
-	ES2022: 'ES2022',
-	ESNext: 'ESNext',
-	// Lowercase alternatives
-	es3: 'es3',
-	es5: 'es5',
-	es6: 'es6',
-	es2015: 'es2015',
-	es2016: 'es2016',
-	es2017: 'es2017',
-	es2018: 'es2018',
-	es2019: 'es2019',
-	es2020: 'es2020',
-	es2021: 'es2021',
-	es2022: 'es2022',
-	esnext: 'esnext',
-});

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectAssignable} from 'tsd';
 import type {TsConfigJson} from '../index';
 
 const tsConfig: TsConfigJson = {};
@@ -11,3 +11,37 @@ expectType<string[] | undefined>(tsConfig.files);
 expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
+
+// Testing compilerOptions#target
+type TargetOption = NonNullable<TsConfigJson.CompilerOptions['target']>;
+type TargetOptionMap = {
+	[ K in TargetOption ]: TargetOption
+};
+
+expectAssignable<TargetOptionMap>({
+	ES3: 'ES3',
+	ES5: 'ES5',
+	ES6: 'ES6',
+	ES2015: 'ES2015',
+	ES2016: 'ES2016',
+	ES2017: 'ES2017',
+	ES2018: 'ES2018',
+	ES2019: 'ES2019',
+	ES2020: 'ES2020',
+	ES2021: 'ES2021',
+	ES2022: 'ES2022',
+	ESNext: 'ESNext',
+	// Lowercase alternatives
+	es3: 'es3',
+	es5: 'es5',
+	es6: 'es6',
+	es2015: 'es2015',
+	es2016: 'es2016',
+	es2017: 'es2017',
+	es2018: 'es2018',
+	es2019: 'es2019',
+	es2020: 'es2020',
+	es2021: 'es2021',
+	es2022: 'es2022',
+	esnext: 'esnext',
+});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
Can't believe this was missing.