### PR TITLE
fix(PackageJson): ensure `Imports` and `Exports` reflect Node.js expectations

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -224,7 +224,10 @@ declare namespace PackageJson {
 	string
 	>;
 
-	type ExportConditions = {[condition in ExportCondition]: Exports};
+	/**
+	A mapping of conditions and the paths to which they resolve.
+	*/
+	type ExportConditions = {[condition in ExportCondition]?: Exports};
 
 	/**
 	Entry points of a module, optionally with conditions and subpath exports.
@@ -233,14 +236,13 @@ declare namespace PackageJson {
 	| null
 	| string
 	| Array<string | ExportConditions>
-	| ExportConditions
-	| {[path: string]: Exports};
+	| ExportConditions;
 
 	/**
-	Import map entries of a module, optionally with conditions.
+	Import map entries of a module, optionally with conditions and subpath imports.
 	*/
 	export type Imports = { // eslint-disable-line @typescript-eslint/consistent-indexed-object-style
-		[key: `#${string}`]: string | {[key in ExportCondition]?: Exports};
+		[key: `#${string}`]: Exports;
 	};
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -57,7 +57,17 @@ expectAssignable<PackageJson.Imports>({'#unicorn': 'unicorn'});
 expectAssignable<PackageJson.Imports>({
 	'#unicorn': {
 		import: {browser: 'unicorn', node: 'pony'},
+		require: ['./fallback-1', './fallback-2', {default: './fallback-3', browser: null}],
+		custom: null,
 		default: 'horse',
+	},
+});
+expectAssignable<PackageJson.Exports>({
+	'./unicorn': {
+		import: {browser: './unicorn.js', node: './pony.js'},
+		require: ['./fallback-1', './fallback-2', {default: './fallback-3', browser: null}],
+		custom: null,
+		default: './horse.js',
 	},
 });
 expectNotAssignable<PackageJson.Imports>({unicorn: 'unicorn'});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Seems my previous PR was incomplete. While reviewing the Node.js source, I noticed a couple more issues. Namely: the `Imports` and `Exports` types should both accept fallback arrays containing exports conditions objects with optional properties. Also, the `Imports` type should accept everything the `Exports` type accepts (with the added constraint that entry points must start with `"#"`).

This PR addresses these and adds tests.