### PR TITLE
optimization: refactor `LastArrayElement` to avoid recursion

### DIFF
--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -18,11 +18,7 @@ typeof lastOf(array);
 @category Array
 @category Template literal
 */
-export type LastArrayElement<ValueType extends readonly unknown[]> =
-	ValueType extends readonly [infer ElementType]
-		? ElementType
-		: ValueType extends readonly [infer _, ...infer Tail]
-			? LastArrayElement<Tail>
-			: ValueType extends ReadonlyArray<infer ElementType>
-				? ElementType
-				: never;
+export type LastArrayElement<Elements extends readonly unknown[]>
+	= number extends Elements["length"] ? Elements extends readonly (infer Element)[] ? Element : never
+	: Elements extends readonly [...any, infer Target] ? Target
+	: never;

--- a/source/last-array-element.d.ts
+++ b/source/last-array-element.d.ts
@@ -19,6 +19,10 @@ typeof lastOf(array);
 @category Template literal
 */
 export type LastArrayElement<Elements extends readonly unknown[]>
-	= number extends Elements["length"] ? Elements extends readonly (infer Element)[] ? Element : never
-	: Elements extends readonly [...any, infer Target] ? Target
-	: never;
+		= number extends Elements['length']
+			? Elements extends ReadonlyArray<infer Element>
+				? Element
+				: never
+			: Elements extends readonly [...any, infer Target]
+				? Target
+				: never;


### PR DESCRIPTION
Hello type-fest!

I was poking around the repo and noticed that `LastArrayElement` was using recursion to iterate until reaching the final element, which is unnecessary since TS 4.2:

[Playground](https://www.typescriptlang.org/play?noImplicitAny=false&target=6&jsx=0&ts=4.2.3#code/HYQwtgpgzgDiDGEAEAVArjANsg3gKCSQgA8YB7AJwBckqBPGZTEKKgHgCMojiqJgAJtwoQQAssEx0kaYAGtgZAO7AA2gF0AfAUJIAvEmBowHCBR59B3LqoBE2YAHMqAC1vqkAfiRcL-IUgiYhJSSAAUAJbAAGZmPgCUGl4+SDqEAFyGEABuZmlImb4klgFB4pLSqgB0NSDAdAA0SFGx5hwe3hypugVZuRR4AL54eKCQsAjIKAwQ2LmYAMqM8BHREfAgVBESSPiEY9BwiKjQNHu6JOTUtDNEAI5sIE0cmvpIqk8+HsX+3KocTRAHVoFDQyEy0RAmCgEHyl0oNHojCQUMwjz8VhBYI0rwMIB0wx0SKYLBoBhQpyqqLYqnyFNYVQgD3QWAgVWYrBpAEYGgAmBoAZi0TQFmgadMpTLYLOw7NJbDKIWkYVYFCijiQAB9DMZTBREsKkKr1VqdSYzNpCFohkA)

Since people are paying more attention to type-level performance lately, this change seemed like a quick and reasonable PR to make.