### PR TITLE
Let Simplify go deep for nested types

### DIFF
--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -55,4 +55,8 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @category Object
 */
-export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};
+export type Simplify<T> = {
+	[KeyType in keyof T]: T[KeyType] extends Record<string | number | symbol, unknown>
+		? Simplify<T[KeyType]>
+		: T[KeyType]
+} & {};


### PR DESCRIPTION
I noticed that when I was I tried to use `Simplify` on a complex type with nested sub-types, it wouldn't simplify the nested sub-types. But when I changed it to this, it did.

Here's my example:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/1267282/233052287-91d5ab28-6456-4ca5-9b11-fcd43e9d3ba2.png">

On hover, vscode shows me this:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/1267282/233052429-a3328ebe-6d2e-42a8-beba-97c72c6ac175.png">

So I tried to wrap it with Simplify:

<img width="527" alt="image" src="https://user-images.githubusercontent.com/1267282/233052752-e92f32e4-a505-4642-9bf0-578dd583adcb.png">

And now, on hover, vscode shows me this:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/1267282/233053053-f3d1a0a9-08e2-4171-bff2-a182881101bc.png">

So as you can see, it doesn't simplify the nested `Modify` type. But when I applied the patch from this PR, I got this:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/1267282/233053544-42603289-0d76-4578-8ab4-a4683712e035.png">

