### PR TITLE
`ConditionalPickDeep`: Recursive scope restriction changed from `object` to `record`

### DIFF
--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -1,6 +1,8 @@
 import type {IsEqual} from './is-equal';
 import type {ConditionalExcept} from './conditional-except';
 import type {ConditionalSimplifyDeep} from './conditional-simplify';
+import type {UnknownRecord} from './unknown-record';
+import type {EmptyObject} from './empty-object';
 
 /**
 Used to mark properties that should be excluded.
@@ -95,7 +97,7 @@ export type ConditionalPickDeep<
 > = ConditionalSimplifyDeep<ConditionalExcept<{
 	[Key in keyof Type]: AssertCondition<Type[Key], Condition, Options> extends true
 		? Type[Key]
-		: Type[Key] extends object
+		: Type[Key] extends UnknownRecord
 			? ConditionalPickDeep<Type[Key], Condition, Options>
 			: typeof conditionalPickDeepSymbol;
-}, (typeof conditionalPickDeepSymbol | undefined) | Record<PropertyKey, never>>>;
+}, (typeof conditionalPickDeepSymbol | undefined) | EmptyObject>, never, UnknownRecord>;

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -1,46 +1,113 @@
 import {expectType} from 'tsd';
 import type {ConditionalPickDeep} from '../index';
 
+declare class ClassA {
+	public a: string;
+}
+
 type Example = {
-	a: string;
-	b: string | boolean;
-	c: {
-		d: string;
-		e: {
-			f?: string;
-			g?: boolean;
-			h: string | boolean;
-			i: boolean | bigint;
+	optional?: boolean;
+	literal: 'foo';
+	string: string;
+	map: Map<string, string>;
+	set: Set<string>;
+	date: Date;
+	array: string[];
+	tuples: ['foo', 'bar'];
+	instanceA: ClassA;
+	ClassA: typeof ClassA;
+	function: (...args: string[]) => string;
+	strbool: string | boolean;
+	obj: {
+		string: string;
+		subObj: {
+			optional?: string;
+			string: string;
 		};
-		j: boolean;
 	};
 };
 
 declare const stringPick: ConditionalPickDeep<Example, string>;
-expectType<{a: string; c: {d: string}}>(stringPick);
+expectType<{
+	literal: 'foo';
+	string: string;
+	obj: {
+		string: string;
+		subObj: {
+			string: string;
+		};
+	};
+}>(stringPick);
+
+declare const stringEqualityPick: ConditionalPickDeep<Example, string, {condition: 'equality'}>;
+expectType<{
+	string: string;
+	obj: {
+		string: string;
+		subObj: {
+			string: string;
+		};
+	};
+}>(stringEqualityPick);
 
 declare const stringPickOptional: ConditionalPickDeep<Example, string | undefined>;
-expectType<{a: string; c: {d: string; e: {f?: string}}}>(stringPickOptional);
+expectType<{
+	literal: 'foo';
+	string: string;
+	obj: {
+		string: string;
+		subObj: {
+			optional?: string | undefined;
+			string: string;
+		};
+	};
+}>(stringPickOptional);
 
 declare const stringPickOptionalOnly: ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
-expectType<{c: {e: {f?: string}}}>(stringPickOptionalOnly);
+expectType<{obj: {subObj: {optional?: string | undefined}}}>(stringPickOptionalOnly);
 
 declare const booleanPick: ConditionalPickDeep<Example, boolean | undefined>;
-expectType<{c: {e: {g?: boolean}; j: boolean}}>(booleanPick);
+expectType<{optional?: boolean | undefined}>(booleanPick);
 
 declare const numberPick: ConditionalPickDeep<Example, number>;
 expectType<{}>(numberPick);
 
 declare const stringOrBooleanPick: ConditionalPickDeep<Example, string | boolean>;
 expectType<{
-	a: string;
-	b: string | boolean;
-	c: {
-		d: string;
-		e: {h: string | boolean};
-		j: boolean;
+	literal: 'foo';
+	string: string;
+	strbool: string | boolean;
+	obj: {
+		string: string;
+		subObj: {
+			string: string;
+		};
 	};
 }>(stringOrBooleanPick);
 
 declare const stringOrBooleanPickOnly: ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
-expectType<{b: string | boolean; c: {e: {h: string | boolean}}}>(stringOrBooleanPickOnly);
+expectType<{strbool: string | boolean}>(stringOrBooleanPickOnly);
+
+declare const arrayPick: ConditionalPickDeep<Example, string[]>;
+expectType<{array: string[]; tuples: ['foo', 'bar']}>(arrayPick);
+
+declare const arrayEqualityPick: ConditionalPickDeep<Example, string[], {condition: 'equality'}>;
+expectType<{array: string[]}>(arrayEqualityPick);
+
+declare const tuplePick: ConditionalPickDeep<Example, ['foo', 'bar']>;
+expectType<{tuples: ['foo', 'bar']}>(tuplePick);
+
+declare const instancePick: ConditionalPickDeep<Example, ClassA>;
+expectType<{instanceA: ClassA}>(instancePick);
+
+declare const classPick: ConditionalPickDeep<Example, typeof ClassA>;
+expectType<{ClassA: typeof ClassA}>(classPick);
+
+declare const functionPick: ConditionalPickDeep<Example, (...args: string[]) => string>;
+expectType<{function: (...args: string[]) => string}>(functionPick);
+
+declare const mapPick: ConditionalPickDeep<Example, Map<string, string>>;
+expectType<{map: Map<string, string>}>(mapPick);
+
+declare const setPick: ConditionalPickDeep<Example, Set<string>>;
+expectType<{set: Set<string>}>(setPick);

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -17,10 +17,10 @@ type Example = {
 	instanceA: ClassA;
 	ClassA: typeof ClassA;
 	function: (...args: string[]) => string;
-	strbool: string | boolean;
-	obj: {
+	stringOrBoolean: string | boolean;
+	object: {
 		string: string;
-		subObj: {
+		subObject: {
 			optional?: string;
 			string: string;
 		};
@@ -31,9 +31,9 @@ declare const stringPick: ConditionalPickDeep<Example, string>;
 expectType<{
 	literal: 'foo';
 	string: string;
-	obj: {
+	object: {
 		string: string;
-		subObj: {
+		subObject: {
 			string: string;
 		};
 	};
@@ -42,9 +42,9 @@ expectType<{
 declare const stringEqualityPick: ConditionalPickDeep<Example, string, {condition: 'equality'}>;
 expectType<{
 	string: string;
-	obj: {
+	object: {
 		string: string;
-		subObj: {
+		subObject: {
 			string: string;
 		};
 	};
@@ -54,9 +54,9 @@ declare const stringPickOptional: ConditionalPickDeep<Example, string | undefine
 expectType<{
 	literal: 'foo';
 	string: string;
-	obj: {
+	object: {
 		string: string;
-		subObj: {
+		subObject: {
 			optional?: string | undefined;
 			string: string;
 		};
@@ -64,7 +64,7 @@ expectType<{
 }>(stringPickOptional);
 
 declare const stringPickOptionalOnly: ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
-expectType<{obj: {subObj: {optional?: string | undefined}}}>(stringPickOptionalOnly);
+expectType<{object: {subObject: {optional?: string | undefined}}}>(stringPickOptionalOnly);
 
 declare const booleanPick: ConditionalPickDeep<Example, boolean | undefined>;
 expectType<{optional?: boolean | undefined}>(booleanPick);
@@ -76,17 +76,17 @@ declare const stringOrBooleanPick: ConditionalPickDeep<Example, string | boolean
 expectType<{
 	literal: 'foo';
 	string: string;
-	strbool: string | boolean;
-	obj: {
+	stringOrBoolean: string | boolean;
+	object: {
 		string: string;
-		subObj: {
+		subObject: {
 			string: string;
 		};
 	};
 }>(stringOrBooleanPick);
 
 declare const stringOrBooleanPickOnly: ConditionalPickDeep<Example, string | boolean, {condition: 'equality'}>;
-expectType<{strbool: string | boolean}>(stringOrBooleanPickOnly);
+expectType<{stringOrBoolean: string | boolean}>(stringOrBooleanPickOnly);
 
 declare const arrayPick: ConditionalPickDeep<Example, string[]>;
 expectType<{array: string[]; tuples: ['foo', 'bar']}>(arrayPick);


### PR DESCRIPTION


<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
- Fixed #570 
