### PR TITLE
Tests: Ensure that `.d.ts` files are checked by setting `skipLibCheck: false`

### DIFF
--- a/.github/workflows/ts-canary.yml
+++ b/.github/workflows/ts-canary.yml
@@ -21,4 +21,6 @@ jobs:
           node-version: lts/*
       - run: npm install
       - run: npm install typescript@${{ matrix.typescript-version }}
+      - name: show installed typescript version
+        run: npm list typescript --depth=0
       - run: npx tsc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"lib": [
 			"ES2020",
 			"DOM"
-		]
+		],
+    "skipLibCheck": false, // Required to ensure that .d.ts files are checked, see: https://github.com/sindresorhus/tsconfig/issues/15
 	},
 	"exclude": [
 		"test-d/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 			"ES2020",
 			"DOM"
 		],
-    "skipLibCheck": false, // Required to ensure that .d.ts files are checked, see: https://github.com/sindresorhus/tsconfig/issues/15
+		"skipLibCheck": false, // Ensures .d.ts files are checked: https://github.com/sindresorhus/tsconfig/issues/15
 	},
 	"exclude": [
 		"test-d/**/*"


### PR DESCRIPTION
For background discussion, see https://github.com/sindresorhus/tsconfig/issues/15 and my personal decision to use `skipLibCheck: false` in my projects: https://github.com/voxpelli/tsconfig/issues/1

This enables the errors that are shown in https://github.com/sindresorhus/type-fest/issues/784 to be surfaced in here, and as such the canary tests to actually be a canary of something
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
