### PR TITLE
Add `preserveConsecutiveUppercase` to `PascalCase` and friends

### DIFF
--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -33,6 +33,6 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 @category Change case
 @category Template literal
 */
-export type PascalCase<Value, Options extends CamelCaseOptions = { preserveConsecutiveUppercase: true }> = CamelCase<Value, Options> extends string
+export type PascalCase<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = CamelCase<Value, Options> extends string
 	? Capitalize<CamelCase<Value, Options>>
 	: CamelCase<Value, Options>;

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCase} from './camel-case';
+import type {CamelCase, CamelCaseOptions} from './camel-case';
 
 /**
 Converts a string literal to pascal-case.
@@ -33,6 +33,6 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 @category Change case
 @category Template literal
 */
-export type PascalCase<Value> = CamelCase<Value> extends string
-	? Capitalize<CamelCase<Value>>
-	: CamelCase<Value>;
+export type PascalCase<Value, Options extends CamelCaseOptions = { preserveConsecutiveUppercase: true }> = CamelCase<Value, Options> extends string
+	? Capitalize<CamelCase<Value, Options>>
+	: CamelCase<Value, Options>;

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -1,3 +1,4 @@
+import type {CamelCaseOptions} from './camel-case';
 import type {PascalCase} from './pascal-case';
 
 /**
@@ -44,11 +45,11 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 @category Template literal
 @category Object
 */
-export type PascalCasedPropertiesDeep<Value> = Value extends Function | Date | RegExp
+export type PascalCasedPropertiesDeep<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Value extends Function | Date | RegExp
 	? Value
 	: Value extends Array<infer U>
-		? Array<PascalCasedPropertiesDeep<U>>
+		? Array<PascalCasedPropertiesDeep<U, Options>>
 		: Value extends Set<infer U>
-			? Set<PascalCasedPropertiesDeep<U>> : {
-				[K in keyof Value as PascalCase<K>]: PascalCasedPropertiesDeep<Value[K]>;
+			? Set<PascalCasedPropertiesDeep<U, Options>> : {
+				[K in keyof Value as PascalCase<K, Options>]: PascalCasedPropertiesDeep<Value[K], Options>;
 			};

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -1,3 +1,4 @@
+import type {CamelCaseOptions} from './camel-case';
 import type {PascalCase} from './pascal-case';
 
 /**

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -27,8 +27,8 @@ const result: PascalCasedProperties<User> = {
 @category Template literal
 @category Object
 */
-export type PascalCasedProperties<Value> = Value extends Function
+export type PascalCasedProperties<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Value extends Function
 	? Value
 	: Value extends Array<infer U>
 		? Value
-		: {[K in keyof Value as PascalCase<K>]: Value[K]};
+		: {[K in keyof Value as PascalCase<K, Options>]: Value[K]};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

As per https://github.com/sindresorhus/type-fest/pull/501#issuecomment-1808109652.

Not sure if you want to reuse `CamelCaseOptions` or create an explicit `PascalCaseOptions` with (for now) the same property.