### PR TITLE
Fix OverrideProperties doesn't throw an error #608

### DIFF
--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -25,5 +25,5 @@ type Fizz = OverrideProperties<Foo, {b: number; c: number}>
 */
 export type OverrideProperties<
 	TOriginal,
-	TOverride extends {[K in keyof TOverride]: K extends keyof TOriginal ? TOverride[K] : never},
+	TOverride extends {[Key in keyof TOverride]: Key extends keyof TOriginal ? TOverride[Key] : never},
 > = Merge<TOriginal, TOverride>;

--- a/source/override-properties.d.ts
+++ b/source/override-properties.d.ts
@@ -15,12 +15,15 @@ type Bar = OverrideProperties<Foo, {b: number}>
 //=> {a: string, b: number}
 
 type Baz = OverrideProperties<Foo, {c: number}>
-// error TS2559: Type '{c: number}' has no properties in common with type 'Partial{a: unknown; b: unknown}>'.
+// Error, type '{ c: number; }' does not satisfy the constraint '{ c: never; }'
+
+type Fizz = OverrideProperties<Foo, {b: number; c: number}>
+// Error, type '{ b: number; c: number; }' does not satisfy the constraint '{ b: number; c: never; }'
 ```
 
 @category Object
 */
 export type OverrideProperties<
 	TOriginal,
-	TOverride extends Partial<{[key in keyof TOriginal]: unknown}>,
+	TOverride extends {[K in keyof TOverride]: K extends keyof TOriginal ? TOverride[K] : never},
 > = Merge<TOriginal, TOverride>;

--- a/test-d/override-properties.ts
+++ b/test-d/override-properties.ts
@@ -12,3 +12,7 @@ expectType<{a: number; b: number}>(fixture);
 expectError(() => {
     type Bar = OverrideProperties<Foo, {c: number}>;
 });
+
+expectError(() => {
+    type Bar = OverrideProperties<Foo, {b: number; c: number}>;
+});


### PR DESCRIPTION
Fixes #608, used Mapping Types instead of Partial.