### PR TITLE
fix(JsonValue): accept readonly arrays

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -26,7 +26,7 @@ Matches a JSON array.
 
 @category JSON
 */
-export type JsonArray = JsonValue[];
+export type JsonArray = JsonValue[] | readonly JsonValue[];
 
 /**
 Matches any valid JSON primitive value.

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -47,6 +47,7 @@ expectAssignable<JsonValue>(false);
 expectAssignable<JsonValue>(0);
 expectAssignable<JsonValue>('');
 expectAssignable<JsonValue>([]);
+expectAssignable<JsonValue>([] as const);
 expectAssignable<JsonValue>({});
 expectAssignable<JsonValue>([0]);
 expectAssignable<JsonValue>({a: 0});


### PR DESCRIPTION
Accept readonly arrays in JsonValue so that types with deep readonly arrays are assignable to JsonValue.