### PR TITLE
fix(package-json): make `Imports` object properties optional in `PackageJson`

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -240,7 +240,7 @@ declare namespace PackageJson {
 	Import map entries of a module, optionally with conditions.
 	*/
 	export type Imports = { // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
-		[key: `#${string}`]: string | {[key in ExportCondition]: Exports};
+		[key: `#${string}`]: string | {[key in ExportCondition]?: Exports};
 	};
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -54,6 +54,12 @@ string
 >>
 >(packageJson.cpu);
 expectAssignable<PackageJson.Imports>({'#unicorn': 'unicorn'});
+expectAssignable<PackageJson.Imports>({
+	'#unicorn': {
+		import: {browser: 'unicorn', node: 'pony'},
+		default: 'horse',
+	},
+});
 expectNotAssignable<PackageJson.Imports>({unicorn: 'unicorn'});
 expectType<boolean | undefined>(packageJson.preferGlobal);
 expectType<boolean | undefined>(packageJson.private);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Was testing out [resolve.exports](https://github.com/lukeed/resolve.exports) using the `PackageJson` type. The type seems to expect `"#hash"` in the [example `imports` object](https://github.com/lukeed/resolve.exports#usage) to define every `Exports` key, which I don't believe is the correct behavior. This PR loosens the constraint by making those keys optional.

Also added a test to prevent regressions.