### PR TITLE
Fix: export `SimplifyDeep`

### DIFF
--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -15,7 +15,7 @@ import type {EnforceOptional} from './enforce-optional';
 /**
 Deeply simplifies an object excluding iterables and functions. Used internally to improve the UX and accept both interfaces and type aliases as inputs.
 */
-type SimplifyDeep<Type> = ConditionalSimplifyDeep<Type, Function | Iterable<unknown>, object>;
+export type SimplifyDeep<Type> = ConditionalSimplifyDeep<Type, Function | Iterable<unknown>, object>;
 
 /**
 Try to merge two record properties or return the source property value, preserving `undefined` properties values in both cases.


### PR DESCRIPTION
`OmitDeep` is trying to import `SimplifyDeep`, which isn't exported:

https://github.com/sindresorhus/type-fest/blob/8bfcd750a5bb3231c8fdf2d76110dbad8c209cb7/source/omit-deep.d.ts#L4

This is causing a build to fail in `meow`: https://github.com/sindresorhus/meow/actions/runs/8145322629/job/22261300690?pr=252#step:4:20

---

`SimplifyDeep` should probably be moved to `internal.d.ts` and have its own type tests added, but that can be done later.