### PR TITLE
feat: add `IsXLiteral` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,15 @@ export type {HasRequiredKeys} from './source/has-required-keys';
 export type {Spread} from './source/spread';
 export type {TupleToUnion} from './source/tuple-to-union';
 export type {IsEqual} from './source/is-equal';
+export type {
+	IsLiteral,
+	IsStringLiteral,
+	IsNumericLiteral,
+	IsBooleanLiteral,
+	IsSymbolLiteral,
+	IsUndefinedLiteral,
+	IsNullLiteral,
+} from './source/is-literal';
 
 // Template literal types
 export type {CamelCase} from './source/camel-case';

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,8 +82,6 @@ export type {
 	IsNumericLiteral,
 	IsBooleanLiteral,
 	IsSymbolLiteral,
-	IsUndefinedLiteral,
-	IsNullLiteral,
 } from './source/is-literal';
 
 // Template literal types

--- a/readme.md
+++ b/readme.md
@@ -176,8 +176,6 @@ Click the type names for complete docs.
 - [`IsNumericLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 - [`IsBooleanLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 - [`IsSymbolLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsNullLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `null` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsUndefinedLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is an `undefined` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
 ### JSON
 

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,13 @@ Click the type names for complete docs.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.
 - [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread syntax.
 - [`IsEqual`](source/is-equal.d.ts) - Returns a boolean for whether the two given types are equal.
+- [`IsLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsStringLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsNumericLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsBooleanLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsSymbolLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsNullLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `null` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsUndefinedLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is an `undefined` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
 ### JSON
 

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -257,3 +257,8 @@ export type HasMultipleCallSignatures<T extends (...arguments: any[]) => unknown
 			? false
 			: true
 		: false;
+
+/**
+Returns a boolean for whether the given `boolean` is not `false`.
+*/
+export type IsNotFalse<T extends boolean> = [T] extends [false] ? false : true;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -2,7 +2,23 @@ import type {Primitive} from './primitive';
 import type {Numeric} from './numeric';
 import type {IsNever, IsNotFalse} from './internal';
 
-/** @link https://stackoverflow.com/a/52806744/10292952 */
+/**
+Returns a boolean for whether the given type `T` is the specified `LiteralType`.
+
+@link https://stackoverflow.com/a/52806744/10292952
+
+@example
+```
+LiteralCheck<1, number>
+//=> true
+
+LiteralCheck<number, number>
+//=> false
+
+LiteralCheck<1, string>
+//=> false
+```
+*/
 type LiteralCheck<T, LiteralType extends Primitive> = (
 	IsNever<T> extends false // Must be wider than `never`
 		? [T] extends [LiteralType] // Must be narrower than `LiteralType`
@@ -13,8 +29,25 @@ type LiteralCheck<T, LiteralType extends Primitive> = (
 		: false
 );
 
+/**
+Returns a boolean for whether the given type `T` is one of the specified literal types in `LiteralUnionType`.
+
+@example
+```
+LiteralChecks<1, Numeric>
+//=> true
+
+LiteralChecks<1n, Numeric>
+//=> true
+
+LiteralChecks<bigint, Numeric>
+//=> false
+```
+*/
 type LiteralChecks<T, LiteralUnionType> = (
-	// Conditional type to force union distribution
+	// Conditional type to force union distribution.
+	// If `T` is none of the literal types in the union `LiteralUnionType`, then `LiteralCheck<T, LiteralType>` will evaluate to `false` for the whole union.
+	// If `T` is one of the literal types in the union, it will evaluate to `boolean` (i.e. `true | false`)
 	IsNotFalse<LiteralUnionType extends Primitive
 		? LiteralCheck<T, LiteralUnionType>
 		: never

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,37 +1,29 @@
 import type {Primitive} from './primitive';
-import type {Numeric} from './numeric';
-import type {IsNotFalse} from './internal';
+import type {IsNever, IsNotFalse} from './internal';
 
 /** @link https://stackoverflow.com/a/52806744/10292952 */
 type LiteralCheck<T, LiteralType extends Primitive> = (
-	[T] extends [never] // Must be wider than `never`
-		? false
-		: T extends LiteralType // Must be narrower than `LiteralType`
-			? LiteralType extends T // Cannot be wider than `LiteralType`
+	IsNever<T> extends false // Must be wider than `never`
+		? [T] extends [LiteralType] // Must be narrower than `LiteralType`
+			? [LiteralType] extends [T] // Cannot be wider than `LiteralType`
 				? false
 				: true
 			: false
+		: false
 );
 
-type LiteralChecks<T, Union> = Union extends Primitive ? IsNotFalse<LiteralCheck<T, Union>> : false;
+type LiteralChecks<T, LiteralUnionType> = (
+	// Conditional type to force union distribution
+	LiteralUnionType extends Primitive
+		? IsNotFalse<LiteralCheck<T, LiteralUnionType>>
+		: false
+);
 
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
-export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
+export type IsNumericLiteral<T> = IsNotFalse<LiteralCheck<T, number> | LiteralCheck<T, bigint>>;
 
-export type IsBooleanLiteral<T> = (
-	[T] extends [never] // Must be wider than `never`
-		? false
-		: [T] extends [true]
-			? boolean extends T // Must be narrower than `boolean`
-				? false
-				: true
-			: [T] extends [false]
-				? boolean extends T // Must be narrower than `boolean`
-					? false
-					: true
-				: false
-);
+export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 
 export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
 

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -24,7 +24,10 @@ type LiteralChecks<T, LiteralUnionType> = (
 /**
 Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for constraining strings to be a string literal, or for providing strongly-typed string manipulation functions, as well as constructing parsers and ASTs.
+Useful for:
+	- providing strongly-typed string manipulation functions
+	- constraining strings to be a string literal
+	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -13,16 +13,6 @@ type LiteralCheck<T, LiteralType extends Primitive> = (
 			: false
 );
 
-type StringifiedLiteralCheck<T, LiteralType extends null | undefined> = (
-	[T] extends [never] // Must be wider than `never`
-		? false
-		: T extends LiteralType // Safe stringify
-			? `${T}` extends `${LiteralType}` // Must be narrower than `${LiteralType}`
-				? true
-				: false
-			: false
-);
-
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
 export type IsNumericLiteral<T> = Includes<[LiteralCheck<T, number>, LiteralCheck<T, bigint>], true>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,4 +1,5 @@
 import type {Primitive} from './primitive';
+import type {Numeric} from './numeric';
 import type {IsNever, IsNotFalse} from './internal';
 
 /** @link https://stackoverflow.com/a/52806744/10292952 */
@@ -14,14 +15,15 @@ type LiteralCheck<T, LiteralType extends Primitive> = (
 
 type LiteralChecks<T, LiteralUnionType> = (
 	// Conditional type to force union distribution
-	LiteralUnionType extends Primitive
-		? IsNotFalse<LiteralCheck<T, LiteralUnionType>>
-		: false
+	IsNotFalse<LiteralUnionType extends Primitive
+		? LiteralCheck<T, LiteralUnionType>
+		: never
+	>
 );
 
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
-export type IsNumericLiteral<T> = IsNotFalse<LiteralCheck<T, number> | LiteralCheck<T, bigint>>;
+export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
 export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -78,6 +78,7 @@ const output = capitalize('hello, world!');
 ```
 
 @category Utilities
+@category Type Guard
 */
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
@@ -125,6 +126,7 @@ endsWith('abc123', end);
 ```
 
 @category Utilities
+@category Type Guard
 */
 export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
@@ -164,6 +166,7 @@ const eitherId = getId({asString: runtimeBoolean});
 ```
 
 @category Utilities
+@category Type Guard
 */
 export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 
@@ -198,6 +201,7 @@ get({[symbolValue]: 1} as const, symbolValue);
 ```
 
 @category Utilities
+@category Type Guard
 */
 export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
 
@@ -243,5 +247,6 @@ stripLeading(str, 'abc');
 ```
 
 @category Utilities
+@category Type Guard
 */
 export type IsLiteral<T extends Primitive> = IsNotFalse<IsLiteralUnion<T>>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -21,18 +21,74 @@ type LiteralChecks<T, LiteralUnionType> = (
 	>
 );
 
+/**
+Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsStringLiteral} from 'type-fest';
+
+```
+
+@category Utilities
+*/
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
+/**
+Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsNumericLiteral} from 'type-fest';
+
+```
+
+@category Utilities
+*/
 export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
+/**
+Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsBooleanLiteral} from 'type-fest';
+
+```
+
+@category Utilities
+*/
 export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 
+/**
+Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsLiteral} from 'type-fest';
+
+```
+
+@category Utilities
+*/
 export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
 
+/** Helper type for `IsLiteral`. */
 type IsLiteralUnion<T> =
 	| IsStringLiteral<T>
 	| IsNumericLiteral<T>
 	| IsBooleanLiteral<T>
 	| IsSymbolLiteral<T>;
 
+/**
+Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsLiteral} from 'type-fest';
+
+```
+
+@category Utilities
+*/
 export type IsLiteral<T extends Primitive> = IsNotFalse<IsLiteralUnion<T>>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -90,6 +90,36 @@ Useful for type utilities, such as when constructing parsers and ASTs.
 ```
 import type {IsNumericLiteral} from 'type-fest';
 
+// https://github.com/inocan-group/inferred-types/blob/master/src/types/boolean-logic/EndsWith.ts
+type EndsWith<TValue, TEndsWith extends string> =
+	TValue extends string
+		? IsStringLiteral<TEndsWith> extends true
+			? IsStringLiteral<TValue> extends true
+				? TValue extends `${string}${TEndsWith}`
+					? true
+					: false
+				: boolean
+			: boolean
+		: TValue extends number
+			? IsNumericLiteral<TValue> extends true
+				? EndsWith<`${TValue}`, TEndsWith>
+				: false
+			: false;
+
+function endsWith<Input extends string | number, End extends string>(input: Input, end: End) {
+	return `${input}`.endsWith(end) as EndsWith<Input, End>;
+}
+
+endsWith('abc', 'c');
+//=> true
+
+endsWith(123456, '456');
+//=> true
+
+const end = '123' as string;
+
+endsWith('abc123', end);
+//=> boolean
 ```
 
 @category Utilities

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -43,17 +43,11 @@ export type IsBooleanLiteral<T> = (
 
 export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
 
-export type IsNullLiteral<T> = StringifiedLiteralCheck<T, null>;
-
-export type IsUndefinedLiteral<T> = StringifiedLiteralCheck<T, undefined>;
-
 type IsLiteralTuple<T> = [
 	IsStringLiteral<T>,
 	IsNumericLiteral<T>,
 	IsBooleanLiteral<T>,
 	IsSymbolLiteral<T>,
-	IsNullLiteral<T>,
-	IsUndefinedLiteral<T>,
 ];
 
 export type IsLiteral<T extends Primitive> = Includes<IsLiteralTuple<T>, true>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -170,12 +170,31 @@ export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 /**
 Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for type utilities, such as when constructing parsers and ASTs.
+Useful for:
+	- providing strongly-typed functions when given literal arguments
+	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```
 import type {IsSymbolLiteral} from 'type-fest';
 
+type Get<Obj extends Record<symbol, number>, Key extends keyof Obj> =
+	IsSymbolLiteral<Key> extends true
+		? Obj[Key]
+		: number;
+
+function get<Obj extends Record<symbol, number>, Key extends keyof Obj>(o: Obj, key: Key) {
+	return o[key] as Get<Obj, Key>;
+}
+
+const symbolLiteral = Symbol('literal');
+const symbolValue: symbol = Symbol('value');
+
+get({[symbolLiteral]: 1} as const, symbolLiteral);
+//=> 1
+
+get({[symbolValue]: 1} as const, symbolValue);
+//=> number
 ```
 
 @category Utilities

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -32,6 +32,7 @@ import type {IsStringLiteral} from 'type-fest';
 
 type CapitalizedString<T extends string> = IsStringLiteral<T> extends true ? Capitalize<T> : string;
 
+// https://github.com/yankeeinlondon/native-dash/blob/master/src/capitalize.ts
 function capitalize<T extends Readonly<string>>(input: T): CapitalizedString<T> {
 	return (input.slice(0, 1).toUpperCase() + input.slice(1)) as CapitalizedString<T>;
 }

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -24,7 +24,7 @@ type LiteralChecks<T, LiteralUnionType> = (
 /**
 Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for constraining strings to be a string literal, or for providing strongly-typed string manipulation functions.
+Useful for constraining strings to be a string literal, or for providing strongly-typed string manipulation functions, as well as constructing parsers and ASTs.
 
 @example
 ```
@@ -48,6 +48,8 @@ export type IsStringLiteral<T> = LiteralCheck<T, string>;
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
+Useful for constructing parsers and ASTs.
+
 @example
 ```
 import type {IsNumericLiteral} from 'type-fest';
@@ -60,6 +62,8 @@ export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+Useful for constructing parsers and ASTs.
 
 @example
 ```
@@ -74,9 +78,11 @@ export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 /**
 Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
+Useful for constructing parsers and ASTs.
+
 @example
 ```
-import type {IsLiteral} from 'type-fest';
+import type {IsSymbolLiteral} from 'type-fest';
 
 ```
 

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -24,10 +24,20 @@ type LiteralChecks<T, LiteralUnionType> = (
 /**
 Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
+Useful for constraining strings to be a string literal, or for providing strongly-typed string manipulation functions.
+
 @example
 ```
 import type {IsStringLiteral} from 'type-fest';
 
+type CapitalizedString<T extends string> = IsStringLiteral<T> extends true ? Capitalize<T> : string;
+
+function capitalize<T extends Readonly<string>>(input: T): CapitalizedString<T> {
+	return (input.slice(0, 1).toUpperCase() + input.slice(1)) as CapitalizedString<T>;
+}
+
+const output = capitalize('hello, world!');
+//=> 'Hello, world!'
 ```
 
 @category Utilities

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -84,7 +84,9 @@ export type IsStringLiteral<T> = LiteralCheck<T, string>;
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for type utilities, such as when constructing parsers and ASTs.
+Useful for:
+	- providing strongly-typed functions when given literal arguments
+	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,6 +1,6 @@
-import type {Numeric} from './numeric';
 import type {Primitive} from './primitive';
-import type {Includes} from './includes';
+import type {Numeric} from './numeric';
+import type {IsNotFalse} from './internal';
 
 /** @link https://stackoverflow.com/a/52806744/10292952 */
 type LiteralCheck<T, LiteralType extends Primitive> = (
@@ -13,9 +13,11 @@ type LiteralCheck<T, LiteralType extends Primitive> = (
 			: false
 );
 
+type LiteralChecks<T, Union> = Union extends Primitive ? IsNotFalse<LiteralCheck<T, Union>> : false;
+
 export type IsStringLiteral<T> = LiteralCheck<T, string>;
 
-export type IsNumericLiteral<T> = Includes<[LiteralCheck<T, number>, LiteralCheck<T, bigint>], true>;
+export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
 export type IsBooleanLiteral<T> = (
 	[T] extends [never] // Must be wider than `never`
@@ -33,11 +35,10 @@ export type IsBooleanLiteral<T> = (
 
 export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
 
-type IsLiteralTuple<T> = [
-	IsStringLiteral<T>,
-	IsNumericLiteral<T>,
-	IsBooleanLiteral<T>,
-	IsSymbolLiteral<T>,
-];
+type IsLiteralUnion<T> =
+	| IsStringLiteral<T>
+	| IsNumericLiteral<T>
+	| IsBooleanLiteral<T>
+	| IsSymbolLiteral<T>;
 
-export type IsLiteral<T extends Primitive> = Includes<IsLiteralTuple<T>, true>;
+export type IsLiteral<T extends Primitive> = IsNotFalse<IsLiteralUnion<T>>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -104,6 +104,27 @@ Returns a boolean for whether the given type is a [literal type](https://www.typ
 ```
 import type {IsLiteral} from 'type-fest';
 
+// https://github.com/inocan-group/inferred-types/blob/master/src/types/string-literals/StripLeading.ts
+export type StripLeading<A, B> =
+	A extends string
+		? B extends string
+			? IsLiteral<A> extends true
+				? string extends B ? never : A extends `${B & string}${infer After}` ? After : A
+				: string
+			: A
+		: A;
+
+function stripLeading<Input extends string, Strip extends string>(input: Input, strip: Strip) {
+	return input.replace(`^${strip}`, '') as StripLeading<Input, Strip>;
+}
+
+stripLeading('abc123', 'abc');
+//=> '123'
+
+const str = 'abc123' as string;
+
+stripLeading(str, 'abc');
+//=> string
 ```
 
 @category Utilities

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -51,7 +51,7 @@ export type IsStringLiteral<T> = LiteralCheck<T, string>;
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for constructing parsers and ASTs.
+Useful for type utilities, such as when constructing parsers and ASTs.
 
 @example
 ```
@@ -66,7 +66,7 @@ export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for constructing parsers and ASTs.
+Useful for type utilities, such as when constructing parsers and ASTs.
 
 @example
 ```
@@ -81,7 +81,7 @@ export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
 /**
 Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for constructing parsers and ASTs.
+Useful for type utilities, such as when constructing parsers and ASTs.
 
 @example
 ```
@@ -102,6 +102,10 @@ type IsLiteralUnion<T> =
 
 /**
 Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+Useful for:
+	- providing strongly-typed functions when given literal arguments
+	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -131,12 +131,36 @@ export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 
-Useful for type utilities, such as when constructing parsers and ASTs.
+Useful for:
+	- providing strongly-typed functions when given literal arguments
+	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```
 import type {IsBooleanLiteral} from 'type-fest';
 
+const id = 123;
+
+type GetId<AsString extends boolean> =
+	IsBooleanLiteral<AsString> extends true
+		? AsString extends true
+			? `${typeof id}`
+			: typeof id
+		: number | string;
+
+function getId<AsString extends boolean = false>(options?: {asString: AsString}) {
+	return (options?.asString ? `${id}` : id) as GetId<AsString>;
+}
+
+const numberId = getId();
+//=> 123
+
+const stringId = getId({asString: true});
+//=> '123'
+
+declare const runtimeBoolean: boolean;
+const eitherId = getId({asString: runtimeBoolean});
+//=> number | string
 ```
 
 @category Utilities

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,0 +1,59 @@
+import type {Numeric} from './numeric';
+import type {Primitive} from './primitive';
+import type {Includes} from './includes';
+
+/** @link https://stackoverflow.com/a/52806744/10292952 */
+type LiteralCheck<T, LiteralType extends Primitive> = (
+	[T] extends [never] // Must be wider than `never`
+		? false
+		: T extends LiteralType // Must be narrower than `LiteralType`
+			? LiteralType extends T // Cannot be wider than `LiteralType`
+				? false
+				: true
+			: false
+);
+
+type StringifiedLiteralCheck<T, LiteralType extends null | undefined> = (
+	[T] extends [never] // Must be wider than `never`
+		? false
+		: T extends LiteralType // Safe stringify
+			? `${T}` extends `${LiteralType}` // Must be narrower than `${LiteralType}`
+				? true
+				: false
+			: false
+);
+
+export type IsStringLiteral<T> = LiteralCheck<T, string>;
+
+export type IsNumericLiteral<T> = Includes<[LiteralCheck<T, number>, LiteralCheck<T, bigint>], true>;
+
+export type IsBooleanLiteral<T> = (
+	[T] extends [never] // Must be wider than `never`
+		? false
+		: [T] extends [true]
+			? boolean extends T // Must be narrower than `boolean`
+				? false
+				: true
+			: [T] extends [false]
+				? boolean extends T // Must be narrower than `boolean`
+					? false
+					: true
+				: false
+);
+
+export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
+
+export type IsNullLiteral<T> = StringifiedLiteralCheck<T, null>;
+
+export type IsUndefinedLiteral<T> = StringifiedLiteralCheck<T, undefined>;
+
+type IsLiteralTuple<T> = [
+	IsStringLiteral<T>,
+	IsNumericLiteral<T>,
+	IsBooleanLiteral<T>,
+	IsSymbolLiteral<T>,
+	IsNullLiteral<T>,
+	IsUndefinedLiteral<T>,
+];
+
+export type IsLiteral<T extends Primitive> = Includes<IsLiteralTuple<T>, true>;

--- a/test-d/internal.ts
+++ b/test-d/internal.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {IsWhitespace, IsNumeric} from '../source/internal';
+import type {IsWhitespace, IsNumeric, IsNotFalse} from '../source/internal';
 
 expectType<IsWhitespace<''>>(false);
 expectType<IsWhitespace<' '>>(true);
@@ -27,3 +27,11 @@ expectType<IsNumeric<' 1.2'>>(false);
 expectType<IsNumeric<'1 2'>>(false);
 expectType<IsNumeric<'1_200'>>(false);
 expectType<IsNumeric<' 1 '>>(false);
+
+expectType<IsNotFalse<true>>(true);
+expectType<IsNotFalse<boolean>>(true);
+expectType<IsNotFalse<true | false>>(true);
+expectType<IsNotFalse<true | false | false | false>>(true);
+expectType<IsNotFalse<false>>(false);
+expectType<IsNotFalse<false | false>>(false);
+expectType<IsNotFalse<false | false | false | false>>(false);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -9,7 +9,7 @@ import type {
 
 const stringLiteral = '';
 const numberLiteral = 1;
-// @ts-expect-error (suppress BigInt literal tsd warning)
+// @ts-expect-error: suppress BigInt literal tsd warning
 const bigintLiteral = 1n;
 const booleanLiteral = true;
 const symbolLiteral = Symbol('');

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -19,8 +19,6 @@ declare const _number: number;
 declare const _bigint: bigint;
 declare const _boolean: boolean;
 declare const _symbol: symbol;
-declare const _null: null;
-declare const _undefined: undefined;
 
 // Literals should be true
 expectType<IsLiteral<typeof stringLiteral>>(true);
@@ -37,6 +35,8 @@ expectType<IsLiteral<typeof _boolean>>(false);
 expectType<IsLiteral<typeof _symbol>>(false);
 expectType<IsLiteral<any>>(false);
 expectType<IsLiteral<never>>(false);
+expectType<IsLiteral<null>>(false);
+expectType<IsLiteral<undefined>>(false);
 
 expectType<IsStringLiteral<typeof stringLiteral>>(true);
 expectType<IsStringLiteral<typeof _string>>(false);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -27,16 +27,18 @@ expectType<IsLiteral<typeof bigintLiteral>>(true);
 expectType<IsLiteral<typeof booleanLiteral>>(true);
 expectType<IsLiteral<typeof symbolLiteral>>(true);
 
-// Primitives and others should be false
+// Primitives should be false
 expectType<IsLiteral<typeof _string>>(false);
 expectType<IsLiteral<typeof _number>>(false);
 expectType<IsLiteral<typeof _bigint>>(false);
 expectType<IsLiteral<typeof _boolean>>(false);
 expectType<IsLiteral<typeof _symbol>>(false);
-expectType<IsLiteral<any>>(false);
-expectType<IsLiteral<never>>(false);
+
+// Null, undefined, and non-primitives should fail all literal checks
 expectType<IsLiteral<null>>(false);
 expectType<IsLiteral<undefined>>(false);
+expectType<IsLiteral<any>>(false);
+expectType<IsLiteral<never>>(false);
 
 expectType<IsStringLiteral<typeof stringLiteral>>(true);
 expectType<IsStringLiteral<typeof _string>>(false);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -21,8 +21,8 @@ declare const _number: number;
 declare const _bigint: bigint;
 declare const _boolean: boolean;
 declare const _symbol: symbol;
-declare const _undefined: undefined;
 declare const _null: null;
+declare const _undefined: undefined;
 
 // Literals should be true
 expectType<IsLiteral<typeof stringLiteral>>(true);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -1,0 +1,76 @@
+import {expectError, expectType} from 'tsd';
+import type {
+	IsLiteral,
+	IsStringLiteral,
+	IsNumericLiteral,
+	IsBooleanLiteral,
+	IsSymbolLiteral,
+	IsUndefinedLiteral,
+	IsNullLiteral,
+} from '../index';
+
+const stringLiteral = '';
+const numberLiteral = 1;
+// @ts-expect-error (suppress BigInt literal tsd warning)
+const bigintLiteral = 1n;
+const booleanLiteral = true;
+const symbolLiteral = Symbol('');
+
+declare const _string: string;
+declare const _number: number;
+declare const _bigint: bigint;
+declare const _boolean: boolean;
+declare const _symbol: symbol;
+declare const _undefined: undefined;
+declare const _null: null;
+
+// Literals should be true
+expectType<IsLiteral<typeof stringLiteral>>(true);
+expectType<IsLiteral<typeof numberLiteral>>(true);
+expectType<IsLiteral<typeof bigintLiteral>>(true);
+expectType<IsLiteral<typeof booleanLiteral>>(true);
+expectType<IsLiteral<typeof symbolLiteral>>(true);
+expectType<IsLiteral<null>>(true);
+expectType<IsLiteral<undefined>>(true);
+
+// Primitives and others should be false
+expectType<IsLiteral<typeof _string>>(false);
+expectType<IsLiteral<typeof _number>>(false);
+expectType<IsLiteral<typeof _bigint>>(false);
+expectType<IsLiteral<typeof _boolean>>(false);
+expectType<IsLiteral<typeof _symbol>>(false);
+// Fix: expectType<IsLiteral<typeof _null>>(false);
+// Fix: expectType<IsLiteral<typeof _undefined>>(false);
+expectType<IsLiteral<any>>(false);
+expectType<IsLiteral<never>>(false);
+
+expectType<IsStringLiteral<typeof stringLiteral>>(true);
+expectType<IsStringLiteral<typeof _string>>(false);
+
+expectType<IsNumericLiteral<typeof numberLiteral>>(true);
+expectType<IsNumericLiteral<typeof bigintLiteral>>(true);
+expectType<IsNumericLiteral<typeof _number>>(false);
+expectType<IsNumericLiteral<typeof _bigint>>(false);
+
+expectType<IsBooleanLiteral<typeof booleanLiteral>>(true);
+expectType<IsBooleanLiteral<typeof _boolean>>(false);
+
+expectType<IsSymbolLiteral<typeof symbolLiteral>>(true);
+expectType<IsSymbolLiteral<typeof _symbol>>(false);
+
+expectType<IsNullLiteral<null>>(true);
+// Fix: expectType<IsNullLiteral<typeof _null>>(false);
+
+expectType<IsUndefinedLiteral<undefined>>(true);
+// Fix: expectType<IsUndefinedLiteral<typeof _undefined>>(false);
+
+declare const anything: any;
+
+// Missing generic parameter
+expectError<IsLiteral>(anything);
+expectError<IsStringLiteral>(anything);
+expectError<IsNumericLiteral>(anything);
+expectError<IsBooleanLiteral>(anything);
+expectError<IsSymbolLiteral>(anything);
+expectError<IsNullLiteral>(anything);
+expectError<IsUndefinedLiteral>(anything);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -5,8 +5,6 @@ import type {
 	IsNumericLiteral,
 	IsBooleanLiteral,
 	IsSymbolLiteral,
-	IsUndefinedLiteral,
-	IsNullLiteral,
 } from '../index';
 
 const stringLiteral = '';
@@ -30,8 +28,6 @@ expectType<IsLiteral<typeof numberLiteral>>(true);
 expectType<IsLiteral<typeof bigintLiteral>>(true);
 expectType<IsLiteral<typeof booleanLiteral>>(true);
 expectType<IsLiteral<typeof symbolLiteral>>(true);
-expectType<IsLiteral<null>>(true);
-expectType<IsLiteral<undefined>>(true);
 
 // Primitives and others should be false
 expectType<IsLiteral<typeof _string>>(false);
@@ -39,8 +35,6 @@ expectType<IsLiteral<typeof _number>>(false);
 expectType<IsLiteral<typeof _bigint>>(false);
 expectType<IsLiteral<typeof _boolean>>(false);
 expectType<IsLiteral<typeof _symbol>>(false);
-// Fix: expectType<IsLiteral<typeof _null>>(false);
-// Fix: expectType<IsLiteral<typeof _undefined>>(false);
 expectType<IsLiteral<any>>(false);
 expectType<IsLiteral<never>>(false);
 
@@ -58,12 +52,6 @@ expectType<IsBooleanLiteral<typeof _boolean>>(false);
 expectType<IsSymbolLiteral<typeof symbolLiteral>>(true);
 expectType<IsSymbolLiteral<typeof _symbol>>(false);
 
-expectType<IsNullLiteral<null>>(true);
-// Fix: expectType<IsNullLiteral<typeof _null>>(false);
-
-expectType<IsUndefinedLiteral<undefined>>(true);
-// Fix: expectType<IsUndefinedLiteral<typeof _undefined>>(false);
-
 declare const anything: any;
 
 // Missing generic parameter
@@ -72,5 +60,3 @@ expectError<IsStringLiteral>(anything);
 expectError<IsNumericLiteral>(anything);
 expectError<IsBooleanLiteral>(anything);
 expectError<IsSymbolLiteral>(anything);
-expectError<IsNullLiteral>(anything);
-expectError<IsUndefinedLiteral>(anything);


### PR DESCRIPTION
Closes #541, closes #339.

Adds types to check if a given type is a `Primitive` literal:

- `IsLiteral`
- `IsStringLiteral`
- `IsNumericLiteral`
- `IsBooleanLiteral`
- `IsSymbolLiteral`
- ~`IsNullLiteral`~
- ~`IsUndefinedLiteral`~

Marking as draft as I still need to add documentation comments to the types. 

<details>
<summary>Info About Removed Types</summary>

I'm not sure if it's possible to check for `null` or `undefined` literals without also allowing their values, e.g:

```ts
import type {IsNullLiteral} from 'type-fest';

declare const _null: null;

type ShouldBeTrue = IsNullLiteral<null>;
//=> true

type ShouldBeFalse = IsNullLiteral<typeof _null>;
//=> true
```

Marking as draft as I still need to figure out the above issue and add documentation comments to the types. Currently the test cases for `_null` and `_undefined` values are commented out.
</details>