### PR TITLE
Add distributed omit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export * from './source/basic';
 export * from './source/observable-like';
 
 // Utilities
+export type {AllKeys} from './source/all-keys';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object';
 export type {NonEmptyObject} from './source/non-empty-object';
 export type {UnknownRecord} from './source/unknown-record';

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export * from './source/observable-like';
 
 // Utilities
 export type {AllKeys} from './source/all-keys';
+export type {DistributedOmit} from './source/distributed-omit';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object';
 export type {NonEmptyObject} from './source/non-empty-object';
 export type {UnknownRecord} from './source/unknown-record';

--- a/source/all-keys.d.ts
+++ b/source/all-keys.d.ts
@@ -1,0 +1,36 @@
+/**
+Returns a union of all the keys of a given type, including those that are only present in some of the union members.
+
+This is similar to the native `keyof` keyword, however while `keyof` only returns the keys that are present in **ALL** union members, `AllKeys` returns the keys that are present in **ANY** union member.
+
+@example
+```
+import type {AllKeys} from 'type-fest';
+
+type A = {
+  common: string;
+  a: number;
+};
+
+type B = {
+  common: string;
+  b: string;
+};
+
+type C = {
+  common: string;
+  c: boolean;
+};
+
+type Union = A | B | C;
+
+type KeyofUnion = keyof Union; //=> 'common'
+
+type AllKeysOfUnion = AllKeys<Union>; //=> 'common' | 'a' | 'b' | 'c'
+```
+
+@category Object
+*/
+export type AllKeys<ObjectType> = ObjectType extends unknown
+	? keyof ObjectType
+	: never;

--- a/source/distributed-omit.d.ts
+++ b/source/distributed-omit.d.ts
@@ -1,0 +1,80 @@
+import type {AllKeys} from './all-keys';
+
+/**
+Omits keys from a type, distributing the operation over a union.
+
+Typescript's `Omit` doesn't distribute over unions, which causes the following situation:
+
+```ts
+type A = {
+  discriminant: "A";
+  foo: string;
+  a: number;
+};
+
+type B = {
+  discriminant: "B";
+  foo: string;
+  b: string;
+};
+
+type Union = A | B;
+
+type OmittedUnion = Omit<Union, "foo">; //==> { discriminant: "A" | "B" }
+
+const omittedUnion: OmittedUnion = createOmittedUnion();
+
+if(omittedUnion.discriminant === "A") {
+  // We would like to narrow `omittedUnion`'s type
+  // to `A` here, but we can't because `Omit`
+  // doesn't distribute over unions.
+
+  omittedUnion.a; //==> Error, `a` is not a property of `{ discriminant: "A" | "B" }`
+}
+```
+
+While `Except` solves this problem, it restricts the keys you can omit to the ones that are present in **ALL** union members, where `DistributedOmit` allows you to omit keys that are present in **ANY** union member.
+
+@example
+```ts
+type A = {
+  discriminant: "A";
+  foo: string;
+  a: number;
+};
+
+type B = {
+  discriminant: "B";
+  foo: string;
+  bar: string;
+  b: string;
+};
+
+type C = {
+  discriminant: "C";
+  bar: string;
+  c: boolean;
+};
+
+// Notice that `foo` exists in `A` and `B`, but not in `C`, and
+// `bar` exists in `B` and `C`, but not in `A`.
+
+type Union = A | B | C;
+
+type OmittedUnion = DistributedOmit<Union, "foo" | "bar">;
+
+const omittedUnion: OmittedUnion = createOmittedUnion();
+
+if(omittedUnion.discriminant === "A") {
+  omittedUnion.a; //==> OK
+  omittedUnion.foo; //==> Error, `foo` is not a property of `{ discriminant: "A"; a: string; }`
+  omittedUnion.bar; //==> Error, `bar` is not a property of `{ discriminant: "A"; a: string; }`
+}
+```
+
+@category Object
+*/
+export type DistributedOmit<ObjectType, KeyType extends AllKeys<ObjectType>> =
+	ObjectType extends unknown
+		? Omit<ObjectType, KeyType>
+		: never;

--- a/test-d/all-keys.ts
+++ b/test-d/all-keys.ts
@@ -1,0 +1,39 @@
+import {expectType} from 'tsd';
+import type {AllKeys} from '../index';
+
+// When passing types that are not unions
+// It behaves exactly as the `keyof` operator
+
+type Example1 = {
+	string: string;
+	number: number;
+	boolean: boolean;
+	null: null;
+	array: number[];
+};
+
+type Expected1 = keyof Example1;
+
+declare const actual1: AllKeys<Example1>;
+
+expectType<Expected1>(actual1);
+
+// When passing a type that is a union
+// It returns a union of all keys of all union members
+
+type Example2 = {
+	common: string;
+	a: number;
+} | {
+	common: string;
+	b: string;
+} | {
+	common: string;
+	c: boolean;
+};
+
+type Expected2 = 'common' | 'a' | 'b' | 'c';
+
+declare const actual2: AllKeys<Example2>;
+
+expectType<Expected2>(actual2);

