### PR TITLE
fix(jsonify): fix array jsonify handler

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -6,7 +6,6 @@ import type {IsNever} from './is-never';
 import type {IsUnknown} from './is-unknown';
 import type {NegativeInfinity, PositiveInfinity} from './numeric';
 import type {TypedArray} from './typed-array';
-import type {Writable} from './writable';
 import type {WritableDeep} from './writable-deep';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -3,24 +3,25 @@ import type {EmptyObject} from './empty-object';
 import type {UndefinedToOptional} from './internal';
 import type {IsAny} from './is-any';
 import type {IsNever} from './is-never';
+import type {IsUnknown} from './is-unknown';
 import type {NegativeInfinity, PositiveInfinity} from './numeric';
 import type {TypedArray} from './typed-array';
+import type {Writable} from './writable';
+import type {WritableDeep} from './writable-deep';
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
-type FilterNonNever<T extends unknown[]> = T extends [infer F, ...infer R]
-	? IsNever<F> extends true
-		? FilterNonNever<R>
-		: [F, ...FilterNonNever<R>]
-	: IsNever<T[number]> extends true
-		? []
-		: T;
+type NeverToNull<T> = IsNever<T> extends true ? null : T;
 
 // Handles tuples and arrays
-type JsonifyList<T extends unknown[]> = T extends [infer F, ...infer R]
-	? FilterNonNever<[Jsonify<F>, ...JsonifyList<R>]>
-	: Array<Jsonify<T[number]>>;
+type JsonifyList<T extends unknown[]> = T extends []
+	? []
+	: T extends [infer F, ...infer R]
+		? [NeverToNull<Jsonify<F>>, ...JsonifyList<R>]
+		: IsUnknown<T[number]> extends true
+			? []
+			: Array<T[number] extends NotJsonable ? null : Jsonify<T[number]>>;
 
 type FilterJsonableKeys<T extends object> = {
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
@@ -116,10 +117,10 @@ export type Jsonify<T> = IsAny<T> extends true
 											: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
 										: T extends []
 											? []
-											: T extends [unknown, ...unknown[]]
+											: T extends unknown[]
 												? JsonifyList<T>
-												: T extends ReadonlyArray<infer U>
-													? Array<U extends NotJsonable ? null : Jsonify<U>>
+												: T extends readonly unknown[]
+													? JsonifyList<WritableDeep<T>>
 													: T extends object
 														? JsonifyObject<UndefinedToOptional<T>> // JsonifyObject recursive call for its children
 														: never; // Otherwise any other non-object is removed

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -222,7 +222,7 @@ expectType<[string, string]>(tupleJson);
 declare const tupleRestJson: Jsonify<[string, ...Date[]]>;
 expectType<[string, ...string[]]>(tupleRestJson);
 
-declare const mixTupleJson: Jsonify<['1', typeof fn, 2]>;
+declare const mixTupleJson: Jsonify<['1', (_: any) => void, 2]>;
 expectType<['1', null, 2]>(mixTupleJson);
 
 declare const tupleStringJson: Jsonify<string[] & ['some value']>;
@@ -330,6 +330,6 @@ expectType<{a: any}>(objectWithAnyProperty);
 declare const objectWithAnyProperties: Jsonify<Record<string, any>>;
 expectType<Record<string, any>>(objectWithAnyProperties);
 
-/// #629
+// Regression test for https://github.com/sindresorhus/type-fest/issues/629
 declare const readonlyTuple: Jsonify<readonly [1, 2, 3]>;
 expectType<[1, 2, 3]>(readonlyTuple);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -222,6 +222,9 @@ expectType<[string, string]>(tupleJson);
 declare const tupleRestJson: Jsonify<[string, ...Date[]]>;
 expectType<[string, ...string[]]>(tupleRestJson);
 
+declare const mixTupleJson: Jsonify<['1', typeof fn, 2]>;
+expectType<['1', null, 2]>(mixTupleJson);
+
 declare const tupleStringJson: Jsonify<string[] & ['some value']>;
 expectType<['some value']>(tupleStringJson);
 
@@ -328,5 +331,5 @@ declare const objectWithAnyProperties: Jsonify<Record<string, any>>;
 expectType<Record<string, any>>(objectWithAnyProperties);
 
 /// #629
-// declare const readonlyTuple: Jsonify<readonly [1, 2, 3]>;
-// expectType<readonly [1, 2, 3]>(readonlyTuple);
+declare const readonlyTuple: Jsonify<readonly [1, 2, 3]>;
+expectType<[1, 2, 3]>(readonlyTuple);


### PR DESCRIPTION
hey！this is my first contribution

1. fix #629
2. fix another jsonfity array bug
  ```typescript
  // main branch
  declare const mixTupleJson: Jsonify<['1', typeof fn, 2]>; // type: ['1', 2]
  // this pr
  declare const mixTupleJson: Jsonify<['1', typeof fn, 2]>; // type: ['1', null, 2]

  // because `FilterNonNever` filter all NotJsonable value. but in array, NotJsonable value should be `null`
```