### PR TITLE
Fixes #351, define prototype field on Class type.

### DIFF
--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -3,7 +3,10 @@ Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 @category Class
 */
-export type Class<T, Arguments extends unknown[] = any[]> = {prototype: T; new(...arguments_: Arguments): T};
+export type Class<T, Arguments extends unknown[] = any[]> = {
+	prototype: T;
+	new(...arguments_: Arguments): T;
+};
 
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
@@ -16,8 +19,17 @@ export type Constructor<T, Arguments extends unknown[] = any[]> = new(...argumen
 Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/classes.html#abstract-classes).
 
 @category Class
+
+@privateRemarks
+The usual "export type = " won't work, because TypeScript throws:
+'abstract' modifier cannot appear on a type member.(1070)
+
+So if we really want this, it has to be an interface.
 */
-export type AbstractClass<T, Arguments extends unknown[] = any[]> = AbstractConstructor<T, Arguments> & {prototype: T};
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface AbstractClass<T, Arguments extends unknown[] = any[]> extends AbstractConstructor<T, Arguments> {
+	prototype: T;
+}
 
 /**
 Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures) constructor.

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -21,10 +21,7 @@ Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/class
 @category Class
 
 @privateRemarks
-The usual "export type = " won't work, because TypeScript throws:
-'abstract' modifier cannot appear on a type member.(1070)
-
-So if we really want this, it has to be an interface.
+We cannot use a `type` here because TypeScript throws: 'abstract' modifier cannot appear on a type member. (1070)
 */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AbstractClass<T, Arguments extends unknown[] = any[]> extends AbstractConstructor<T, Arguments> {

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -3,7 +3,7 @@ Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 @category Class
 */
-export type Class<T, Arguments extends unknown[] = any[]> = {prototype: T; new(...args: Arguments): T};
+export type Class<T, Arguments extends unknown[] = any[]> = {prototype: T; new(...arguments_: Arguments): T};
 
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -3,7 +3,7 @@ Matches a [`class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 @category Class
 */
-export type Class<T, Arguments extends unknown[] = any[]> = Constructor<T, Arguments> & {prototype: T};
+export type Class<T, Arguments extends unknown[] = any[]> = {prototype: T; new(...args: Arguments): T};
 
 /**
 Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -1,5 +1,5 @@
-import {expectError} from 'tsd';
-import type {Constructor} from '../index';
+import {expectAssignable, expectError, expectType} from 'tsd';
+import type {Class, Constructor, IsAny} from '../index';
 
 class Foo {
 	constructor(x: number, y: any) {
@@ -21,3 +21,20 @@ function fn2(Cls: Constructor<Foo, [number, number]>): Foo {
 
 fn(Foo);
 fn2(Foo);
+
+type PositionProps = {
+	top: number;
+	left: number;
+};
+
+class Position {
+	top = 0;
+	left = 0;
+}
+
+declare const Bar: Class<PositionProps>;
+
+expectAssignable<Class<PositionProps>>(Position);
+expectAssignable<Constructor<PositionProps>>(Position);
+expectType<IsAny<typeof Bar['prototype']>>(false);
+expectType<PositionProps>(Position.prototype);

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -22,6 +22,7 @@ function fn2(Cls: Constructor<Foo, [number, number]>): Foo {
 fn(Foo);
 fn2(Foo);
 
+// Prototype test
 type PositionProps = {
 	top: number;
 	left: number;
@@ -38,3 +39,4 @@ expectAssignable<Class<PositionProps>>(Position);
 expectAssignable<Constructor<PositionProps>>(Position);
 expectType<IsAny<typeof Bar['prototype']>>(false);
 expectType<PositionProps>(Position.prototype);
+// /Prototype test

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectError, expectType} from 'tsd';
+import {expectAssignable, expectError, expectNotAssignable, expectType} from 'tsd';
 import type {Class, Constructor, IsAny} from '../index';
 
 class Foo {
@@ -29,14 +29,28 @@ type PositionProps = {
 };
 
 class Position {
-	top = 0;
-	left = 0;
+	public top: number;
+
+	public left: number;
+
+	constructor(parameterTop: number, parameterLeft: number) {
+		this.top = parameterTop;
+		this.left = parameterLeft;
+	}
 }
 
 declare const Bar: Class<PositionProps>;
 
 expectAssignable<Class<PositionProps>>(Position);
-expectAssignable<Constructor<PositionProps>>(Position);
+
+expectNotAssignable<Class<PositionProps, [number]>>(Position);
+
+expectAssignable<Class<PositionProps, [number, number]>>(Position);
+expectAssignable<Constructor<PositionProps, [number, number]>>(Position);
+
 expectType<IsAny<typeof Bar['prototype']>>(false);
 expectType<PositionProps>(Position.prototype);
 // /Prototype test
+
+expectError(new Position(17));
+expectAssignable<PositionProps>(new Position(17, 34));


### PR DESCRIPTION
Yes, I know this is potentially risky, changing one of the most fundamental types in type-fest.  I was unable to apply the same fix to `AbstractClass`.

Still, I have added a test for the prototype field which fails on the existing type and passes with the new type.

Credit to @jcalz for the corrected type itself, at https://github.com/microsoft/TypeScript/issues/54585.

Fixes #351