### PR TITLE
Make Simplify works for deep nesting

### DIFF
--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -55,4 +55,8 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 
 @category Object
 */
-export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};
+export type Simplify<T> = {
+	[KeyType in keyof T]: T[KeyType] extends object
+		? Simplify<T[KeyType]>
+		: T[KeyType];
+} & {};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR makes `Simplify` type works for computed types with deep nesting.

Example:

```typescript
type Foo = {
  foo: string;
  bar: number;
  baz: boolean;
}

type Result = {
  [K in keyof Foo]: Pick<Foo, K>
}

// {
//     foo: Pick<Foo, "foo">;
//     bar: Pick<Foo, "bar">;
//     baz: Pick<Foo, "baz">;
// }
type SimplifiedResult = Simplify<Result>;
```

With deep version:

```typescript
type DeepSimplify<T> = { [KeyType in keyof T]: T[KeyType] extends object ? DeepSimplify<T[KeyType]> : T[KeyType] } & {};

type Result = {
  [K in keyof Foo]: Pick<Foo, K>
}

// {
//     foo: {
//         foo: string;
//     };
//     bar: {
//         bar: number;
//     };
//     baz: {
//         baz: boolean;
//     };
// }
type DeepSimplifiedResult = DeepSimplify<Result>;
```
