### PR TITLE
Supported `exactOptionalPropertyTypes: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"test": "xo && tsd && tsc && npm run test:undefined-on-partial-deep && node script/test/source-files-extension.js",
-		"test:undefined-on-partial-deep": "cd test-d/undefined-on-partial-deep && tsc --project tsconfig.json"
+		"test": "xo && tsd && tsc && node script/test/source-files-extension.js"
 	},
 	"files": [
 		"index.d.ts",

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -10,6 +10,7 @@ import type {
 	UnknownArrayOrTuple,
 } from './internal';
 import type {UnknownRecord} from './unknown-record';
+import type {EnforceOptional} from './enforce-optional';
 
 /**
 Deeply simplifies an object excluding iterables and functions. Used internally to improve the UX and accept both interfaces and type aliases as inputs.
@@ -289,7 +290,7 @@ type MergeDeepOrReturn<
 			: DefaultType
 		: Destination extends UnknownArrayOrTuple
 			? Source extends UnknownArrayOrTuple
-				? MergeDeepArrayOrTuple<Destination, Source, Merge<Options, {spreadTopLevelArrays: false}>>
+				? MergeDeepArrayOrTuple<Destination, Source, EnforceOptional<Merge<Options, {spreadTopLevelArrays: false}>>>
 				: DefaultType
 			: DefaultType>;
 

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -12,6 +12,7 @@ interface InterfaceA {
 
 type Example = {
 	optional?: boolean;
+	optionalWithUndefined?: boolean | undefined;
 	literal: 'foo';
 	string: string;
 	map: Map<string, string>;
@@ -73,17 +74,17 @@ expectType<{
 	object: {
 		string: string;
 		subObject: {
-			optional?: string | undefined;
+			optional?: string;
 			string: string;
 		};
 	};
 }>(stringPickOptional);
 
 declare const stringPickOptionalOnly: ConditionalPickDeep<Example, string | undefined, {condition: 'equality'}>;
-expectType<{object: {subObject: {optional?: string | undefined}}}>(stringPickOptionalOnly);
+expectType<{object: {subObject: {optional?: string}}}>(stringPickOptionalOnly);
 
 declare const booleanPick: ConditionalPickDeep<Example, boolean | undefined>;
-expectType<{optional?: boolean | undefined}>(booleanPick);
+expectType<{optional?: boolean; optionalWithUndefined?: boolean | undefined}>(booleanPick);
 
 declare const numberPick: ConditionalPickDeep<Example, number>;
 expectType<{number: 1; interface: {a: number}}>(numberPick);

--- a/test-d/undefined-on-partial-deep.ts
+++ b/test-d/undefined-on-partial-deep.ts
@@ -1,8 +1,6 @@
-/**
-@note This file is used for testing by `tsc` but not `tsd`, so we can just test assignable.
-*/
+// TODO: Test equality
 import {expectAssignable} from 'tsd';
-import type {UndefinedOnPartialDeep} from '../../source/undefined-on-partial-deep';
+import type {UndefinedOnPartialDeep} from '../source/undefined-on-partial-deep';
 
 type TestType1 = UndefinedOnPartialDeep<{required: string; optional?: string; optional2?: number; optional3?: string}>;
 expectAssignable<TestType1>({required: '', optional: undefined, optional2: 1});

--- a/test-d/undefined-on-partial-deep/tsconfig.json
+++ b/test-d/undefined-on-partial-deep/tsconfig.json
@@ -1,7 +1,0 @@
-{
-	"extends": "../../tsconfig",
-	"compilerOptions": {
-		"exactOptionalPropertyTypes": true,
-	},
-	"exclude": []
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 			"ES2020",
 			"DOM"
 		],
+		"exactOptionalPropertyTypes": true,
 		"skipLibCheck": false, // Ensures .d.ts files are checked: https://github.com/sindresorhus/tsconfig/issues/15
 	},
 	"exclude": [


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
closed #801 

Should I split this PR?