### PR TITLE
Fix Jsonify for object with properties that are `Record<string, any> | null`

### DIFF
--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -348,3 +348,6 @@ expectType<typeof nestedObjectWithNameProperty>(
 // Regression test for https://github.com/sindresorhus/type-fest/issues/629
 declare const readonlyTuple: Jsonify<readonly [1, 2, 3]>;
 expectType<[1, 2, 3]>(readonlyTuple);
+
+declare const objectWithNullOrObjectWithAnyProperties: Jsonify<{schema: Record<string, any> | null}>;
+expectType<Record<string, any> | null>(objectWithNullOrObjectWithAnyProperties.schema);


### PR DESCRIPTION
As described here: https://github.com/remix-run/remix/issues/7246#issuecomment-1745302199