### PR TITLE
Remove need for @ts-expect-error usage in test

### DIFF
--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -9,8 +9,8 @@ import type {
 
 const stringLiteral = '';
 const numberLiteral = 1;
-// @ts-expect-error: suppress BigInt literal tsd warning
-const bigintLiteral = 1n;
+// Note: tsd warns on direct literal usage so we cast to the literal type
+const bigintLiteral = BigInt(1) as 1n;
 const booleanLiteral = true;
 const symbolLiteral = Symbol('');
 


### PR DESCRIPTION
When `tsc` is not set to permit `bigint` literals, it's better to wrap the equivalent number in a `BigInt` constructor call and then cast to the desired literal type.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
