### PR TITLE
Fix/Refine Type Inference for Objects with toJSON() Extending Primitives

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -96,24 +96,24 @@ export type Jsonify<T> = IsAny<T> extends true
 		? null
 		: T extends JsonPrimitive
 			? T
-			: // Instanced primitives are objects
-			T extends Number
-				? number
-				: T extends String
-					? string
-					: T extends Boolean
-						? boolean
-						: T extends Map<any, any> | Set<any>
-							? EmptyObject
-							: T extends TypedArray
-								? Record<string, number>
-								: T extends NotJsonable
-									? never // Non-JSONable type union was found not empty
-									: // Any object with toJSON is special case
-									T extends {toJSON(): infer J}
-										? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
-											? J // Then T is Jsonable and its Jsonable value is J
-											: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
+			: // Any object with toJSON is special case
+			T extends {toJSON(): infer J}
+				? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
+					? J // Then T is Jsonable and its Jsonable value is J
+					: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
+				: // Instanced primitives are objects
+				T extends Number
+					? number
+					: T extends String
+						? string
+						: T extends Boolean
+							? boolean
+							: T extends Map<any, any> | Set<any>
+								? EmptyObject
+								: T extends TypedArray
+									? Record<string, number>
+									: T extends NotJsonable
+										? never // Non-JSONable type union was found not empty
 										: T extends []
 											? []
 											: T extends [unknown, ...unknown[]]

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -112,6 +112,21 @@ expectNotAssignable<JsonValue>(nonJsonWithToJSON);
 expectAssignable<JsonValue>(nonJsonWithToJSON.toJSON());
 expectAssignable<Jsonify<NonJsonWithToJSON>>(nonJsonWithToJSON.toJSON());
 
+class NonJsonExtendPrimitiveWithToJSON extends Number {
+	public fixture = BigInt('42');
+
+	public toJSON(): {fixture: string} {
+		return {
+			fixture: '42n',
+		};
+	}
+}
+
+const nonJsonExtendPrimitiveWithToJSON = new NonJsonExtendPrimitiveWithToJSON();
+expectNotAssignable<JsonValue>(nonJsonExtendPrimitiveWithToJSON);
+expectAssignable<JsonValue>(nonJsonExtendPrimitiveWithToJSON.toJSON());
+expectAssignable<Jsonify<NonJsonExtendPrimitiveWithToJSON>>(nonJsonExtendPrimitiveWithToJSON.toJSON());
+
 class NonJsonWithToJSONWrapper {
 	public inner: NonJsonWithToJSON = nonJsonWithToJSON;
 	public override = 42;


### PR DESCRIPTION
Ensure objects implementing `toJSON()`, but also extending primitive types, have their type inferred by `toJSON()` and not by the extended type. This refinement helps prevent incorrect type inference for specialized objects with enhanced serialization.

Changes:
    - Updated type conditions in `source/jsonify.d.ts` by prioritizing
      `{toJSON(): infer J}` case before primitives.
    - Added corresponding test cases in `test-d/jsonify.ts`.

Example:
This fix resolves issues like the incorrect inference of `Jsonify<Temporal.PlainDate>`, where `Temporal` is sourced from `@js-temporal/polyfill` and where `PlainDate` is extending `Boolean`.

```typescript
import { Temporal } from '@js-temporal/polyfill';
// Incorrectly inferred as Boolean, but string is expected
Jsonify<Temporal.PlainDate>
```

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
