### PR TITLE
Add `typescript` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
 		"typescript": "^5.0.2",
 		"xo": "^0.53.1"
 	},
+	"peerDependencies": {
+		"typescript": "^4.7.0 || ^5.0.0"
+	},
 	"xo": {
 		"rules": {
 			"@typescript-eslint/ban-ts-comment": "off",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"xo": "^0.53.1"
 	},
 	"peerDependencies": {
-		"typescript": "^4.7.0 || ^5.0.0"
+		"typescript": ">=4.7.0"
 	},
 	"xo": {
 		"rules": {


### PR DESCRIPTION
Resolves https://github.com/sindresorhus/type-fest/issues/598.

`type-fest` requires TypeScript >= 4.7, let's make that explicit via a peer dependency.