### PR TITLE
fix breaking performance change in set-required

### DIFF
--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -27,8 +27,14 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 @category Object
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType> =
-	Simplify<
-	BaseType &
-	// Pick the keys that should be required from the base type and make them required.
-	Required<Pick<BaseType, Keys>>
-	>;
+	// `extends unknown` is always going to be the case and is used to convert any
+	// union into a [distributive conditional
+	// type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+	BaseType extends unknown
+		? Simplify<
+			// Pick just the keys that are optional from the base type.
+			Except<BaseType, Keys> &
+			// Pick the keys that should be required from the base type and make them required.
+			Required<Pick<BaseType, Keys>>
+		  >
+		: never;


### PR DESCRIPTION
This PR updates https://github.com/sindresorhus/type-fest/pull/611 with a better fix that uses a distributive conditional to expand union types. 

The original fix released in `v3.10.0` is less efficient, producing TS error `TS2589: 'Type instantiation is excessively deep and possibly infinite'` when applied to my application code (as a result of computing all the intersections of each key in `Keys` with it's `Required<>` version).

Fixes https://github.com/sindresorhus/type-fest/issues/627