### PR TITLE
Add `Destructurable` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export * from './source/observable-like';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object';
 export type {Except} from './source/except';
 export type {TaggedUnion} from './source/tagged-union';
+export type {Destructurable} from './source/destructurable';
 export type {Writable} from './source/writable';
 export type {WritableDeep} from './source/writable-deep';
 export type {Merge} from './source/merge';

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ Click the type names for complete docs.
 - [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread syntax.
 - [`IsEqual`](source/is-equal.d.ts) - Returns a boolean for whether the two given types are equal.
 - [`TaggedUnion`](source/tagged-union.d.ts) - Create a union of types that share a common discriminant property.
+- [`Destructurable`](source/destructurable.d.ts) - Convert a union type of objects to a destructurable type.
 
 ### Type Guard
 

--- a/source/destructurable.d.ts
+++ b/source/destructurable.d.ts
@@ -12,11 +12,14 @@ type Success = {
 	type: 'success';
 	value: number;
 };
+
 type Failure = {
 	type: 'failure';
 	error: Error;
 };
+
 type Result = Destructurable<Success | Failure>;
+
 function divide(x: number, y: number): Result {
 	return y === 0
 		? {type: 'success', value: x / y}
@@ -27,10 +30,10 @@ function divide(x: number, y: number): Result {
 const {type, value, error} = divide(4, 2);
 
 // Narrowing also works.
-if (type === "success") {
-  value - 1; // value is a number
+if (type === 'success') {
+	value - 1; // `value` is a number
 } else {
-  error.message;
+	error.message;
 }
 ```
 

--- a/source/destructurable.d.ts
+++ b/source/destructurable.d.ts
@@ -1,0 +1,47 @@
+import {type Simplify} from './simplify';
+import {type UnionToIntersection} from './union-to-intersection';
+
+/**
+Convert a union type of objects to a destructurable type.
+
+@example
+```
+import type {Destructurable} from 'type-fest';
+
+type Success = {
+	type: 'success';
+	value: number;
+};
+type Failure = {
+	type: 'failure';
+	error: Error;
+};
+type Result = Destructurable<Success | Failure>;
+function divide(x: number, y: number): Result {
+	return y === 0
+		? {type: 'success', value: x / y}
+		: {type: 'failure', error: new Error('Division by zero')};
+}
+
+// The `result` can be destructured directly.
+const {type, value, error} = divide(4, 2);
+
+// Narrowing also works.
+if (type === "success") {
+  value - 1; // value is a number
+} else {
+  error.message;
+}
+```
+
+@category Utilities
+*/
+type Destructurable<UnionType> = Simplify<
+UnionToIntersection<{
+	[KeyType in keyof UnionType]?: undefined;
+}> extends infer ObjectWithAllKeys // Create an object that has all keys of UnionTypes with undefined, and assign it to ObjectWithAllKeys.
+	? UnionType extends infer EachType // For each types in UnionTypes.
+		? EachType & Omit<ObjectWithAllKeys, keyof EachType> // Create a new type that is the intersection of EachType and the object that has all keys of UnionTypes with undefined, but omit the keys that are already in EachType.
+		: never
+	: never
+>;

--- a/test-d/destructurable.ts
+++ b/test-d/destructurable.ts
@@ -1,0 +1,50 @@
+import {expectType} from 'tsd';
+import {type Destructurable} from '../index';
+
+// Typological use cases
+type Success = {
+	type: 'success';
+	value: number;
+};
+type Failure = {
+	type: 'failure';
+	error: Error;
+};
+type Result = Destructurable<Success | Failure>;
+function divide(x: number, y: number): Result {
+	return y === 0
+		? {type: 'success', value: x / y}
+		: {type: 'failure', error: new Error('Division by zero')};
+}
+
+// The type of `result` should be the union of the destructured types
+const {type, value, error} = divide(4, 2);
+expectType<'success' | 'failure'>(type);
+expectType<number | undefined>(value);
+expectType<Error | undefined>(error);
+
+// Narrowing should work
+if (type === 'success') {
+	expectType<number>(value);
+	expectType<undefined>(error);
+} else {
+	expectType<Error>(error);
+	expectType<undefined>(value);
+}
+
+// Readonly properties should be preserved
+declare const result1: Destructurable<{readonly x: number}>;
+expectType<Expect1>(result1);
+type Expect1 = {readonly x: number};
+
+// If both writable properties and readonly properties are present, it should be converted to writable properties
+type FooIsWritable = {type: 1; foo: number};
+type FooIsReadonly = {type: 2; readonly foo: number};
+type WithoutFoo = {type: 3; bar: number};
+type Result2 = Destructurable<FooIsWritable | FooIsReadonly | WithoutFoo>;
+declare const result2: Result2;
+expectType<Expect2>(result2);
+type Expect2 =
+	| {type: 1; foo: number; bar?: undefined}
+	| {type: 2; readonly foo: number; bar?: undefined}
+	| {type: 3; bar: number; foo?: undefined}; // Note: foo should not be readonly.


### PR DESCRIPTION
## Overview
This pull request introduces the `Destructurable` type that aims to resolve an issue encountered when trying to destructure the return values of functions with union types.

## TypeScript Compiler's Type Inference
When we define a function and omit the return type, the TypeScript compiler infers the return type automatically. For example, in the provided code snippet:

```typescript
function doSomething() {
  return Math.random() > 0.5
    ? { type: "success" as const, value: "foo" }
    : { type: "failure" as const, error: new Error("Something wrong") };
}
```

The compiler infers the `ReturnType` as:

```typescript
type ReturnType =
  | {
      type: "success";
      value: string;
      error?: undefined;
    }
  | {
      type: "failure";
      error: Error;
      value?: undefined;
    };
```

Thanks to this inferred type, we can destructure the return value directly as shown:

```typescript
const { type, value, error } = doSomething();
```

## Problem

However, when defining functions with union types as return values, the TypeScript compiler is unable to destructure the return values directly, causing errors when accessing properties of the return value. For instance, when explicitly annotating the return type of the `doSomething()` function with `Success | Failure` union type:

```typescript
type Success = {
  type: "success";
  value: string;
};
type Failure = {
  type: "failure";
  error: Error;
};
function doSomething(): Success | Failure {
  return Math.random() > 0.5
    ? { type: "success" as const, value: "foo" }
    : { type: "failure" as const, error: new Error("Something wrong") };
}
const { type, value, error } = doSomething();
```

It leads to the following errors:

> Property 'value' does not exist on type 'Success | Failure'.(2339)
> Property 'error' does not exist on type 'Success | Failure'.(2339)

A workaround for this issue would be to add the `error` property to the `Success` type and the `value` property to the `Failure` type. However, this approach adds unnecessary properties to the types.

## Solution

The `Destructurable` type resolves the problem by allowing the union types to be destructured directly. In the example provided, the `Result` type is defined as a `Destructurable<Success | Failure>`:

```typescript
type Result = Destructurable<Success | Failure>;
function doSomething(): Result {
  return Math.random() > 0.5
    ? { type: "success", value: "foo" }
    : { type: "failure", error: new Error("Something wrong") };
}
```

The `Destructurable<Success | Failure>` type is calculated as:

```typescript
type Result =
  | {
      type: "success";
      value: string;
      error?: undefined;
    }
  | {
      type: "failure";
      error: Error;
      value?: undefined;
    };
```

With the `Destructurable` type, the result can be destructured directly, and narrowing also works as expected:

```typescript
const { type, value, error } = doSomething();

if (type === "success") {
  value.toUpperCase();
} else {
  error.message;
}
```

This new type simplifies the handling of union types in functions' return values, making it easier to destructure and work with the properties of those types.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
