### PR TITLE
`PartialDeep`: Ensure it doesn't recurse into prototype properties

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,4 +1,4 @@
-import type {BuiltIns} from './internal';
+import type {BuiltIns, UnknownRecord} from './internal';
 
 /**
 @see PartialDeep
@@ -69,8 +69,9 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 				? PartialReadonlyMapDeep<KeyType, ValueType, Options>
 				: T extends ReadonlySet<infer ItemType>
 					? PartialReadonlySetDeep<ItemType, Options>
-					: T extends object
-						? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
+					: T extends UnknownRecord
+						? PartialObjectDeep<T, Options>
+						: T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
 							? Options['recurseIntoArrays'] extends true
 								? ItemType[] extends T // Test for arrays (non-tuples) specifically
 									? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
@@ -78,8 +79,7 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 										: Array<PartialDeep<ItemType | undefined, Options>>
 									: PartialObjectDeep<T, Options> // Tuples behave properly
 								: T // If they don't opt into array testing, just use the original type
-							: PartialObjectDeep<T, Options>
-						: unknown;
+							: T;
 
 /**
 Same as `PartialDeep`, but accepts only `Map`s and as inputs. Internal helper for `PartialDeep`.

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -10,6 +10,7 @@ const foo = {
 	bar: {
 		function: (_: string): void => undefined,
 		classConstructor: ClassA,
+		html: document.createElement('div'),
 		object: {key: 'value'},
 		string: 'waldo',
 		number: 1,
@@ -58,6 +59,8 @@ expectAssignable<ReadonlyMap<string | undefined, string | undefined> | undefined
 expectAssignable<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
 expectType<ReadonlyArray<string | undefined> | undefined>(partialDeepFoo.bar!.readonlyArray);
 expectType<readonly ['foo'?] | undefined>(partialDeepFoo.bar!.readonlyTuple);
+// Test for https://github.com/sindresorhus/type-fest/issues/651
+expectType<HTMLDivElement | undefined>(partialDeepFoo.bar!.html);
 // Check for compiling with omitting partial keys
 partialDeepFoo = {baz: 'fred'};
 partialDeepFoo = {bar: {string: 'waldo'}};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

 - Fixed #651 
