### PR TITLE
`DelimiterCasedPropertiesDeep`: Don't recurse into intersection type that included primitive value

### DIFF
--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCase} from './delimiter-case';
+import type {NonRecursiveType} from './internal';
 import type {UnknownArray} from './unknown-array';
 
 /**
@@ -48,7 +49,7 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
-> = Value extends Function | Date | RegExp
+> = Value extends NonRecursiveType
 	? Value
 	: Value extends UnknownArray
 		? DelimiterCasedPropertiesArrayDeep<Value, Delimiter>

--- a/test-d/opaque.ts
+++ b/test-d/opaque.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectNotAssignable, expectNotType, expectType} from 'tsd';
-import type {Opaque, UnwrapOpaque, Tagged, UnwrapTagged} from '../index';
+import type {Opaque, UnwrapOpaque, Tagged, UnwrapTagged, SnakeCasedPropertiesDeep} from '../index';
 
 type Value = Opaque<number, 'Value'>;
 
@@ -112,3 +112,8 @@ const unwrapped2 = 123 as PlainValueUnwrapTagged;
 
 expectType<number>(unwrapped1);
 expectType<number>(unwrapped2);
+
+// Test for issue https://github.com/sindresorhus/type-fest/issues/643
+type IdType = Opaque<number, 'test'>;
+type TestSnakeObject = SnakeCasedPropertiesDeep<{testId: IdType}>;
+expectType<TestSnakeObject>({test_id: 2 as IdType});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
- Fixed #643 

Core changes are similar to 
```ts
- Value extends Function | Date | RegExp ? Value : ...
+ Value extends Function | Date | RegExp | Primitive ? Value : ...
```
To ensure the intersection type that included Primitive value like `number & {}` Don't be recursed.

