### PR TITLE
`PartialOnUndefinedDeepValue`: Fix strict mode compilation

### DIFF
--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -55,7 +55,7 @@ export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOpti
 /**
 Utility type to get the value type by key and recursively call `PartialOnUndefinedDeep` to transform sub-objects.
 */
-type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOptions> = T extends BuiltIns | ((...arguments: any[]) => unknown)
+type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOptions> = T extends BuiltIns | ((...anyArguments: any[]) => unknown)
 	? T
 	: T extends ReadonlyArray<infer U> // Test if type is array or tuple
 		? Options['recurseIntoArrays'] extends true // Check if option is activated


### PR DESCRIPTION
This change fixes an issue where `type-fest` is being used by a project that uses SWC.  
In strict mode, the keyword `arguments` and `eval` are disallowed.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

fixes #644
