### PR TITLE
fix(join): edge case for single elem const tuple

### DIFF
--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -21,15 +21,15 @@ const path: Join<[1, 2, 3], '.'> = [1, 2, 3].join('.');
 @category Template literal
 */
 export type Join<
-	Strings extends Readonly<Array<string | number>>,
+	Strings extends ReadonlyArray<string | number>,
 	Delimiter extends string,
 > = Strings extends []
 	? ''
-	: Strings extends [string | number]
+	: Strings extends readonly [string | number]
 		? `${Strings[0]}`
 		: Strings extends readonly [
 			string | number,
-			...infer Rest extends Array<string | number>,
+			...infer Rest extends ReadonlyArray<string | number>,
 		]
 			? `${Strings[0]}${Delimiter}${Join<Rest, Delimiter>}`
 			: string;

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -22,12 +22,13 @@ const emptyInput: Join<[], '.'> = '';
 expectType<''>(emptyInput);
 expectNotAssignable<'foo'>(emptyInput);
 
-// Single input.
-const singleInput: Join<['test'], '.'> = 'test';
+// Single input with string[].
+const singleStringArray = ['test'];
+const singleInput: Join<typeof singleStringArray, '.'> = 'test';
 expectType<string>(singleInput);
 expectNotAssignable<'test'>(singleInput);
 
-// Single input.
+// Single input with const tuple.
 const singleTuple = ['test'] as const;
 const singleTupleJoined: Join<typeof singleTuple, '.'> = 'test';
 expectType<'test'>(singleTupleJoined);

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -22,12 +22,23 @@ const emptyInput: Join<[], '.'> = '';
 expectType<''>(emptyInput);
 expectNotAssignable<'foo'>(emptyInput);
 
-// Typeof of const tuple
+// Single input.
+const singleInput: Join<['test'], '.'> = 'test';
+expectType<string>(singleInput);
+expectNotAssignable<'test'>(singleInput);
+
+// Single input.
+const singleTuple = ['test'] as const;
+const singleTupleJoined: Join<typeof singleTuple, '.'> = 'test';
+expectType<'test'>(singleTupleJoined);
+expectNotAssignable<'test.'>(singleTupleJoined);
+
+// Typeof of const tuple.
 const tuple = ['foo', 'bar', 'baz'] as const;
 const joinedTuple: Join<typeof tuple, ','> = 'foo,bar,baz';
 expectType<'foo,bar,baz'>(joinedTuple);
 
-// Typeof of string[]
+// Typeof of string[].
 const stringArray = ['foo', 'bar', 'baz'];
 const joinedStringArray: Join<typeof stringArray, ','> = '';
 expectType<string>(joinedStringArray);


### PR DESCRIPTION
This fixes the usage of `Join<['test'] as const, '.'>`.

With #533 the output changed to `test.` instead of the expected `test`, this PR restores the old (and correct) behaviour.
