### PR TITLE
Fix `MergeDeep` in TypeScript 5.4

### DIFF
--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -64,7 +64,7 @@ type MergeDeepRecord<
 & Merge<PickIndexSignature<Destination>, PickIndexSignature<Source>>;
 
 /**
-The maximal depth to use when looking for rest types in {@link PickRestType}
+The maximal depth to use when looking for rest types in {@link PickRestType}. 50 is arbitrary selected through manual testing. 100 was too much.
 */
 type PickRestTypeMaxDepth = 50;
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -64,6 +64,11 @@ type MergeDeepRecord<
 & Merge<PickIndexSignature<Destination>, PickIndexSignature<Source>>;
 
 /**
+The maximal depth to use when looking for rest types in {@link PickRestType}
+*/
+type PickRestTypeMaxDepth = 50;
+
+/**
 Pick the rest type.
 
 @example
@@ -75,8 +80,12 @@ type Rest4 = PickRestType<[string, ...number[]]>; // => number[]
 type Rest5 = PickRestType<string[]>; // => string[]
 ```
 */
-type PickRestType<Type extends UnknownArrayOrTuple> = number extends Type['length']
-	? ArrayTail<Type> extends [] ? Type : PickRestType<ArrayTail<Type>>
+type PickRestType<Type extends UnknownArrayOrTuple, DepthTracker extends Array<true> = []> = number extends Type['length']
+	? (
+		PickRestTypeMaxDepth extends DepthTracker['length']
+			? unknown[]
+			: ArrayTail<Type> extends [] ? Type : PickRestType<ArrayTail<Type>, [true, ...DepthTracker]>
+	)
 	: [];
 
 /**


### PR DESCRIPTION
After the change in https://github.com/microsoft/TypeScript/pull/56004 the `PickRestType` was causing some types to be considered theoretically infinite in their recursion.

I can't wrap my mind around exactly why right now, but I can see how `PickRestType` on a crazy long tuple will cause a very deep recursion, so I decided to simply cap its recursion and return `unknown[]` if it goes past that point and that solved the errors.

Side effects:

- In practice: rarely any I believe
- In theory: some merged types will regress to `unknown[]` in TypeScript versions older than 5.4

Considerations:

Is the `DepthTracker extends Array<true> = []` + `PickRestTypeMaxDepth extends DepthTracker['length']` a good way to track depth? I know I have done a depth check previous times but can't remember what solution I picked then.

Fixes #784
