### PR TITLE
fix(Exact): correct type for deep optional union using IsEqual type

### DIFF
--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -1,5 +1,6 @@
 import type {KeysOfUnion, ArrayElement, ObjectValue} from './internal';
 import type {Opaque} from './opaque';
+import type {IsEqual} from './is-equal';
 
 /**
 Create a type from `ParameterType` and `InputType` and change keys exclusive to `InputType` to `never`.
@@ -50,11 +51,12 @@ onlyAcceptNameImproved(invalidInput); // Compilation error
 @category Utilities
 */
 export type Exact<ParameterType, InputType> =
-	// Convert union of array to array of union: A[] & B[] => (A & B)[]
-	ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-	// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
-		: ParameterType extends readonly unknown[] ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-			// For Opaque types, internal details are hidden from public, so let's leave it as is.
-			: ParameterType extends Opaque<infer OpaqueType, infer OpaqueToken> ? ParameterType
-				: ParameterType extends object ? ExactObject<ParameterType, InputType>
-					: ParameterType;
+	IsEqual<ParameterType, InputType> extends true ? ParameterType
+		// Convert union of array to array of union: A[] & B[] => (A & B)[]
+		: ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+			// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
+			: ParameterType extends readonly unknown[] ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+				// For Opaque types, internal details are hidden from public, so let's leave it as is.
+				: ParameterType extends Opaque<infer OpaqueType, infer OpaqueToken> ? ParameterType
+					: ParameterType extends object ? ExactObject<ParameterType, InputType>
+						: ParameterType;

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -371,3 +371,53 @@ import type {Exact, Opaque} from '../index';
 		name: 1 as SpecialName,
 	});
 }
+
+// Spec - special test case for deep optional union
+// https://github.com/sindresorhus/type-fest/issues/545
+{
+	type ParameterType = {
+		outer?: {
+			inner?: {
+				union: 'foo' | 'bar';
+			};
+		};
+	};
+
+	const fn = <InputT extends Exact<ParameterType, InputT>>(arguments_: InputT) => arguments_;
+
+	// Test input with declared type
+	type Input = {
+		outer?: {
+			inner?: {
+				union: 'foo' | 'bar';
+			};
+		};
+	};
+	const varWithDeclaredType: Input = {
+		outer: {
+			inner: {
+				union: 'foo',
+			},
+		},
+	};
+	fn(varWithDeclaredType);
+
+	// Test input without declared type
+	const varWithoutDeclaredType = {
+		outer: {
+			inner: {
+				union: 'foo' as const,
+			},
+		},
+	};
+	fn(varWithoutDeclaredType);
+
+	// Test input with plain object
+	fn({
+		outer: {
+			inner: {
+				union: 'foo',
+			},
+		},
+	});
+}

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -114,6 +114,24 @@ import type {Exact, Opaque} from '../index';
 	}
 }
 
+{ // Spec - object with optional outer object @see https://github.com/sindresorhus/type-fest/pull/546#issuecomment-1385620838
+	type Type = {
+		outer?: {
+			inner: {
+				field: string;
+			};
+		};
+	};
+	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	fn({
+		outer: {
+			inner: {
+				field: 'foo',
+			},
+		},
+	});
+}
+
 { // Spec - union - only object
 	type Type = {code: string} | {name: string};
 	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fix #545

I am not entirely sure what is the problem. It looks like an issue with deep optional union (could be related to how `keyof` works in TypeScript).

This is now fixed with another available type `IsEqual`.
