### PR TITLE
`BuiltIns`: adds `void`

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -68,9 +68,9 @@ export type Subtract<A extends number, B extends number> = BuildTuple<A> extends
 	: never;
 
 /**
-Matches any primitive, `Date`, or `RegExp` value.
+Matches any primitive, `void`, `Date`, or `RegExp` value.
 */
-export type BuiltIns = Primitive | Date | RegExp;
+export type BuiltIns = Primitive | void | Date | RegExp;
 
 /**
 Matches non-recursive types.

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -110,3 +110,15 @@ expectType<NamespaceWithOverload>(readonlyData.namespaceWithOverload);
 expectType<string>(readonlyData.namespaceWithOverload(1));
 expectType<number>(readonlyData.namespaceWithOverload('foo', 1));
 expectType<boolean[]>(readonlyData.namespaceWithOverload.baz);
+
+// Test void
+type VoidType = {
+	foo: void;
+	bar: string | void;
+};
+type VoidTypeExpected = {
+	readonly foo: void;
+	readonly bar: string | void;
+};
+declare const voidType: ReadonlyDeep<VoidType>;
+expectType<VoidTypeExpected>(voidType);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
 - Fixed #781 

and I had another thought that should we put void into `Primitive`? I think void is a primitive type same as `undefined` in TS, but void is not [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) at `Primitive`'s document.

How about your thoughts? @sindresorhus 