### PR TITLE
Create grouped dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      development-dependencies:
+        dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,17 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       github-actions:
-        patterns: "*"
-
-  - package-ecosystem: "npm"
-    directory: "/"
+        patterns: '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
+      interval: 'weekly'
+    versioning-strategy: 'increase-if-necessary'
     groups:
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: 'weekly'
     groups:
       github-actions:
-        patterns: '*'
+        patterns:
+          - '*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
Fixes #840

I know @sindresorhus thinks this can get noisy, but I tried to make it as non-noisy as possible.

I would really love to get notified when eg. a new `tsd`, `xo` or similar dependency needs to be updated, and same for GitHub Actions.

This setup makes it so that at max one PR for npm and one PR for GitHub Actions will be created, and it will only be created/updated weekly, and for npm it will only create it if the version range _needs_ to be increased, so no needless bumping of the lower range of a version.

Can we give this a test and revisit it in a couple of weeks and see if it did get too noisy?