### PR TITLE
Fix `Simplify` to actually expand type-hints

### DIFF
--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -55,4 +55,4 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @category Object
 */
-export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]};
+export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

## Problem
`Simplify` didn't actually expand the type-hints.

It showed `Simplify<T>` instead:

<img width="500" src="https://user-images.githubusercontent.com/1075694/217116146-1c910497-70f3-41c8-ab6b-19c7ade8b94f.png">
<img width="500" src="https://user-images.githubusercontent.com/1075694/217116150-74a8ed3f-ddd5-4003-9ef9-61d1700b5a32.png">


## Changes
Adding `& {}` seems to do the trick:

<img width="500" src="https://user-images.githubusercontent.com/1075694/217116131-fa63620b-cbfd-4260-825d-c6c3235b7ce2.png">
<img width="500" src="https://user-images.githubusercontent.com/1075694/217116133-93a95a7a-387c-4dec-b3ad-597d11cc0fd2.png">


Source:
https://twitter.com/mattpocockuk/status/1622730173446557697 by @mattpocock

