### PR TITLE
`Join`: faster handing of readonly empty tuple

### DIFF
--- a/source/join.d.ts
+++ b/source/join.d.ts
@@ -51,7 +51,7 @@ const path: Join<['hello' | undefined, 'world' | null], '.'> = ['hello', 'world'
 export type Join<
 	Items extends readonly JoinableItem[],
 	Delimiter extends string,
-> = Items extends []
+> = Items extends readonly []
 	? ''
 	: Items extends readonly [JoinableItem?]
 		? `${NullishCoalesce<Items[0], ''>}`

--- a/test-d/join.ts
+++ b/test-d/join.ts
@@ -48,6 +48,11 @@ const tuple = ['foo', 'bar', 'baz'] as const;
 const joinedTuple: Join<typeof tuple, ','> = 'foo,bar,baz';
 expectType<'foo,bar,baz'>(joinedTuple);
 
+// Typeof of const empty tuple.
+const emptyTuple = [] as const;
+const joinedEmptyTuple: Join<typeof emptyTuple, ','> = '';
+expectType<''>(joinedEmptyTuple);
+
 // Typeof of string[].
 const stringArray = ['foo', 'bar', 'baz'];
 const joinedStringArray: Join<typeof stringArray, ','> = '';


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
Related #759 

Although readonly empty arrays are currently handled correctly, it could be faster