### PR TITLE
Update `xo`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,13 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"expect-type": "^0.15.0",
 		"tsd": "^0.28.1",
 		"typescript": "^5.2.2",
-		"xo": "^0.56.0"
+		"xo": "^0.58.0"
 	},
 	"xo": {
 		"rules": {
@@ -50,7 +50,11 @@
 			"import/extensions": "off",
 			"@typescript-eslint/no-redeclare": "off",
 			"@typescript-eslint/no-confusing-void-expression": "off",
-			"@typescript-eslint/no-unsafe-argument": "off"
+			"@typescript-eslint/no-unsafe-argument": "off",
+			"object-curly-newline": ["error", {
+				"multiline": true,
+				"consistent": true
+			}]
 		}
 	},
 	"tsd": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"test": "xo && tsd && tsc && npm run test:set-parameter-type && node script/test/source-files-extension.js",
-		"test:set-parameter-type": "tsc --noEmit test-d/set-parameter-type"
+		"test:set-parameter-type": "tsc --noEmit test-d/set-parameter-type",
+		"test:source-files-extension": "node script/test/source-files-extension.js",
+		"test:tsc": "tsc",
+		"test:tsd": "tsd",
+		"test:xo": "xo",
+		"test": "run-p test:*"
 	},
 	"files": [
 		"index.d.ts",
@@ -38,6 +42,7 @@
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "~0.7.0",
 		"expect-type": "^0.15.0",
+		"npm-run-all2": "^6.1.2",
 		"tsd": "^0.28.1",
 		"typescript": "^5.2.2",
 		"xo": "^0.58.0"

--- a/source/asyncify.d.ts
+++ b/source/asyncify.d.ts
@@ -29,4 +29,4 @@ const getFooAsync: AsyncifiedFooGetter = (someArg) => {
 
 @category Async
 */
-export type Asyncify<Fn extends (...arguments_: any[]) => any> = SetReturnType<Fn, Promise<Awaited<ReturnType<Fn>>>>;
+export type Asyncify<Function_ extends (...arguments_: any[]) => any> = SetReturnType<Function_, Promise<Awaited<ReturnType<Function_>>>>;

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -98,7 +98,7 @@ export type BuiltIns = Primitive | void | Date | RegExp;
 /**
 Matches non-recursive types.
 */
-export type NonRecursiveType = BuiltIns | Function | (new (...args: any[]) => unknown);
+export type NonRecursiveType = BuiltIns | Function | (new (...arguments_: any[]) => unknown);
 
 /**
 Returns a boolean for whether the given type is a plain key-value object.

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -38,7 +38,7 @@ Note that types containing overloaded functions are not made deeply readonly due
 */
 export type ReadonlyDeep<T> = T extends BuiltIns
 	? T
-	: T extends new (...args: any[]) => unknown
+	: T extends new (...arguments_: any[]) => unknown
 		? T // Skip class constructors
 		: T extends (...arguments_: any[]) => unknown
 			? {} extends ReadonlyObjectDeep<T>

--- a/source/set-parameter-type.d.ts
+++ b/source/set-parameter-type.d.ts
@@ -104,14 +104,14 @@ type HandleLog2 = SetParameterType<HandleMessage, {2: string}>;
 
 @category Function
 */
-export type SetParameterType<Fn extends (...arguments_: any[]) => unknown, P extends Record<number, unknown>> =
+export type SetParameterType<Function_ extends (...arguments_: any[]) => unknown, P extends Record<number, unknown>> =
 	// Just using `Parameters<Fn>` isn't ideal because it doesn't handle the `this` fake parameter.
-	Fn extends (this: infer ThisArg, ...arguments_: infer Arguments) => unknown
+	Function_ extends (this: infer ThisArgument, ...arguments_: infer Arguments) => unknown
 		? (
 			// If a function did not specify the `this` fake parameter, it will be inferred to `unknown`.
 			// We want to detect this situation just to display a friendlier type upon hovering on an IntelliSense-powered IDE.
-			IsUnknown<ThisArg> extends true
-				? (...arguments_: MergeObjectToArray<Arguments, P>) => ReturnType<Fn>
-				: (this: ThisArg, ...arguments_: MergeObjectToArray<Arguments, P>) => ReturnType<Fn>
+			IsUnknown<ThisArgument> extends true
+				? (...arguments_: MergeObjectToArray<Arguments, P>) => ReturnType<Function_>
+				: (this: ThisArgument, ...arguments_: MergeObjectToArray<Arguments, P>) => ReturnType<Function_>
 		)
-		: Fn;	// This part should be unreachable
+		: Function_;	// This part should be unreachable

--- a/source/set-return-type.d.ts
+++ b/source/set-return-type.d.ts
@@ -17,13 +17,13 @@ type MyWrappedFunction = SetReturnType<MyFunctionThatCanThrow, SomeOtherType | u
 
 @category Function
 */
-export type SetReturnType<Fn extends (...arguments_: any[]) => any, TypeToReturn> =
+export type SetReturnType<Function_ extends (...arguments_: any[]) => any, TypeToReturn> =
 	// Just using `Parameters<Fn>` isn't ideal because it doesn't handle the `this` fake parameter.
-	Fn extends (this: infer ThisArg, ...arguments_: infer Arguments) => any ? (
+	Function_ extends (this: infer ThisArgument, ...arguments_: infer Arguments) => any ? (
 		// If a function did not specify the `this` fake parameter, it will be inferred to `unknown`.
 		// We want to detect this situation just to display a friendlier type upon hovering on an IntelliSense-powered IDE.
-		IsUnknown<ThisArg> extends true ? (...arguments_: Arguments) => TypeToReturn : (this: ThisArg, ...arguments_: Arguments) => TypeToReturn
+		IsUnknown<ThisArgument> extends true ? (...arguments_: Arguments) => TypeToReturn : (this: ThisArgument, ...arguments_: Arguments) => TypeToReturn
 	) : (
 		// This part should be unreachable, but we make it meaningful just in case…
-		(...arguments_: Parameters<Fn>) => TypeToReturn
+		(...arguments_: Parameters<Function_>) => TypeToReturn
 	);

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -68,6 +68,7 @@ declare namespace TsConfigJson {
 			| 'es2022'
 			| 'esnext';
 
+		// eslint-disable-next-line unicorn/prevent-abbreviations
 		export type Lib =
 			| 'ES5'
 			| 'ES6'

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -10,20 +10,20 @@ class Foo {
 	method(): void {}
 }
 
-function fn(Cls: Constructor<Foo>): Foo {
+function function_(Cls: Constructor<Foo>): Foo {
 	return new Cls(1, '', 123);
 }
 
-function fn2(Cls: Constructor<Foo, [number, number]>): Foo {
+function function2(Cls: Constructor<Foo, [number, number]>): Foo {
 	expectError(new Cls(1, ''));
 	return new Cls(1, 2);
 }
 
-fn(Foo);
-fn2(Foo);
+function_(Foo);
+function2(Foo);
 
 // Prototype test
-type PositionProps = {
+type PositionProperties = {
 	top: number;
 	left: number;
 };
@@ -39,21 +39,21 @@ class Position {
 	}
 }
 
-declare const Bar: Class<PositionProps>;
+declare const Bar: Class<PositionProperties>;
 
-expectAssignable<Class<PositionProps>>(Position);
+expectAssignable<Class<PositionProperties>>(Position);
 
-expectNotAssignable<Class<PositionProps, [number]>>(Position);
+expectNotAssignable<Class<PositionProperties, [number]>>(Position);
 
-expectAssignable<Class<PositionProps, [number, number]>>(Position);
-expectAssignable<Constructor<PositionProps, [number, number]>>(Position);
+expectAssignable<Class<PositionProperties, [number, number]>>(Position);
+expectAssignable<Constructor<PositionProperties, [number, number]>>(Position);
 
 expectType<IsAny<typeof Bar['prototype']>>(false);
-expectType<PositionProps>(Position.prototype);
+expectType<PositionProperties>(Position.prototype);
 // /Prototype test
 
 expectError(new Position(17));
-expectAssignable<PositionProps>(new Position(17, 34));
+expectAssignable<PositionProperties>(new Position(17, 34));
 
 // Prototype test with type parameter
 class Building<T = unknown> {

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -24,7 +24,7 @@ type Example = {
 	interface: InterfaceA;
 	instanceA: ClassA;
 	ClassA: typeof ClassA;
-	function: (...args: string[]) => string;
+	function: (...arguments_: string[]) => string;
 	stringOrBoolean: string | boolean;
 	object: {
 		string: string;
@@ -126,8 +126,8 @@ expectType<{instanceA: ClassA}>(instancePick);
 declare const classPick: ConditionalPickDeep<Example, typeof ClassA>;
 expectType<{ClassA: typeof ClassA}>(classPick);
 
-declare const functionPick: ConditionalPickDeep<Example, (...args: string[]) => string>;
-expectType<{function: (...args: string[]) => string}>(functionPick);
+declare const functionPick: ConditionalPickDeep<Example, (...arguments_: string[]) => string>;
+expectType<{function: (...arguments_: string[]) => string}>(functionPick);
 
 declare const mapPick: ConditionalPickDeep<Example, Map<string, string>>;
 expectType<{map: Map<string, string>}>(mapPick);

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -3,115 +3,115 @@ import type {Exact, Opaque} from '../index';
 
 { // Spec - string type
 	type Type = string;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept string
 		const input = '';
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject number
 		const input = 1;
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject object
 		const input = {};
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - array
 	type Type = Array<{code: string; name?: string}>;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept array with required property only
 		const input = [{code: ''}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject readonly array
 		const input = [{code: ''}] as ReadonlyArray<{code: string}>;
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept array with optional property
 		const input = [{code: '', name: ''}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject array with excess property
 		const input = [{code: '', name: '', excessProperty: ''}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject invalid type
 		const input = '';
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - readonly array
 	type Type = ReadonlyArray<{code: string; name?: string}>;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept array with required property only
 		const input = [{code: ''}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept readonly array
 		const input = [{code: ''}] as ReadonlyArray<{code: string}>;
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept array with optional property
 		const input = [{code: '', name: ''}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject array with excess property
 		const input = [{code: '', name: '', excessProperty: ''}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject invalid type
 		const input = '';
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - object
 	type Type = {code: string; name?: string};
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept object with required property only
 		const input = {code: ''};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept object with optional property
 		const input = {code: '', name: ''};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject object with excess property
 		const input = {code: '', name: '', excessProperty: ''};
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject invalid type
 		const input = '';
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
@@ -123,8 +123,8 @@ import type {Exact, Opaque} from '../index';
 			};
 		};
 	};
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
-	fn({
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	function_({
 		outer: {
 			inner: {
 				field: 'foo',
@@ -135,43 +135,43 @@ import type {Exact, Opaque} from '../index';
 
 { // Spec - union - only object
 	type Type = {code: string} | {name: string};
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept type a
 		const input = {code: ''};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept type b
 		const input = {name: ''};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject intersection
 		const input = {name: '', code: ''};
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - union - mixture object/primitive
 	type Type = {code: string} | string;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept type a
 		const input = {code: ''};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept type b
 		const input = '';
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject intersection
 		const input = {name: '', code: ''};
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
@@ -183,34 +183,34 @@ import type {Exact, Opaque} from '../index';
 			name?: string;
 		};
 	};
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept input with required property only
 		const input = {body: {code: ''}};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should accept input with optional property
 		const input = {body: {code: '', name: ''}};
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should allow input with excess property
 		const input = {body: {code: '', name: '', excessProperty: ''}};
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - union of array
 	type Type = Array<{x: string}> & Array<{z: number}>;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept valid input
 		const input = [{
 			x: '',
 			z: 1,
 		}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -218,7 +218,7 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -226,7 +226,7 @@ import type {Exact, Opaque} from '../index';
 			x: '',
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject incorrect type
@@ -235,7 +235,7 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject excess field
@@ -245,20 +245,20 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - union of readonly array + non readonly array
 	type Type = ReadonlyArray<{x: string}> & Array<{z: number}>;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept valid input
 		const input = [{
 			x: '',
 			z: 1,
 		}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -266,7 +266,7 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -274,7 +274,7 @@ import type {Exact, Opaque} from '../index';
 			x: '',
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject incorrect type
@@ -283,7 +283,7 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject excess field
@@ -293,13 +293,13 @@ import type {Exact, Opaque} from '../index';
 			z: 1,
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
 { // Spec - union of array with nested fields
 	type Type = Array<{x: string}> & Array<{z: number; d: {e: string; f: boolean}}>;
-	const fn = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept valid input
 		const input = [{
@@ -310,7 +310,7 @@ import type {Exact, Opaque} from '../index';
 				f: true,
 			},
 		}];
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject excess field
@@ -324,7 +324,7 @@ import type {Exact, Opaque} from '../index';
 			},
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -337,7 +337,7 @@ import type {Exact, Opaque} from '../index';
 			},
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 
 	{ // It should reject missing field
@@ -350,7 +350,7 @@ import type {Exact, Opaque} from '../index';
 			},
 		}];
 		// @ts-expect-error
-		fn(input);
+		function_(input);
 	}
 }
 
@@ -382,9 +382,9 @@ import type {Exact, Opaque} from '../index';
 		name: SpecialName;
 	};
 
-	const fn = <T extends Exact<OnlyAcceptName, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<OnlyAcceptName, T>>(arguments_: T) => arguments_;
 
-	fn({
+	function_({
 		// The error before the workaround:
 		// Error: Type 'SpecialName' is not assignable to type 'never'
 		name: 1 as SpecialName,
@@ -395,10 +395,10 @@ import type {Exact, Opaque} from '../index';
 {
 	type TaggedNumber = Opaque<number, 'tag'>;
 
-	const fn = <T extends Exact<{a: TaggedNumber}, T>>(arguments_: T) => arguments_;
+	const function_ = <T extends Exact<{a: TaggedNumber}, T>>(arguments_: T) => arguments_;
 
-	fn({a: 1 as TaggedNumber});
-	expectError(fn({a: 1 as TaggedNumber, b: true}));
+	function_({a: 1 as TaggedNumber});
+	expectError(function_({a: 1 as TaggedNumber, b: true}));
 }
 
 // Spec - special test case for deep optional union
@@ -412,7 +412,7 @@ import type {Exact, Opaque} from '../index';
 		};
 	};
 
-	const fn = <InputT extends Exact<ParameterType, InputT>>(arguments_: InputT) => arguments_;
+	const function_ = <InputT extends Exact<ParameterType, InputT>>(arguments_: InputT) => arguments_;
 
 	// Test input with declared type
 	type Input = {
@@ -422,27 +422,27 @@ import type {Exact, Opaque} from '../index';
 			};
 		};
 	};
-	const varWithDeclaredType: Input = {
+	const variableWithDeclaredType: Input = {
 		outer: {
 			inner: {
 				union: 'foo',
 			},
 		},
 	};
-	fn(varWithDeclaredType);
+	function_(variableWithDeclaredType);
 
 	// Test input without declared type
-	const varWithoutDeclaredType = {
+	const variableWithoutDeclaredType = {
 		outer: {
 			inner: {
 				union: 'foo' as const,
 			},
 		},
 	};
-	fn(varWithoutDeclaredType);
+	function_(variableWithoutDeclaredType);
 
 	// Test input with plain object
-	fn({
+	function_({
 		outer: {
 			inner: {
 				union: 'foo',

--- a/test-d/global-this.ts
+++ b/test-d/global-this.ts
@@ -1,14 +1,14 @@
 import {expectType} from 'tsd';
 import type {GlobalThis} from '../index';
 
-type ExtraProps = GlobalThis & {
+type ExtraProperties = GlobalThis & {
 	readonly GLOBAL_TOKEN: string;
 };
 
 // Verify `globalThis` can be cast to a type which extends `GlobalThis`.
-expectType<string>((globalThis as ExtraProps).GLOBAL_TOKEN);
+expectType<string>((globalThis as ExtraProperties).GLOBAL_TOKEN);
 
 // Verify that object literals cannot be cast to a type which extends `GlobalThis`.
-declare function consumeExtraProps(extraProps: ExtraProps): void;
+declare function consumeExtraProperties(extraProperties: ExtraProperties): void;
 // @ts-expect-error
-consumeExtraProps(({something: 'value'}) as ExtraProps);
+consumeExtraProperties(({something: 'value'}) as ExtraProperties);

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -172,8 +172,8 @@ expectNotAssignable<JsonValue>(nonJsonWithInvalidToJSON.toJSON());
 declare const undefined: undefined;
 expectNotAssignable<JsonValue>(undefined);
 
-declare const fn: (_: any) => void;
-expectNotAssignable<JsonValue>(fn);
+declare const function_: (_: any) => void;
+expectNotAssignable<JsonValue>(function_);
 
 declare const symbol: symbol;
 expectNotAssignable<JsonValue>(symbol);
@@ -182,8 +182,8 @@ expectNotAssignable<JsonValue>(symbol);
 declare const plainUndefined: Jsonify<typeof undefined>;
 expectType<never>(plainUndefined);
 
-declare const plainFn: Jsonify<typeof fn>;
-expectType<never>(plainFn);
+declare const plainFunction: Jsonify<typeof function_>;
+expectType<never>(plainFunction);
 
 declare const plainSymbol: Jsonify<typeof symbol>;
 expectType<never>(plainSymbol);
@@ -192,8 +192,8 @@ expectType<never>(plainSymbol);
 declare const arrayMemberUndefined: Jsonify<Array<typeof undefined>>;
 expectType<null[]>(arrayMemberUndefined);
 
-declare const arrayMemberFn: Jsonify<Array<typeof fn>>;
-expectType<null[]>(arrayMemberFn);
+declare const arrayMemberFunction: Jsonify<Array<typeof function_>>;
+expectType<null[]>(arrayMemberFunction);
 
 declare const arrayMemberSymbol: Jsonify<Array<typeof symbol>>;
 expectType<null[]>(arrayMemberSymbol);
@@ -202,8 +202,8 @@ expectType<null[]>(arrayMemberSymbol);
 declare const objectValueUndefined: Jsonify<{keep: string; undefined: typeof undefined}>;
 expectType<{keep: string}>(objectValueUndefined);
 
-declare const objectValueFn: Jsonify<{keep: string; fn: typeof fn}>;
-expectType<{keep: string}>(objectValueFn);
+declare const objectValueFunction: Jsonify<{keep: string; fn: typeof function_}>;
+expectType<{keep: string}>(objectValueFunction);
 
 declare const objectValueSymbol: Jsonify<{keep: string; symbol: typeof symbol}>;
 expectType<{keep: string}>(objectValueSymbol);

--- a/test-d/required-deep.ts
+++ b/test-d/required-deep.ts
@@ -5,19 +5,19 @@ import type {RequiredDeep} from '../index';
 type Foo = {
 	baz?: string | undefined;
 	bar?: {
-		function?: ((...args: any[]) => void) | undefined;
-		functionFixedArity?: ((arg1: unknown, arg2: unknown) => void);
+		function?: ((...arguments_: any[]) => void) | undefined;
+		functionFixedArity?: ((argument1: unknown, argument2: unknown) => void);
 		functionWithOverload?: {
-			(arg: number): string;
-			(arg1: string, arg2: number): number;
+			(argument: number): string;
+			(argument1: string, argument2: number): number;
 		};
 		namespace?: {
-			(arg: number): string;
+			(argument: number): string;
 			key: string | undefined;
 		};
 		namespaceWithOverload: {
-			(arg: number): string;
-			(arg1: string, arg2: number): number;
+			(argument: number): string;
+			(argument1: string, argument2: number): number;
 			key: string | undefined;
 		};
 		object?: {key?: 'value'} | undefined;
@@ -46,19 +46,19 @@ type Foo = {
 type FooRequired = {
 	baz: string;
 	bar: {
-		function: (...args: any[]) => void;
-		functionFixedArity: (arg1: unknown, arg2: unknown) => void;
+		function: (...arguments_: any[]) => void;
+		functionFixedArity: (argument1: unknown, argument2: unknown) => void;
 		functionWithOverload: {
-			(arg: number): string;
-			(arg1: string, arg2: number): number;
+			(argument: number): string;
+			(argument1: string, argument2: number): number;
 		};
 		namespace: {
-			(arg: number): string;
+			(argument: number): string;
 			key: string;
 		};
 		namespaceWithOverload: {
-			(arg: number): string;
-			(arg1: string, arg2: number): number;
+			(argument: number): string;
+			(argument1: string, argument2: number): number;
 			key: string;
 		};
 		object: {key: 'value'};

--- a/test-d/set-non-nullable.ts
+++ b/test-d/set-non-nullable.ts
@@ -23,8 +23,8 @@ expectType<{a: number; b: string; c: boolean}>(variation5);
 
 // Does not throw type error in type predicate contexts.
 type Variation6Config = {a: boolean | null; b: boolean | null};
-const variant6Fn = <TProp extends keyof Variation6Config>(
+const variant6Function = <TProperty extends keyof Variation6Config>(
 	config: Variation6Config,
-	prop: TProp,
-): config is SetNonNullable<Variation6Config, TProp> => Boolean(config[prop]);
-expectNotAssignable<never>(variant6Fn); // Just to prevent unused error.
+	property: TProperty,
+): config is SetNonNullable<Variation6Config, TProperty> => Boolean(config[property]);
+expectNotAssignable<never>(variant6Function); // Just to prevent unused error.

--- a/test-d/set-parameter-type.ts
+++ b/test-d/set-parameter-type.ts
@@ -1,38 +1,38 @@
 import {expectType} from 'tsd';
 import type {SetParameterType} from '../index';
 
-function fn(_a: number, _b: string, _c: Object, ..._arguments: boolean[]) {
+function function_(_a: number, _b: string, _c: Object, ..._arguments: boolean[]) {
 	return null;
 }
 
-function fnWithThis(this: Window, _a: number) {
+function functionWithThis(this: Window, _a: number) {
 	return null;
 }
 
 const arrowFunction = (_a: number) => null;
 
 // Normal case
-declare const test1: SetParameterType<typeof fn, {1: boolean}>;
-expectType<(a: number, b: boolean, c: Object, ...args: boolean[]) => null>(test1);
+declare const test1: SetParameterType<typeof function_, {1: boolean}>;
+expectType<(a: number, b: boolean, c: Object, ...arguments_: boolean[]) => null>(test1);
 test1(1, true, {}, true);
 
 // Test multiple parameters
-declare const test2: SetParameterType<typeof fn, {0: string; 2: boolean}>;
-expectType<(a: string, b: string, c: boolean, ...args: boolean[]) => null>(test2);
+declare const test2: SetParameterType<typeof function_, {0: string; 2: boolean}>;
+expectType<(a: string, b: string, c: boolean, ...arguments_: boolean[]) => null>(test2);
 test2('1', '2', true, true);
 
 // Test another define way
-declare const test3: SetParameterType<typeof fn, [a: 'a', b: 'b']>;
-expectType<(a: 'a', b: 'b', c: Object, ...args: boolean[]) => null>(test3);
+declare const test3: SetParameterType<typeof function_, [a: 'a', b: 'b']>;
+expectType<(a: 'a', b: 'b', c: Object, ...arguments_: boolean[]) => null>(test3);
 test3('a', 'b', {}, true);
 
 // Test `...args` parameter
-declare const testargs: SetParameterType<typeof fn, {3: string}>;
-expectType<(a: number, b: string, c: Object, ...args: string[]) => null>(testargs);
+declare const testargs: SetParameterType<typeof function_, {3: string}>;
+expectType<(a: number, b: string, c: Object, ...arguments_: string[]) => null>(testargs);
 testargs(1, '1', {}, '1');
 
-declare const testargs2: SetParameterType<typeof fn, [string, number, number, ...boolean[]]>;
-expectType<(a: string, b: number, c: number, ...args: boolean[]) => null>(testargs2);
+declare const testargs2: SetParameterType<typeof function_, [string, number, number, ...boolean[]]>;
+expectType<(a: string, b: number, c: number, ...arguments_: boolean[]) => null>(testargs2);
 testargs2('1', 1, 1, true);
 
 // Test arrow function
@@ -40,6 +40,6 @@ declare const test5: SetParameterType<typeof arrowFunction, {0: string}>;
 expectType<(a: string) => null>(test5);
 
 // Test the function that has `this` parameter
-declare const testThis: SetParameterType<typeof fnWithThis, {0: string}>;
+declare const testThis: SetParameterType<typeof functionWithThis, {0: string}>;
 expectType<(this: Window, a: string) => null>(testThis);
 testThis.call(window, '1');

--- a/test-d/set-return-type.ts
+++ b/test-d/set-return-type.ts
@@ -14,15 +14,15 @@ expectType<(foo: string, bar: boolean) => void>(variation2);
 variation2.call(anything, 'foo', true);
 
 // With `thisArg` and without parameters.
-function fn1(this: Date): void {} // eslint-disable-line @typescript-eslint/no-empty-function
-declare const variation3: SetReturnType<typeof fn1, string[]>;
+function function1(this: Date): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+declare const variation3: SetReturnType<typeof function1, string[]>;
 expectType<(this: Date) => string[]>(variation3);
 variation3.call(new Date());
 expectError(variation3.call('not-a-date'));
 
 // With `thisArg` and with parameters.
-declare function fn2(this: Date, foo: any, bar: Array<[number]>): any;
-declare const variation4: SetReturnType<typeof fn2, never>;
+declare function function2(this: Date, foo: any, bar: Array<[number]>): any;
+declare const variation4: SetReturnType<typeof function2, never>;
 expectType<(this: Date, foo: any, bar: Array<[number]>) => never>(variation4);
 variation4.call(new Date(), anything, [[4], [7]]);
 expectError(variation4.call('not-a-date', anything, [[4], [7]]));

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -1,19 +1,19 @@
 import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Simplify} from '../index';
 
-type PositionProps = {
+type PositionProperties = {
 	top: number;
 	left: number;
 };
 
-type SizeProps = {
+type SizeProperties = {
 	width: number;
 	height: number;
 };
 
 // Flatten the type output to improve type hints shown in editors.
-const flattenProps = {top: 120, left: 240, width: 480, height: 600};
-expectType<Simplify<PositionProps & SizeProps>>(flattenProps);
+const flattenProperties = {top: 120, left: 240, width: 480, height: 600};
+expectType<Simplify<PositionProperties & SizeProperties>>(flattenProperties);
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface SomeInterface {

--- a/test-d/undefined-on-partial-deep.ts
+++ b/test-d/undefined-on-partial-deep.ts
@@ -26,7 +26,7 @@ type MixedType = UndefinedOnPartialDeep<{
 	symbol?: symbol;
 	date?: Date;
 	regExp?: RegExp;
-	func?: (args0: string, args1: number) => boolean;
+	func?: (arguments0: string, arguments1: number) => boolean;
 }>;
 expectAssignable<MixedType>({
 	required: '',


### PR DESCRIPTION
This is a straight up update and auto-fix

Only manual fix was the addition of this in one file:

```ts
// eslint-disable-next-line unicorn/prevent-abbreviations
```