### PR TITLE
`SetParameterType`: Fix compatibility with TypeScript 5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"test": "xo && tsd && tsc && node script/test/source-files-extension.js"
+		"test": "xo && tsd && tsc && npm run test:set-parameter-type && node script/test/source-files-extension.js",
+		"test:set-parameter-type": "tsc --noEmit test-d/set-parameter-type"
 	},
 	"files": [
 		"index.d.ts",

--- a/source/set-parameter-type.d.ts
+++ b/source/set-parameter-type.d.ts
@@ -1,5 +1,5 @@
 import type {IsUnknown} from './is-unknown';
-import type {StaticPartOfArray} from './internal';
+import type {StaticPartOfArray, VariablePartOfArray} from './internal';
 import type {UnknownArray} from './unknown-array';
 
 /**
@@ -32,7 +32,10 @@ type MergeObjectToArray<TArray extends UnknownArray, TObject, TArrayCopy extends
 		? number extends TObject['length']
 			? TObject
 			: {
-				[K in keyof TArray]: K extends keyof TObject ? TObject[K] : TArray[K]
+				[K in keyof TArray]:
+				number extends K
+					?	VariablePartOfArray<TArray>[number]
+					: K extends keyof TObject ? TObject[K] : TArray[K]
 			}
 		: TObject extends object
 			// If `TObject` is a object witch key is number like `{0: string, 1: number}`

--- a/source/set-parameter-type.d.ts
+++ b/source/set-parameter-type.d.ts
@@ -34,7 +34,7 @@ type MergeObjectToArray<TArray extends UnknownArray, TObject, TArrayCopy extends
 			: {
 				[K in keyof TArray]:
 				number extends K
-					?	VariablePartOfArray<TArray>[number]
+					? VariablePartOfArray<TArray>[number]
 					: K extends keyof TObject ? TObject[K] : TArray[K]
 			}
 		: TObject extends object

--- a/test-d/set-parameter-type.ts
+++ b/test-d/set-parameter-type.ts
@@ -22,9 +22,9 @@ expectType<(a: string, b: string, c: boolean, ...args: boolean[]) => null>(test2
 test2('1', '2', true, true);
 
 // Test another define way
-declare const test3: SetParameterType<typeof fn, [a: string, b: boolean]>;
-expectType<(a: string, b: boolean, c: Object, ...args: boolean[]) => null>(test3);
-test3('1', true, {}, true);
+declare const test3: SetParameterType<typeof fn, [a: 'a', b: 'b']>;
+expectType<(a: 'a', b: 'b', c: Object, ...args: boolean[]) => null>(test3);
+test3('a', 'b', {}, true);
 
 // Test `...args` parameter
 declare const testargs: SetParameterType<typeof fn, {3: string}>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
related #831 