--- a/test-d/distributed-omit.ts
+++ b/test-d/distributed-omit.ts
@@ -1,0 +1,77 @@
+import {expectType, expectError} from 'tsd';
+import type {DistributedOmit, Except} from '../index';
+
+// When passing a non-union type, and
+// omitting keys that are present in the type.
+// It behaves exactly like `Except`.
+
+type Example1 = {
+	a: number;
+	b: string;
+};
+
+type Actual1 = DistributedOmit<Example1, 'a'>;
+type Actual2 = DistributedOmit<Example1, 'b'>;
+type Actual3 = DistributedOmit<Example1, 'a' | 'b'>;
+
+type Expected1 = Except<Example1, 'a'>;
+type Expected2 = Except<Example1, 'b'>;
+type Expected3 = Except<Example1, 'a' | 'b'>;
+
+declare const expected1: Expected1;
+declare const expected2: Expected2;
+declare const expected3: Expected3;
+
+expectType<Actual1>(expected1);
+expectType<Actual2>(expected2);
+expectType<Actual3>(expected3);
+
+// When passing a non-union type, and
+// omitting keys that are NOT present in the type.
+// It behaves exactly like `Except`, by not letting you
+// omit keys that are not present in the type.
+
+type Example2 = {
+	a: number;
+	b: string;
+};
+
+expectError(() => {
+	type Actual4 = DistributedOmit<Example2, 'c'>;
+});
+
+// When passing a union type, and
+// omitting keys that are present in some union members.
+// It lets you omit keys that are present in some union members,
+// and distributes over the union.
+
+type A = {
+	discriminant: 'A';
+	foo: string;
+	a: number;
+};
+
+type B = {
+	discriminant: 'B';
+	foo: string;
+	bar: string;
+	b: string;
+};
+
+type C = {
+	discriminant: 'C';
+	bar: string;
+	c: boolean;
+};
+
+type Union = A | B | C;
+
+type OmittedUnion = DistributedOmit<Union, 'foo' | 'bar'>;
+
+declare const omittedUnion: OmittedUnion;
+
+if (omittedUnion.discriminant === 'A') {
+	expectType<{discriminant: 'A'; a: number}>(omittedUnion);
+	expectError(omittedUnion.foo);
+	expectError(omittedUnion.bar);
+}


### PR DESCRIPTION
> [!WARNING]
> DO NOT MERGE BEFORE #709 

Implements `DistributedOmit`, that omits keys from a type, distributing the operation over a union, while also offering autocompletion for keys that can be omitted.

Requested in #132.

Typescript's `Omit` doesn't distribute over unions, which causes the following situation:

```ts
type A = {
  discriminant: "A";
  foo: string;
  a: number;
};

type B = {
  discriminant: "B";
  foo: string;
  b: string;
};

type Union = A | B;

type OmittedUnion = Omit<Union, "foo">; //==> { discriminant: "A" | "B" }

const omittedUnion: OmittedUnion = createOmittedUnion();

if(omittedUnion.discriminant === "A") {
  // We would like to narrow `omittedUnion`'s type
  // to `A` here, but we can't because `Omit`
  // doesn't distribute over unions.

  omittedUnion.a; //==> Error, `a` is not a property of `{ discriminant: "A" | "B" }`
}
```

While `Except` solves this problem, it restricts the keys you can omit to the ones that are present in **ALL** union members, where `DistributedOmit` allows you to omit keys that are present in **ANY** union member.

```ts
type A = {
  discriminant: "A";
  foo: string;
  a: number;
};

type B = {
  discriminant: "B";
  foo: string;
  bar: string;
  b: string;
};

type C = {
  discriminant: "C";
  bar: string;
  c: boolean;
};

// Notice that `foo` exists in `A` and `B`, but not in `C`, and
// `bar` exists in `B` and `C`, but not in `A`.

type Union = A | B | C;

type OmittedUnion = DistributedOmit<Union, "foo" | "bar">;

const omittedUnion: OmittedUnion = createOmittedUnion();

if(omittedUnion.discriminant === "A") {
  omittedUnion.a; //==> OK
  omittedUnion.foo; //==> Error, `foo` is not a property of `{ discriminant: "A"; a: string; }`
  omittedUnion.bar; //==> Error, `bar` is not a property of `{ discriminant: "A"; a: string; }`
}
```
