### PR TITLE
Word separators

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -44,8 +44,6 @@ export type KeysOfUnion<T> = T extends T ? keyof T : never;
 
 export type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
 
-export type WordSeparators = '-' | '_' | ' ';
-
 export type StringDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
 export type Whitespace =
@@ -75,6 +73,8 @@ export type Whitespace =
 	| '\u{205F}'
 	| '\u{3000}'
 	| '\u{FEFF}';
+
+export type WordSeparators = '-' | '_' | Whitespace;
 
 /**
 Matches any unknown record.

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -75,6 +75,7 @@ expectType<CamelCase<'fooBARBiz', {preserveConsecutiveUppercase: false}>>('fooBa
 
 expectType<CamelCase<'foo BAR-Biz_BUZZ'>>('fooBARBizBUZZ');
 expectType<CamelCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('fooBarBizBuzz');
+expectType<CamelCase<'foo\tBAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('fooBarBizBuzz');
 
 expectType<CamelCase<string>>('string' as string);
 expectType<CamelCase<string, {preserveConsecutiveUppercase: false}>>('string' as string);

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -30,6 +30,9 @@ expectType<'foo#bar#abc#123'>(delimiterFromComplexKebab);
 const delimiterFromSpace: DelimiterCase<'foo bar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromSpace);
 
+const delimiterFromTab: DelimiterCase<'foo\tbar', '#'> = 'foo#bar';
+expectType<'foo#bar'>(delimiterFromTab);
+
 const delimiterFromSnake: DelimiterCase<'foo_bar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromSnake);
 

--- a/test-d/split-words.ts
+++ b/test-d/split-words.ts
@@ -75,6 +75,7 @@ expectType<SplitWords<'   hello  world'>>(['hello', 'world']);
 expectType<SplitWords<'---Hello--world'>>(['Hello', 'world']);
 expectType<SplitWords<'___hello__world'>>(['hello', 'world']);
 expectType<SplitWords<'hello  world   '>>(['hello', 'world']);
+expectType<SplitWords<'hello\tworld'>>(['hello', 'world']);
 expectType<SplitWords<'Hello--world--'>>(['Hello', 'world']);
 expectType<SplitWords<'hello__world___'>>(['hello', 'world']);
 expectType<SplitWords<'___ hello -__  _world'>>(['hello', 'world']);


### PR DESCRIPTION
Includes all whitespace characters in `WordSeparators`.

This affects `SplitWords` and `DelimiterCase`, and types derived from each.

Example:
```ts
type Test = SplitWords<"hello\tworld">;
// Previous: ["hello", "/t", "world"]
// Fixed: ["hello", "world"]
```
