### PR TITLE
`SharedUnionFieldsDeep`: Skip if input type is not a union type.

### DIFF
--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -436,3 +436,39 @@ type InternalUnionMax<N extends number, T extends UnknownArray = []> =
 		:	T['length'] extends N
 			? InternalUnionMax<Exclude<N, T['length']>, T>
 			: InternalUnionMax<N, [...T, unknown]>;
+
+/**
+Returns a boolean for whether the given type is a union type.
+
+@example
+```
+type A = IsUnion<string | number>;
+//=> true
+
+type B = IsUnion<string>;
+//=> false
+```
+*/
+export type IsUnion<T> = InternalIsUnion<T>;
+
+/**
+The actual implementation of `IsUnion`.
+*/
+type InternalIsUnion<T, U = T> =
+(
+	// @link https://ghaiklor.github.io/type-challenges-solutions/en/medium-isunion.html
+	IsNever<T> extends true
+		? false
+		: T extends any
+			? [U] extends [T]
+				? false
+				: true
+			: never
+) extends infer Result
+	// In some cases `Result` will return `false | true` which is `boolean`,
+	// that means `T` has at least two types and it's a union type,
+	// so we will return `true` instead of `boolean`.
+	? boolean extends Result ? true
+		: Result
+	: never; // Should never happen
+

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -471,4 +471,3 @@ type InternalIsUnion<T, U = T> =
 	? boolean extends Result ? true
 		: Result
 	: never; // Should never happen
-

--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -1,4 +1,4 @@
-import type {NonRecursiveType, UnionMin, UnionMax, TupleLength, StaticPartOfArray, VariablePartOfArray} from './internal';
+import type {NonRecursiveType, UnionMin, UnionMax, TupleLength, StaticPartOfArray, VariablePartOfArray, IsUnion} from './internal';
 import type {IsNever} from './is-never';
 import type {UnknownArray} from './unknown-array';
 
@@ -108,10 +108,13 @@ function displayPetInfo(petInfo: SharedUnionFieldsDeep<Cat | Dog>['info']) {
 @category Union
 */
 export type SharedUnionFieldsDeep<Union, Options extends SharedUnionFieldsDeepOptions = {recurseIntoArrays: false}> =
+// If `Union` is not a union type, return `Union` directly.
+IsUnion<Union> extends false
+	? Union
 	// `Union extends` will convert `Union`
 	// to a [distributive conditionaltype](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
 	// But this is not what we want, so we need to wrap `Union` with `[]` to prevent it.
-	[Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>]
+	: [Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>]
 		? Union
 		: [Union] extends [UnknownArray]
 			? Options['recurseIntoArrays'] extends true

--- a/test-d/internal/is-union.ts
+++ b/test-d/internal/is-union.ts
@@ -1,0 +1,18 @@
+import {expectType} from 'tsd';
+import type {IsUnion} from '../../source/internal';
+
+expectType<IsUnion<1>>(false);
+expectType<IsUnion<true>>(false);
+expectType<IsUnion<'foo'>>(false);
+expectType<IsUnion<[]>>(false);
+expectType<IsUnion<{}>>(false);
+expectType<IsUnion<1 & {}>>(false);
+expectType<IsUnion<never>>(false);
+expectType<IsUnion<unknown>>(false);
+expectType<IsUnion<any>>(false);
+
+expectType<IsUnion<1 | 2>>(true);
+expectType<IsUnion<'foo' | 'bar'>>(true);
+expectType<IsUnion<'foo' | 'bar' | 1>>(true);
+expectType<IsUnion<'foo' | 1>>(true);
+expectType<IsUnion<[] | {}>>(true);

--- a/test-d/shared-union-fields-deep.ts
+++ b/test-d/shared-union-fields-deep.ts
@@ -123,3 +123,8 @@ expectType<{tuple: [number | boolean, ...Array<string | boolean>]}>(nonFixedLeng
 
 declare const nonFixedLengthTuple2: SharedUnionFieldsDeepRecurseIntoArrays<{tuple: [number, ...string[]]} | {tuple: [number, string, ...boolean[]]}>;
 expectType<{tuple: [number, string, ...Array<string | boolean>]}>(nonFixedLengthTuple2);
+
+// Test for same type
+type TestingType2 = TestingType & {foo: any};
+declare const same: SharedUnionFieldsDeepRecurseIntoArrays<TestingType | TestingType2>;
+expectType<TestingType>(same);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

I found that `SharedUnionFieldsDeep` have some isuue on handling some variable-length array like
```ts
type Arr = [...number[], string]

type R = SharedUnionFieldsDeep<{a: Arr} | {a: Arr}>
//=> {a: (number | string)[]}
```

I haven't found a good solution currently, but I can skip the non-union type(same type) to alleviate it now.

and this PR will also improves the performance of `SharedUnionFieldsDeep`