### PR TITLE
fix def of Plugin in TsConfigJson

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -188,11 +188,10 @@ declare namespace TsConfigJson {
 			| 'webworker.iterable';
 
 		export type Plugin = {
-			[key: string]: unknown;
 			/**
 			Plugin name.
 			*/
-			name?: string;
+			name: string;
 		};
 
 		export type ImportsNotUsedAsValues =

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -12,4 +12,3 @@ expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
 expectAssignable<Jsonifiable>(tsConfig);
-

--- a/test-d/tsconfig-json.ts
+++ b/test-d/tsconfig-json.ts
@@ -1,5 +1,5 @@
-import {expectType} from 'tsd';
-import type {TsConfigJson} from '../index';
+import {expectType, expectAssignable} from 'tsd';
+import type {Jsonifiable, TsConfigJson} from '../index';
 
 const tsConfig: TsConfigJson = {};
 
@@ -11,3 +11,5 @@ expectType<string[] | undefined>(tsConfig.files);
 expectType<string[] | undefined>(tsConfig.include);
 expectType<TsConfigJson.References[] | undefined>(tsConfig.references);
 expectType<TsConfigJson.TypeAcquisition | undefined>(tsConfig.typeAcquisition);
+expectAssignable<Jsonifiable>(tsConfig);
+


### PR DESCRIPTION
`Plugin` should always be `{name: string}`. `TsConfigJson` is now assignable to `Jsonifiable`

Closes #548

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
