### PR TITLE
fix: export imported `Numeric` type

### DIFF
--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -1,4 +1,4 @@
-type Numeric = number | bigint;
+export type Numeric = number | bigint;
 
 type Zero = 0 | 0n;
 


### PR DESCRIPTION
This file imports `Numeric`, but it's not exported from `./numeric.d.ts`:
https://github.com/sindresorhus/type-fest/blob/c3bc0e8b08dc7656935eea49c76d8131a0abd32e/source/is-literal.d.ts#L2