### PR TITLE
Add `OverrideProperties` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ export type {StringKeyOf} from './source/string-key-of';
 export type {Exact} from './source/exact';
 export type {ReadonlyTuple} from './source/readonly-tuple';
 export type {OptionalKeysOf} from './source/optional-keys-of';
+export type {OverrideProperties} from './source/override-properties';
 export type {HasOptionalKeys} from './source/has-optional-keys';
 export type {RequiredKeysOf} from './source/required-keys-of';
 export type {HasRequiredKeys} from './source/has-required-keys';

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeDeep`](source/merge-deep.d.ts) - Merge two objects or two arrays/tuples recursively into a new type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive keys.
+- [`OverrideProperties`](source/override-properties.d.ts) - Override only existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given keys.
 - [`RequireExactlyOne`](source/require-exactly-one.d.ts) - Create a type that requires exactly a single key of the given keys and disallows more.
 - [`RequireAllOrNone`](source/require-all-or-none.d.ts) - Create a type that requires all of the given keys or none of the given keys.
@@ -169,7 +170,6 @@ Click the type names for complete docs.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties.
 - [`OptionalKeysOf`](source/optional-keys-of.d.ts) - Extract all optional keys from the given type.
-- [`OverrideProperties`](source/override-properties.d.ts) - Override only existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ Click the type names for complete docs.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties.
 - [`OptionalKeysOf`](source/optional-keys-of.d.ts) - Extract all optional keys from the given type.
+- [`OverrideProperties`](source/override-properties.d.ts) - Override existing properties of the given type.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ Click the type names for complete docs.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties.
 - [`OptionalKeysOf`](source/optional-keys-of.d.ts) - Extract all optional keys from the given type.
-- [`OverrideProperties`](source/override-properties.d.ts) - Override existing properties of the given type.
+- [`OverrideProperties`](source/override-properties.d.ts) - Override only existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Click the type names for complete docs.
 - [`Merge`](source/merge.d.ts) - Merge two types into a new type. Keys of the second type overrides keys of the first type.
 - [`MergeDeep`](source/merge-deep.d.ts) - Merge two objects or two arrays/tuples recursively into a new type.
 - [`MergeExclusive`](source/merge-exclusive.d.ts) - Create a type that has mutually exclusive keys.
-- [`OverrideProperties`](source/override-properties.d.ts) - Override only existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
+- [`OverrideProperties`](source/override-properties.d.ts) - Override only existing properties of the given type. Similar to `Merge`, but enforces that the original type has the properties you want to override.
 - [`RequireAtLeastOne`](source/require-at-least-one.d.ts) - Create a type that requires at least one of the given keys.
 - [`RequireExactlyOne`](source/require-exactly-one.d.ts) - Create a type that requires exactly a single key of the given keys and disallows more.
 - [`RequireAllOrNone`](source/require-all-or-none.d.ts) - Create a type that requires all of the given keys or none of the given keys.

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -1,7 +1,7 @@
 import type {Merge} from './merge';
 
 /**
-Override existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
+Override existing properties of the given type. Similar to `Merge`, but enforces that the original type has the properties you want to override.
 
 This is useful when you want to override existing properties with a different type and make sure that these properties really exist in the original.
 
@@ -17,6 +17,7 @@ type Bar = OverrideProperties<Foo, {b: number}>
 type Baz = OverrideProperties<Foo, {c: number}>
 // error TS2559: Type '{c: number}' has no properties in common with type 'Partial{a: unknown; b: unknown}>'.
 ```
