### PR TITLE
feat(union-to-intersection): allow indexing by the resulting type

### DIFF
--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -56,5 +56,6 @@ export type UnionToIntersection<Union> = (
 		// Infer the `Intersection` type since TypeScript represents the positional
 		// arguments of unions of functions as an intersection of the union.
 ) extends ((mergedIntersection: infer Intersection) => void)
-	? Intersection
+	// The `& Union` is to allow indexing by the resulting type
+	? Intersection & Union
 	: never;

--- a/test-d/union-to-intersection.ts
+++ b/test-d/union-to-intersection.ts
@@ -1,4 +1,4 @@
-import {expectAssignable} from 'tsd';
+import {expectAssignable, expectType} from 'tsd';
 import type {UnionToIntersection} from '../index';
 
 declare const intersection1: UnionToIntersection<{a: string} | {b: number}>;
@@ -7,3 +7,8 @@ expectAssignable<{a: string; b: number}>(intersection1);
 // Creates a union of matching properties.
 declare const intersection2: UnionToIntersection<{a: string} | {b: number} | {a: () => void}>;
 expectAssignable<{a: string | (() => void); b: number}>(intersection2);
+
+// It's possible to index by the resulting type.
+type ObjectsUnion = {a: string; z: string} | {b: string; z: string} | {c: string; z: string};
+declare const value: ObjectsUnion[UnionToIntersection<keyof ObjectsUnion>];
+expectType<string>(value);


### PR DESCRIPTION
Previously, using `UnionToIntersection` in the key position would result in the error: 
> Type 'unknown' cannot be used as an index type.

```ts
type Objects = { a: string } | { b: string } | { c: string }
type X = Objects[UnionToIntersection<keyof Objects>]
```

After the change the error goes away, and it doesn't affect how the type works otherwise.
The use case is when you use generics and want to ensure the type is `never` for unions of objects.