### PR TITLE
Add `AbstractClass` type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,8 @@ Click the type names for complete docs.
 - [`Primitive`](source/primitive.d.ts) - Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
 - [`Class`](source/basic.d.ts) - Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 - [`Constructor`](source/basic.d.ts) - Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
+- [`AbstractClass`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/classes.html#abstract-classes).
+- [`AbstractConstructor`](source/basic.d.ts) - Matches an [`abstract class constructor`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures).
 - [`TypedArray`](source/typed-array.d.ts) - Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
 - [`ObservableLike`](source/observable-like.d.ts) - Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Click the type names for complete docs.
 - [`Class`](source/basic.d.ts) - Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 - [`Constructor`](source/basic.d.ts) - Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 - [`AbstractClass`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/classes.html#abstract-classes).
-- [`AbstractConstructor`](source/basic.d.ts) - Matches an [`abstract class constructor`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures).
+- [`AbstractConstructor`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures) constructor.
 - [`TypedArray`](source/typed-array.d.ts) - Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
 - [`ObservableLike`](source/observable-like.d.ts) - Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
 

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -20,7 +20,7 @@ Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/class
 export type AbstractClass<T, Arguments extends unknown[] = any[]> = AbstractConstructor<T, Arguments> & {prototype: T};
 
 /**
-Matches an [`abstract class constructor`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures).
+Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures) constructor.
 
 @category Class
 */

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -13,6 +13,20 @@ Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/Jav
 export type Constructor<T, Arguments extends unknown[] = any[]> = new(...arguments_: Arguments) => T;
 
 /**
+Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/classes.html#abstract-classes).
+
+@category Class
+*/
+export type AbstractClass<T, Arguments extends unknown[] = any[]> = AbstractConstructor<T, Arguments> & {prototype: T};
+
+/**
+Matches an [`abstract class constructor`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures).
+
+@category Class
+*/
+export type AbstractConstructor<T, Arguments extends unknown[] = any[]> = abstract new(...arguments_: Arguments) => T;
+
+/**
 Matches a JSON object.
 
 This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.

--- a/test-d/abstract-class.ts
+++ b/test-d/abstract-class.ts
@@ -13,7 +13,7 @@ function functionRecevingAbsClass<T>(cls: AbstractClass<T>) {
 	return cls;
 }
 
-function withBar<T extends AbstractConstructor<object>>(Ctor: T): AbstractClass<object> {
+function withBar<T extends AbstractConstructor<object>>(Ctor: T) {
 	abstract class ExtendedBar extends Ctor {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		extendedBarMethod() {}
@@ -23,14 +23,18 @@ function withBar<T extends AbstractConstructor<object>>(Ctor: T): AbstractClass<
 
 function assertWithBar() {
 	// This lacks `barMethod`.
-	expectError(class WrongConcreteExtendedBar extends withBar(Bar) {});
+	// @ts-expect-error
+	class WrongConcreteExtendedBar extends withBar(Bar) {}
 
 	// This should be alright since `barMethod` is implemented.
 	class CorrectConcreteExtendedBar extends withBar(Bar) {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		barMethod() {}
 	}
+	expectAssignable(functionRecevingAbsClass<Bar>(withBar(Bar)));
+	expectAssignable(functionRecevingAbsClass<Bar>(CorrectConcreteExtendedBar));
 }
 
 expectAssignable(functionRecevingAbsClass(Foo));
+expectError(functionRecevingAbsClass<Bar>(Foo));
 assertWithBar();

--- a/test-d/abstract-class.ts
+++ b/test-d/abstract-class.ts
@@ -1,0 +1,36 @@
+import {expectAssignable, expectError} from 'tsd';
+import type {AbstractConstructor, AbstractClass} from '../index';
+
+abstract class Foo {
+	abstract fooMethod(): void;
+}
+
+abstract class Bar {
+	abstract barMethod(): void;
+}
+
+function functionRecevingAbsClass<T>(cls: AbstractClass<T>) {
+	return cls;
+}
+
+function withBar<T extends AbstractConstructor<object>>(Ctor: T): AbstractClass<object> {
+	abstract class ExtendedBar extends Ctor {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		extendedBarMethod() {}
+	}
+	return ExtendedBar;
+}
+
+function assertWithBar() {
+	// This lacks `barMethod`.
+	expectError(class WrongConcreteExtendedBar extends withBar(Bar) {});
+
+	// This should be alright since `barMethod` is implemented.
+	class CorrectConcreteExtendedBar extends withBar(Bar) {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		barMethod() {}
+	}
+}
+
+expectAssignable(functionRecevingAbsClass(Foo));
+assertWithBar();


### PR DESCRIPTION
Fixes #374

This PR adds a generic type `AbstractClass<T>` together with `AbstractConstructor<T>`.

The test is mostly inspire by [the official documentation of abstract construct signatures](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures)
