### PR TITLE
Fix abstract-class test to not needlessly use expectAssignable

### DIFF
--- a/test-d/abstract-class.ts
+++ b/test-d/abstract-class.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectError} from 'tsd';
+import {expectError} from 'tsd';
 import type {AbstractConstructor, AbstractClass} from '../index';
 
 abstract class Foo {
@@ -31,10 +31,10 @@ function assertWithBar() {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		barMethod() {}
 	}
-	expectAssignable(functionRecevingAbsClass<Bar>(withBar(Bar)));
-	expectAssignable(functionRecevingAbsClass<Bar>(CorrectConcreteExtendedBar));
+	functionRecevingAbsClass<Bar>(withBar(Bar));
+	functionRecevingAbsClass<Bar>(CorrectConcreteExtendedBar);
 }
 
-expectAssignable(functionRecevingAbsClass(Foo));
+functionRecevingAbsClass(Foo);
 expectError(functionRecevingAbsClass<Bar>(Foo));
 assertWithBar();


### PR DESCRIPTION
Just noticed this test was using `expectAssignable` without an explicit type parameter making the call meaningless.

The check here is verified with the call to `functionRecevingAbsClass` compiling, not it being wrapped in `expectAssignable`

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
