### PR TITLE
`OmitDeep`: fix handling if path not matched

### DIFF
--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -1,6 +1,8 @@
 import type {ArraySplice} from './array-splice';
 import type {ExactKey, IsArrayReadonly, NonRecursiveType, SetArrayAccess, ToString} from './internal';
 import type {IsEqual} from './is-equal';
+import type {IsNever} from './is-never';
+import type {LiteralUnion} from './literal-union';
 import type {SimplifyDeep} from './merge-deep';
 import type {Paths} from './paths';
 import type {SharedUnionFieldsDeep} from './shared-union-fields-deep';
@@ -69,7 +71,7 @@ type AddressInfo = OmitDeep<Info1, 'address.1.foo'>;
 @category Object
 @category Array
 */
-export type OmitDeep<T, PathUnion extends Paths<T>> =
+export type OmitDeep<T, PathUnion extends LiteralUnion<Paths<T>, string>> =
 	SimplifyDeep<
 	SharedUnionFieldsDeep<
 	{[P in PathUnion]: OmitDeepWithOnePath<T, P>}[PathUnion]
@@ -102,9 +104,11 @@ P extends `${infer RecordKeyInPath}.${infer SubPath}`
 			: ObjectT[Key]
 	}
 	: ExactKey<ObjectT, P> extends infer Key
-		? Key extends PropertyKey
-			? Omit<ObjectT, Key>
-			: ObjectT
+		? IsNever<Key> extends true
+			? ObjectT
+			: Key extends PropertyKey
+				? Omit<ObjectT, Key>
+				: ObjectT
 		: ObjectT;
 
 /**
@@ -133,4 +137,4 @@ type OmitDeepArrayWithOnePath<ArrayType extends UnknownArray, P extends string |
 				? []
 				// If `ArrayIndex` is a number literal
 				: ArraySplice<ArrayType, ArrayIndex, 1, [unknown]>
-			: never;
+			: ArrayType;

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {OmitDeep} from '../index';
+import type {OmitDeep, Simplify} from '../index';
 
 declare class ClassA {
 	a: string;
@@ -36,6 +36,18 @@ expectType<Omit<Testing, 'object'>>(normal);
 
 declare const normal2: OmitDeep<Testing, 'object.string'>;
 expectType<{object: Omit<BaseType, 'string'>}>(normal2);
+
+declare const omitNotExistProperty: OmitDeep<Testing, 'not_in_Testing'>;
+expectType<Testing>(omitNotExistProperty);
+
+declare const omitNotExistProperties: OmitDeep<Testing, 'not_in_Testing' | 'not_in_Testing2'>;
+expectType<Testing>(omitNotExistProperties);
+
+declare const omitNotExistProperty2: OmitDeep<Testing, 'object.not_in_object'>;
+expectType<Testing>(omitNotExistProperty2);
+
+declare const omitNotExistArrayProperty2: OmitDeep<[1, 2, 3], 'not_in_array'>;
+expectType<[1, 2, 3]>(omitNotExistArrayProperty2);
 
 declare const number: OmitDeep<Testing, 'object.number'>;
 expectType<{object: Omit<BaseType, 'number'>}>(number);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
### change:
before
```ts
OmitDeep<{a: string}, 'bbb'> // 'bbb' throw ts error
```
now
```ts
OmitDeep<{a: string}, 'bbb'> // no error and code hints are working
```

### fixed:
before
```ts
type A = OmitDeep<{a: string}, 'bbb'>
// type A = never
```
now
```ts
type A = OmitDeep<{a: string}, 'bbb'>
// type A = {a: string}
```