### PR TITLE
fix(Jsonify): fix `JsonifyTuple`

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -9,7 +9,7 @@ import type {IsAny} from './is-any';
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
 type JsonifyTuple<T extends unknown[]> = T extends [infer F, ... infer R]
-	? [Jsonify<F>, ...JsonifyTuple<R>]
+	? [Jsonify<F>, ...Jsonify<R>]
 	: [];
 
 type FilterJsonableKeys<T extends object> = {

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -1,9 +1,10 @@
 import type {JsonPrimitive, JsonValue} from './basic';
 import type {EmptyObject} from './empty-object';
 import type {UndefinedToOptional} from './internal';
+import type {IsAny} from './is-any';
+import type {IsNever} from './is-never';
 import type {NegativeInfinity, PositiveInfinity} from './numeric';
 import type {TypedArray} from './typed-array';
-import type {IsAny} from './is-any';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -10,7 +10,7 @@ type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
 type JsonifyTuple<T extends unknown[]> = T extends [infer F, ... infer R]
 	? [Jsonify<F>, ...JsonifyTuple<R>]
-	: []
+	: [];
 
 type FilterJsonableKeys<T extends object> = {
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -8,9 +8,9 @@ import type {IsAny} from './is-any';
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
-type JsonifyTuple<T extends [unknown, ...unknown[]]> = {
-	[Key in keyof T]: T[Key] extends NotJsonable ? null : Jsonify<T[Key]>;
-};
+type JsonifyTuple<T extends unknown[]> = T extends [infer F, ... infer R]
+	? [Jsonify<F>, ...JsonifyTuple<R>]
+	: []
 
 type FilterJsonableKeys<T extends object> = {
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -116,7 +116,7 @@ export type Jsonify<T> = IsAny<T> extends true
 										: T extends []
 											? []
 											: T extends [unknown, ...unknown[]]
-												? JsonifyTuple<T>
+												? JsonifyList<T>
 												: T extends ReadonlyArray<infer U>
 													? Array<U extends NotJsonable ? null : Jsonify<U>>
 													: T extends object

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -222,6 +222,9 @@ expectType<[string, string]>(tupleJson);
 declare const tupleRestJson: Jsonify<[string, ...Date[]]>;
 expectType<[string, ...string[]]>(tupleRestJson);
 
+declare const tupleStringJson: Jsonify<string[] & ['some value']>;
+expectType<string[] & ['some value']>(tupleStringJson);
+
 // BigInt fails JSON.stringify
 declare const bigInt: Jsonify<bigint>;
 expectType<never>(bigInt);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -223,7 +223,7 @@ declare const tupleRestJson: Jsonify<[string, ...Date[]]>;
 expectType<[string, ...string[]]>(tupleRestJson);
 
 declare const tupleStringJson: Jsonify<string[] & ['some value']>;
-expectType<string[] & ['some value']>(tupleStringJson);
+expectType<['some value']>(tupleStringJson);
 
 // BigInt fails JSON.stringify
 declare const bigInt: Jsonify<bigint>;


### PR DESCRIPTION
As pointed out by @mattcorner in https://github.com/remix-run/remix/issues/6566, this would otherwise Jsonify `string[] & ["Some value"]` to
```ts
{
    [x: number]: "Some value";
    length: "Some value";
    toString: null;
    toLocaleString: null;
    pop: null;
    push: null;
    concat: null;
    join: null;
    reverse: null;
    shift: null;
    slice: null;
    sort: null;
    splice: null;
    ... 20 more ...;
    0: "Some value";
}
```

Taken from @pcattori's solution in https://github.com/remix-run/remix/pull/6616