### PR TITLE
Fix bug with split words

### DIFF
--- a/source/split-words.d.ts
+++ b/source/split-words.d.ts
@@ -33,7 +33,7 @@ export type SplitWords<
 > = Sentence extends `${infer FirstCharacter}${infer RemainingCharacters}`
 	? FirstCharacter extends WordSeparators
 		// Skip word separator
-		? [...SkipEmptyWord<CurrentWord>, ...SplitWords<RemainingCharacters, LastCharacter>]
+		? [...SkipEmptyWord<CurrentWord>, ...SplitWords<RemainingCharacters>]
 		: LastCharacter extends ''
 			// Fist char of word
 			? SplitWords<RemainingCharacters, FirstCharacter, FirstCharacter>

--- a/test-d/split-words.ts
+++ b/test-d/split-words.ts
@@ -79,6 +79,8 @@ expectType<SplitWords<'Hello--world--'>>(['Hello', 'world']);
 expectType<SplitWords<'hello__world___'>>(['hello', 'world']);
 expectType<SplitWords<'___ hello -__  _world'>>(['hello', 'world']);
 expectType<SplitWords<'__HelloWorld-HELLOWorld helloWORLD'>>(['Hello', 'World', 'HELLO', 'World', 'hello', 'WORLD']);
+expectType<SplitWords<'hello WORLD lowercase'>>(['hello', 'WORLD', 'lowercase']);
+expectType<SplitWords<'hello WORLD Uppercase'>>(['hello', 'WORLD', 'Uppercase']);
 
 expectType<SplitWords<'item0'>>(['item', '0']);
 expectType<SplitWords<'item01'>>(['item', '01']);

--- a/test-d/split-words.ts
+++ b/test-d/split-words.ts
@@ -80,6 +80,7 @@ expectType<SplitWords<'hello__world___'>>(['hello', 'world']);
 expectType<SplitWords<'___ hello -__  _world'>>(['hello', 'world']);
 expectType<SplitWords<'__HelloWorld-HELLOWorld helloWORLD'>>(['Hello', 'World', 'HELLO', 'World', 'hello', 'WORLD']);
 expectType<SplitWords<'hello WORLD lowercase'>>(['hello', 'WORLD', 'lowercase']);
+expectType<SplitWords<'hello WORLD-lowercase'>>(['hello', 'WORLD', 'lowercase']);
 expectType<SplitWords<'hello WORLD Uppercase'>>(['hello', 'WORLD', 'Uppercase']);
 
 expectType<SplitWords<'item0'>>(['item', '0']);


### PR DESCRIPTION
SplitWords seems to have a bug when casing changes from uppercase to lowercase after a separator.

For example, these tests both fail - the type resolves to `never`:
```ts
expectType<SplitWords<'hello WORLD lowercase'>>(['hello', 'WORLD', 'lowercase']);
expectType<SplitWords<'hello WORLD-lowercase'>>(['hello', 'WORLD', 'lowercase']);
```

Removing the carry over of `LastCharacter` after a delimiter should fix this