+
 @category Object
 */
 export type OverrideProperties<

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -1,7 +1,7 @@
 import type {Merge} from './merge';
 
 /**
-Override existing property types in TOriginal with the types in TOverride.
+Override existing properties of the given type. Similar to Merge, but enforces that the original type has the properties you want to override.
 
 This is useful when you want to override existing properties with a different type and make sure that these properties really exist in the original.
 
@@ -17,6 +17,7 @@ type Bar = OverrideProperties<Foo, {b: number}>
 type Baz = OverrideProperties<Foo, {c: number}>
 // error TS2559: Type '{c: number}' has no properties in common with type 'Partial{a: unknown; b: unknown}>'.
 ```
+@category Object
 */
 export type OverrideProperties<
 	TOriginal,

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -2,23 +2,23 @@ import type {Merge} from './merge';
 
 /**
 Override existing property types in TOriginal with the types in TOverride.
+
 This is useful when you want to override existing properties with a different type and make sure that these properties really exist in TOriginal.
 
 @example
-```ts
+```
 type Foo = {
 	a: string
 	b: string
 }
-type Bar = OverrideProperties<Foo, { b: number }>
-//=> type Bar = { a: string, b: number }
+type Bar = OverrideProperties<Foo, {b: number}>
+//=> {a: string, b: number}
 
-type Baz = OverrideProperties<Foo, { c: number }>
-// error TS2559: Type '{ c: number; }' has no properties in common with type 'Partial{ a: unknown; b: unknown; }>'.
-
+type Baz = OverrideProperties<Foo, {c: number}>
+// error TS2559: Type '{c: number}' has no properties in common with type 'Partial{a: unknown; b: unknown}>'.
 ```
- */
+*/
 export type OverrideProperties<
 	TOriginal,
-	TOverride extends Partial<{[k in keyof TOriginal]: unknown}>,
+	TOverride extends Partial<{[key in keyof TOriginal]: unknown}>,
 > = Merge<TOriginal, TOverride>;

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -3,7 +3,7 @@ import type {Merge} from './merge';
 /**
 Override existing property types in TOriginal with the types in TOverride.
 
-This is useful when you want to override existing properties with a different type and make sure that these properties really exist in TOriginal.
+This is useful when you want to override existing properties with a different type and make sure that these properties really exist in the original.
 
 @example
 ```

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -1,0 +1,24 @@
+import type {Merge} from './merge';
+
+/**
+Override existing property types in TOriginal with the types in TOverride.
+This is useful when you want to override existing properties with a different type and make sure that these properties really exist in TOriginal.
+
+@example
+```ts
+type Foo = {
+	a: string
+	b: string
+}
+type Bar = OverrideProperties<Foo, { b: number }>
+//=> type Bar = { a: string, b: number }
+
+type Baz = OverrideProperties<Foo, { c: number }>
+// error TS2559: Type '{ c: number; }' has no properties in common with type 'Partial{ a: unknown; b: unknown; }>'.
+
+```
+ */
+export type OverrideProperties<
+	TOriginal,
+	TOverride extends Partial<{[k in keyof TOriginal]: unknown}>,
+> = Merge<TOriginal, TOverride>;

--- a/test-d/override-properties.ts
+++ b/test-d/override-properties.ts
@@ -12,4 +12,3 @@ expectType<{a: number; b: number}>(aMod);
 expectError(() => {
     type Bar = OverrideProperties<Foo, {c: number}>;
 });
-

--- a/test-d/override-properties.ts
+++ b/test-d/override-properties.ts
@@ -1,0 +1,15 @@
+import {expectError, expectType} from 'tsd';
+import type {OverrideProperties} from '../source/override-properties';
+
+type Foo = {
+	a: number;
+	b: string;
+};
+
+const aMod: OverrideProperties<Foo, {b: number}> = {a: 1, b: 2};
+expectType<{a: number; b: number}>(aMod);
+
+expectError(() => {
+    type Bar = OverrideProperties<Foo, {c: number}>;
+});
+

--- a/test-d/override-properties.ts
+++ b/test-d/override-properties.ts
@@ -6,8 +6,8 @@ type Foo = {
 	b: string;
 };
 
-const aMod: OverrideProperties<Foo, {b: number}> = {a: 1, b: 2};
-expectType<{a: number; b: number}>(aMod);
+const fixture: OverrideProperties<Foo, {b: number}> = {a: 1, b: 2};
+expectType<{a: number; b: number}>(fixture);
 
 expectError(() => {
     type Bar = OverrideProperties<Foo, {c: number}>;


### PR DESCRIPTION
Adds the `OverrideProperties` type.
It is basically a `Merge` with the constraint, that you can only override properties.

Example:
```ts
type Foo = {
	a: string
	b: string
}
type Bar = OverrideProperties<Foo, { b: number }>
//=> type Bar = { a: string, b: number }

type Baz = OverrideProperties<Foo, { c: number }>
// error TS2559: Type '{ c: number; }' has no properties in common with type 'Partial{ a: unknown; b: unknown; }>'.

```
