### PR TITLE
fix: `PartialOnUndefinedDeep` do not make unknown partial / only use LiteralKeys to reconstruct type

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -317,3 +317,8 @@ IsPrimitive<Object>
 ```
 */
 export type IsPrimitive<T> = [T] extends [Primitive] ? true : false;
+
+/**
+Utility type to retrieve only literal keys from type.
+*/
+export type LiteralKeyOf<T> = keyof {[K in keyof T as IsLiteral<K> extends true ? K : never]-?: never};

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -2,6 +2,7 @@ import type {Primitive} from './primitive';
 import type {Simplify} from './simplify';
 import type {Trim} from './trim';
 import type {IsAny} from './is-any';
+import type {IsLiteral} from './is-literal';
 import type {UnknownRecord} from './unknown-record';
 
 // TODO: Remove for v5.

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -71,6 +71,6 @@ type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOption
 			: unknown;
 
 /**
-Utility type to retrieve only literal keys from type 
+Utility type to retrieve only literal keys from type.
 */
 type LiteralKeyOf<T> = keyof {[K in keyof T as IsLiteral<K> extends true ? K : never]-?: never};

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -1,5 +1,5 @@
 import type {IfUnknown} from './if-unknown';
-import type {BuiltIns} from './internal';
+import type {BuiltIns, LiteralKeyOf} from './internal';
 import type {IsLiteral} from './is-literal';
 import type {Merge} from './merge';
 
@@ -70,8 +70,3 @@ type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOption
 		: T extends Record<any, any> | undefined
 			? PartialOnUndefinedDeep<T, Options>
 			: unknown;
-
-/**
-Utility type to retrieve only literal keys from type.
-*/
-type LiteralKeyOf<T> = keyof {[K in keyof T as IsLiteral<K> extends true ? K : never]-?: never};

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -1,3 +1,4 @@
+import type {IfUnknown} from './if-unknown';
 import type {BuiltIns} from './internal';
 import type {Merge} from './merge';
 
@@ -47,7 +48,7 @@ const testSettings: PartialOnUndefinedDeep<Settings> = {
 @category Object
 */
 export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOptions = {}> = T extends Record<any, any> | undefined
-	? {[KeyType in keyof T as undefined extends T[KeyType] ? KeyType : never]?: PartialOnUndefinedDeepValue<T[KeyType], Options>} extends infer U // Make a partial type with all value types accepting undefined (and set them optional)
+	? {[KeyType in keyof T as undefined extends T[KeyType] ? IfUnknown<T[KeyType], never, KeyType> : never]?: PartialOnUndefinedDeepValue<T[KeyType], Options>} extends infer U // Make a partial type with all value types accepting undefined (and set them optional)
 		? Merge<{[KeyType in keyof T as KeyType extends keyof U ? never : KeyType]: PartialOnUndefinedDeepValue<T[KeyType], Options>}, U> // Join all remaining keys not treated in U
 		: never // Should not happen
 	: T;

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -49,7 +49,7 @@ const testSettings: PartialOnUndefinedDeep<Settings> = {
 */
 export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOptions = {}> = T extends Record<any, any> | undefined
 	? {[KeyType in keyof T as undefined extends T[KeyType] ? IfUnknown<T[KeyType], never, KeyType> : never]?: PartialOnUndefinedDeepValue<T[KeyType], Options>} extends infer U // Make a partial type with all value types accepting undefined (and set them optional)
-		? Merge<{[KeyType in keyof T as KeyType extends keyof U ? never : KeyType]: PartialOnUndefinedDeepValue<T[KeyType], Options>}, U> // Join all remaining keys not treated in U
+		? Merge<{[KeyType in keyof T as KeyType extends LiteralKeyOf<U> ? never : KeyType]: PartialOnUndefinedDeepValue<T[KeyType], Options>}, U> // Join all remaining keys not treated in U
 		: never // Should not happen
 	: T;
 
@@ -69,3 +69,8 @@ type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOption
 		: T extends Record<any, any> | undefined
 			? PartialOnUndefinedDeep<T, Options>
 			: unknown;
+
+/**
+Utility type to retrieve only literal keys from type 
+*/
+type LiteralKeyOf<T> = keyof {[K in keyof T as IsLiteral<K> extends true ? K : never]-?: never};

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -1,6 +1,5 @@
 import type {IfUnknown} from './if-unknown';
 import type {BuiltIns, LiteralKeyOf} from './internal';
-import type {IsLiteral} from './is-literal';
 import type {Merge} from './merge';
 
 /**

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -1,5 +1,6 @@
 import type {IfUnknown} from './if-unknown';
 import type {BuiltIns} from './internal';
+import type {IsLiteral} from './is-literal';
 import type {Merge} from './merge';
 
 /**

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -1,4 +1,4 @@
-import {expectAssignable} from 'tsd';
+import {expectAssignable, expectType} from 'tsd';
 import type {PartialOnUndefinedDeep} from '../index';
 
 type TestingType = {
@@ -23,9 +23,9 @@ type TestingType = {
 	readonly1: readonly any[] | undefined;
 	readonly2: ReadonlyArray<{propertyA: string; propertyB: number | undefined}> | undefined;
 	tuple: ['test1', {propertyA: string; propertyB: number | undefined}] | undefined;
-	indexType: {[k: string]: string | undefined; propertyA: string; propertyB: string | undefined};
-	indexTypeUnknown: {[k: string]: unknown; propertyA: string; propertyB: number | undefined};
 };
+declare const indexType: {[k: string]: string | undefined; propertyA: string; propertyB: string | undefined};
+declare const indexTypeUnknown: {[k: string]: unknown; propertyA: string; propertyB: number | undefined};
 
 // Default behavior, without recursion into arrays/tuples
 declare const foo: PartialOnUndefinedDeep<TestingType>;
@@ -51,9 +51,12 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: TestingType['readonly2'];
 	tuple?: TestingType['tuple'];
-	indexType: Partial<Pick<TestingType['indexType'], 'propertyB'>> & Omit<TestingType['indexType'], 'propertyB'>;
-	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(foo);
+
+declare const indexTypeWithoutRecursion: PartialOnUndefinedDeep<typeof indexType>;
+declare const indexTypeUnknownWithoutRecursion: PartialOnUndefinedDeep<typeof indexTypeUnknown>;
+expectType<{[k: string]: string | undefined; propertyA: string; propertyB?: string | undefined}>(indexTypeWithoutRecursion);
+expectType<{[k: string]: unknown; propertyA: string; propertyB?: number | undefined}>(indexTypeUnknownWithoutRecursion);
 
 // With recursion into arrays/tuples activated
 declare const bar: PartialOnUndefinedDeep<TestingType, {recurseIntoArrays: true}>;
@@ -82,3 +85,8 @@ expectAssignable<{
 	indexType: Partial<Pick<TestingType['indexType'], 'propertyB'>> & Omit<TestingType['indexType'], 'propertyB'>;
 	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(bar);
+
+declare const indexTypeWithRecursion: PartialOnUndefinedDeep<typeof indexType, {recurseIntoArrays: true}>;
+declare const indexTypeUnknownWithRecursion: PartialOnUndefinedDeep<typeof indexTypeUnknown, {recurseIntoArrays: true}>;
+expectType<{[k: string]: string | undefined; propertyA: string; propertyB?: string | undefined}>(indexTypeWithRecursion);
+expectType<{[k: string]: unknown; propertyA: string; propertyB?: number | undefined}>(indexTypeUnknownWithRecursion);

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -23,6 +23,7 @@ type TestingType = {
 	readonly1: readonly any[] | undefined;
 	readonly2: ReadonlyArray<{propertyA: string; propertyB: number | undefined}> | undefined;
 	tuple: ['test1', {propertyA: string; propertyB: number | undefined}] | undefined;
+	indexTypeUnknown: {propertyA: string; propertyB: number | undefined; [k: string]: unknown};
 };
 
 // Default behavior, without recursion into arrays/tuples
@@ -49,6 +50,7 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: TestingType['readonly2'];
 	tuple?: TestingType['tuple'];
+	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], "propertyB">> & Omit<TestingType['indexTypeUnknown'], "propertyB">;
 }>(foo);
 
 // With recursion into arrays/tuples activated
@@ -75,4 +77,5 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: ReadonlyArray<{propertyA: string; propertyB?: number | undefined}> | undefined;
 	tuple?: ['test1', {propertyA: string; propertyB?: number | undefined}] | undefined;
+	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], "propertyB">> & Omit<TestingType['indexTypeUnknown'], "propertyB">;
 }>(bar);

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -22,6 +22,7 @@ type TestingType = {
 	array2: Array<{propertyA: string; propertyB: number | undefined}> | undefined;
 	readonly1: readonly any[] | undefined;
 	readonly2: ReadonlyArray<{propertyA: string; propertyB: number | undefined}> | undefined;
+	readonly readonlyProperty: string | undefined;
 	tuple: ['test1', {propertyA: string; propertyB: number | undefined}] | undefined;
 };
 declare const indexType: {[k: string]: string | undefined; propertyA: string; propertyB: string | undefined};
@@ -50,6 +51,7 @@ expectAssignable<{
 	array2?: TestingType['array2'];
 	readonly1?: TestingType['readonly1'];
 	readonly2?: TestingType['readonly2'];
+	readonly readonlyProperty?: TestingType['readonlyProperty'];
 	tuple?: TestingType['tuple'];
 }>(foo);
 
@@ -81,6 +83,7 @@ expectAssignable<{
 	array2?: Array<{propertyA: string; propertyB?: number | undefined}> | undefined;
 	readonly1?: TestingType['readonly1'];
 	readonly2?: ReadonlyArray<{propertyA: string; propertyB?: number | undefined}> | undefined;
+	readonly readonlyProperty?: TestingType['readonlyProperty'];
 	tuple?: ['test1', {propertyA: string; propertyB?: number | undefined}] | undefined;
 }>(bar);
 

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -23,6 +23,7 @@ type TestingType = {
 	readonly1: readonly any[] | undefined;
 	readonly2: ReadonlyArray<{propertyA: string; propertyB: number | undefined}> | undefined;
 	tuple: ['test1', {propertyA: string; propertyB: number | undefined}] | undefined;
+	indexType: {[k: string]: string | undefined; propertyA: string; propertyB: string | undefined};
 	indexTypeUnknown: {[k: string]: unknown; propertyA: string; propertyB: number | undefined};
 };
 
@@ -50,6 +51,7 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: TestingType['readonly2'];
 	tuple?: TestingType['tuple'];
+	indexType: Partial<Pick<TestingType['indexType'], 'propertyB'>> & Omit<TestingType['indexType'], 'propertyB'>;
 	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(foo);
 
@@ -77,5 +79,6 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: ReadonlyArray<{propertyA: string; propertyB?: number | undefined}> | undefined;
 	tuple?: ['test1', {propertyA: string; propertyB?: number | undefined}] | undefined;
+	indexType: Partial<Pick<TestingType['indexType'], 'propertyB'>> & Omit<TestingType['indexType'], 'propertyB'>;
 	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(bar);

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -23,7 +23,7 @@ type TestingType = {
 	readonly1: readonly any[] | undefined;
 	readonly2: ReadonlyArray<{propertyA: string; propertyB: number | undefined}> | undefined;
 	tuple: ['test1', {propertyA: string; propertyB: number | undefined}] | undefined;
-	indexTypeUnknown: {propertyA: string; propertyB: number | undefined; [k: string]: unknown};
+	indexTypeUnknown: {[k: string]: unknown; propertyA: string; propertyB: number | undefined};
 };
 
 // Default behavior, without recursion into arrays/tuples
@@ -50,7 +50,7 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: TestingType['readonly2'];
 	tuple?: TestingType['tuple'];
-	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], "propertyB">> & Omit<TestingType['indexTypeUnknown'], "propertyB">;
+	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(foo);
 
 // With recursion into arrays/tuples activated
@@ -77,5 +77,5 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: ReadonlyArray<{propertyA: string; propertyB?: number | undefined}> | undefined;
 	tuple?: ['test1', {propertyA: string; propertyB?: number | undefined}] | undefined;
-	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], "propertyB">> & Omit<TestingType['indexTypeUnknown'], "propertyB">;
+	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(bar);

--- a/test-d/partial-on-undefined-deep.ts
+++ b/test-d/partial-on-undefined-deep.ts
@@ -82,8 +82,6 @@ expectAssignable<{
 	readonly1?: TestingType['readonly1'];
 	readonly2?: ReadonlyArray<{propertyA: string; propertyB?: number | undefined}> | undefined;
 	tuple?: ['test1', {propertyA: string; propertyB?: number | undefined}] | undefined;
-	indexType: Partial<Pick<TestingType['indexType'], 'propertyB'>> & Omit<TestingType['indexType'], 'propertyB'>;
-	indexTypeUnknown: Partial<Pick<TestingType['indexTypeUnknown'], 'propertyB'>> & Omit<TestingType['indexTypeUnknown'], 'propertyB'>;
 }>(bar);
 
 declare const indexTypeWithRecursion: PartialOnUndefinedDeep<typeof indexType, {recurseIntoArrays: true}>;


### PR DESCRIPTION
fix #756

- Do not treat unknown like undefined (the condition was `undefined extends T[KeyType]` that is true when `T[KeyType]` is `unknown`)
- The bug reported in #756 was due to the condition when reconstructing type (with `Merge`) to check if the key is present in the partial derived type (condition was always true if the index key type is string `KeyType extends keyof U` is always true). The new condition only check the literal keys of the partial derived type.

Note : this `LiteralKeyOf` type could be added to type-fest, it can be useful I think
