### PR TITLE
Expose KeysOfUnion type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export * from './source/basic';
 export * from './source/observable-like';
 
 // Utilities
+export type {KeysOfUnion} from './source/keys-of-union';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object';
 export type {NonEmptyObject} from './source/non-empty-object';
 export type {UnknownRecord} from './source/unknown-record';

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ Click the type names for complete docs.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties.
 - [`OptionalKeysOf`](source/optional-keys-of.d.ts) - Extract all optional keys from the given type.
+- [`KeysOfUnion`](source/keys-of-union.d.ts) - Returns a union of all the keys of a given type, including those that are only present in some of the union members.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ Click the type names for complete docs.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties.
 - [`OptionalKeysOf`](source/optional-keys-of.d.ts) - Extract all optional keys from the given type.
-- [`KeysOfUnion`](source/keys-of-union.d.ts) - Returns a union of all the keys of a given type, including those that are only present in some of the union members.
+- [`KeysOfUnion`](source/keys-of-union.d.ts) - Create a union of all keys from a given type, even those exclusive to specific union members.
 - [`HasOptionalKeys`](source/has-optional-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any optional fields.
 - [`RequiredKeysOf`](source/required-keys-of.d.ts) - Extract all required keys from the given type.
 - [`HasRequiredKeys`](source/has-required-keys.d.ts) - Create a `true`/`false` type depending on whether the given type has any required fields.

--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -1,6 +1,7 @@
-import type {KeysOfUnion, ArrayElement, ObjectValue} from './internal';
+import type {ArrayElement, ObjectValue} from './internal';
 import type {Opaque, TagContainer} from './opaque';
 import type {IsEqual} from './is-equal';
+import type {KeysOfUnion} from './keys-of-union';
 
 /**
 Create a type from `ParameterType` and `InputType` and change keys exclusive to `InputType` to `never`.

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -37,15 +37,6 @@ Matches any primitive, `Date`, or `RegExp` value.
 */
 export type BuiltIns = Primitive | Date | RegExp;
 
-/**
-Gets keys from a type. Similar to `keyof` but this one also works for union types.
-
-The reason a simple `keyof Union` does not work is because `keyof` always returns the accessible keys of a type. In the case of a union, that will only be the common keys.
-
-@link https://stackoverflow.com/a/49402091
-*/
-export type KeysOfUnion<T> = T extends T ? keyof T : never;
-
 export type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
 
 export type StringDigit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';

--- a/source/keys-of-union.d.ts
+++ b/source/keys-of-union.d.ts
@@ -1,7 +1,7 @@
 /**
-Returns a union of all the keys of a given type, including those that are only present in some of the union members.
+Create a union of all keys from a given type, even those exclusive to specific union members.
 
-This is similar to the native `keyof` keyword, however while `keyof` only returns the keys that are present in **ALL** union members, `KeysOfUnion` returns the keys that are present in **ANY** union member.
+Unlike the native `keyof` keyword, which returns keys present in **all** union members, this type returns keys from **any** member.
 
 @link https://stackoverflow.com/a/49402091
 
@@ -10,25 +10,27 @@ This is similar to the native `keyof` keyword, however while `keyof` only return
 import type {KeysOfUnion} from 'type-fest';
 
 type A = {
-  common: string;
-  a: number;
+	common: string;
+	a: number;
 };
 
 type B = {
-  common: string;
-  b: string;
+	common: string;
+	b: string;
 };
 
 type C = {
-  common: string;
-  c: boolean;
+	common: string;
+	c: boolean;
 };
 
 type Union = A | B | C;
 
-type CommonKeys = keyof Union; //=> 'common'
+type CommonKeys = keyof Union;
+//=> 'common'
 
-type AllKeys = KeysOfUnion<Union>; //=> 'common' | 'a' | 'b' | 'c'
+type AllKeys = KeysOfUnion<Union>;
+//=> 'common' | 'a' | 'b' | 'c'
 ```
 
 @category Object

--- a/source/keys-of-union.d.ts
+++ b/source/keys-of-union.d.ts
@@ -1,0 +1,38 @@
+/**
+Returns a union of all the keys of a given type, including those that are only present in some of the union members.
+
+This is similar to the native `keyof` keyword, however while `keyof` only returns the keys that are present in **ALL** union members, `KeysOfUnion` returns the keys that are present in **ANY** union member.
+
+@link https://stackoverflow.com/a/49402091
+
+@example
+```
+import type {KeysOfUnion} from 'type-fest';
+
+type A = {
+  common: string;
+  a: number;
+};
+
+type B = {
+  common: string;
+  b: string;
+};
+
+type C = {
+  common: string;
+  c: boolean;
+};
+
+type Union = A | B | C;
+
+type CommonKeys = keyof Union; //=> 'common'
+
+type AllKeys = KeysOfUnion<Union>; //=> 'common' | 'a' | 'b' | 'c'
+```
+
+@category Object
+*/
+export type KeysOfUnion<ObjectType> = ObjectType extends unknown
+	? keyof ObjectType
+	: never;

--- a/test-d/keys-of-union.ts
+++ b/test-d/keys-of-union.ts
@@ -1,8 +1,7 @@
 import {expectType} from 'tsd';
 import type {KeysOfUnion} from '../index';
 
-// When passing types that are not unions
-// It behaves exactly as the `keyof` operator
+// When passing types that are not unions, it behaves exactly as the `keyof` operator.
 
 type Example1 = {
 	string: string;
@@ -18,8 +17,7 @@ declare const actual1: KeysOfUnion<Example1>;
 
 expectType<Expected1>(actual1);
 
-// When passing a type that is a union
-// It returns a union of all keys of all union members
+// When passing a type that is a union, it returns a union of all keys of all union members.
 
 type Example2 = {
 	common: string;

--- a/test-d/keys-of-union.ts
+++ b/test-d/keys-of-union.ts
@@ -1,0 +1,39 @@
+import {expectType} from 'tsd';
+import type {KeysOfUnion} from '../index';
+
+// When passing types that are not unions
+// It behaves exactly as the `keyof` operator
+
+type Example1 = {
+	string: string;
+	number: number;
+	boolean: boolean;
+	null: null;
+	array: number[];
+};
+
+type Expected1 = keyof Example1;
+
+declare const actual1: KeysOfUnion<Example1>;
+
+expectType<Expected1>(actual1);
+
+// When passing a type that is a union
+// It returns a union of all keys of all union members
+
+type Example2 = {
+	common: string;
+	a: number;
+} | {
+	common: string;
+	b: string;
+} | {
+	common: string;
+	c: boolean;
+};
+
+type Expected2 = 'common' | 'a' | 'b' | 'c';
+
+declare const actual2: KeysOfUnion<Example2>;
+
+expectType<Expected2>(actual2);


### PR DESCRIPTION
Adds the `AllKeys` type, that is similiar to `keyof` but it distributes over unions, that is, it returns the keys of ALL members of a union type.

Although this is a first step to add the types in #132, it is also useful by itself.

Additionally, I only used this name (`AllKeys`) because it's what was suggested in the issue I mentioned above, but there are other possible names we might want to consider, like `KeyOfDistributeUnions` or `DistributedKeyOf`.