### PR TITLE
Fix Jsonify for objects with `Record<string, any>` properties

### DIFF
--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -330,6 +330,9 @@ expectType<{a: any}>(objectWithAnyProperty);
 declare const objectWithAnyProperties: Jsonify<Record<string, any>>;
 expectType<Record<string, any>>(objectWithAnyProperties);
 
+declare const objectWithObjectWithAnyProperties: Jsonify<{payload: Record<string, any>}>;
+expectType<{payload: Record<string, any>}>(objectWithObjectWithAnyProperties);
+
 // Test for `Jsonify` support for nested objects with _only_ a name property.
 // See https://github.com/sindresorhus/type-fest/issues/657
 declare const nestedObjectWithNameProperty: {


### PR DESCRIPTION
Pushing just the test case up first, since I can't replicate the failing test from #668 locally