### PR TITLE
Add `IsInteger` and  `IsFloat`; Fix `Integer` and `Float` handing with edge case

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,6 +98,8 @@ export type {HasReadonlyKeys} from './source/has-readonly-keys';
 export type {WritableKeysOf} from './source/writable-keys-of';
 export type {HasWritableKeys} from './source/has-writable-keys';
 export type {Spread} from './source/spread';
+export type {IsInteger} from './source/is-integer';
+export type {IsFloat} from './source/is-float';
 export type {TupleToUnion} from './source/tuple-to-union';
 export type {IntRange} from './source/int-range';
 export type {IsEqual} from './source/is-equal';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "type-fest",
-	"version": "4.14.0",
+	"version": "4.15.0",
 	"description": "A collection of essential TypeScript types",
 	"license": "(MIT OR CC0-1.0)",
 	"repository": "sindresorhus/type-fest",

--- a/readme.md
+++ b/readme.md
@@ -269,6 +269,8 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - [`NegativeInteger`](source/numeric.d.ts) - A negative (`-∞ < x < 0`) `number` that is an integer.
 - [`NonNegativeInteger`](source/numeric.d.ts) - A non-negative (`0 <= x < ∞`) `number` that is an integer.
 - [`IsNegative`](source/numeric.d.ts) - Returns a boolean for whether the given number is a negative number.
+- [`IsFloat`](source/is-float.d.ts) - Returns a boolean for whether the given number is a float, like `1.5` or `-1.5`.
+- [`IsInteger`](source/is-integer.d.ts) - Returns a boolean for whether the given number is a integer, like `-5`, `1.0` or `100`.
 - [`GreaterThan`](source/greater-than.d.ts) - Returns a boolean for whether a given number is greater than another number.
 - [`GreaterThanOrEqual`](source/greater-than-or-equal.d.ts) - Returns a boolean for whether a given number is greater than or equal to another number.
 - [`LessThan`](source/less-than.d.ts) - Returns a boolean for whether a given number is less than another number.

--- a/source/is-float.d.ts
+++ b/source/is-float.d.ts
@@ -12,10 +12,13 @@ Use-case:
 ```
 type Float = IsFloat<1.5>;
 //=> true
+
 type IntegerWithDecimal = IsInteger<1.0>;
 //=> false
+
 type NegativeFloat = IsInteger<-1.5>;
 //=> true
+
 type Infinity_ = IsInteger<Infinity>;
 //=> false
 ```

--- a/source/is-float.d.ts
+++ b/source/is-float.d.ts
@@ -1,0 +1,30 @@
+import type {Zero} from './numeric';
+
+/**
+Returns a boolean for whether the given number is a float, like `1.5` or `-1.5`.
+
+It returns `false` for `Infinity`.
+
+Use-case:
+- If you want to make a conditional branch based on the result of whether a number is a float or not.
+
+@example
+```
+type Float = IsFloat<1.5>;
+//=> true
+type IntegerWithDecimal = IsInteger<1.0>;
+//=> false
+type NegativeFloat = IsInteger<-1.5>;
+//=> true
+type Infinity_ = IsInteger<Infinity>;
+//=> false
+```
+*/
+export type IsFloat<T> =
+T extends number
+	? `${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
+		? Decimal extends Zero
+			? false
+			: true
+		: false
+	: false;

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -14,18 +14,23 @@ Use-case:
 ```
 type Integer = IsInteger<1>;
 //=> true
+
 type IntegerWithDecimal = IsInteger<1.0>;
 //=> true
+
 type NegativeInteger = IsInteger<-1>;
 //=> true
+
 type Float = IsInteger<1.5>;
 //=> false
 
-//=> supported non-decimal numbers
+// Supported non-decimal numbers
 type OctalInteger: IsInteger<0o10>;
 //=> true
+
 type BinaryInteger: IsInteger<0b10>;
 //=> true
+
 type HexadecimalInteger: IsInteger<0x10>;
 //=> true
 ```

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -24,7 +24,8 @@ type NegativeInteger = IsInteger<-1>;
 type Float = IsInteger<1.5>;
 //=> false
 
-// Supported non-decimal numbers
+// Supports non-decimal numbers
+
 type OctalInteger: IsInteger<0o10>;
 //=> true
 

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -3,7 +3,7 @@ import type {IsFloat} from './is-float';
 import type {PositiveInfinity, NegativeInfinity} from './numeric';
 
 /**
-Returns a boolean for whether the given number is a float, like `-5`, `1` or `100`.
+Returns a boolean for whether the given number is a integer, like `-5`, `1.0` or `100`.
 
 Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
 

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -1,0 +1,42 @@
+import type {Not} from './internal';
+import type {IsFloat} from './is-float';
+import type {PositiveInfinity, NegativeInfinity} from './numeric';
+
+/**
+Returns a boolean for whether the given number is a float, like `-5`, `1` or `100`.
+
+Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
+
+Use-case:
+- If you want to make a conditional branch based on the result of whether a number is a intrger or not.
+
+@example
+```
+type Integer = IsInteger<1>;
+//=> true
+type IntegerWithDecimal = IsInteger<1.0>;
+//=> true
+type NegativeInteger = IsInteger<-1>;
+//=> true
+type Float = IsInteger<1.5>;
+//=> false
+
+//=> supported non-decimal numbers
+type OctalInteger: IsInteger<0o10>;
+//=> true
+type BinaryInteger: IsInteger<0b10>;
+//=> true
+type HexadecimalInteger: IsInteger<0x10>;
+//=> true
+```
+*/
+export type IsInteger<T> =
+T extends bigint
+	? true
+	: T extends number
+		? number extends T
+			? false
+			: T extends PositiveInfinity | NegativeInfinity
+				? false
+				: Not<IsFloat<T>>
+		: false;

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -1,50 +1,9 @@
-import type {Not} from './internal';
+import type {IsFloat} from './is-float';
+import type {IsInteger} from './is-integer';
 
 export type Numeric = number | bigint;
 
 type Zero = 0 | 0n;
-
-/**
-Returns the given number if it is a float, like `1.5` or `-1.5`.
-*/
-type IsFloat<T extends number> =
-`${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
-	? Decimal extends Zero
-		? false
-		: true
-	: false;
-
-/**
-Returns the given number if it is an integer, like `-5`, `1` or `100`.
-
-Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
-
-@example
-```
-type Integer = IsInteger<1>;
-//=> true
-type IntegerWithDecimal = IsInteger<1.0>;
-//=> true
-type NegativeInteger = IsInteger<-1>;
-//=> true
-type Float = IsInteger<1.5>;
-//=> false
-
-//=> supported non-decimal numbers
-type OctalInteger: IsInteger<0o10>;
-//=> true
-type BinaryInteger: IsInteger<0b10>;
-//=> true
-type HexadecimalInteger: IsInteger<0x10>;
-//=> true
-```
-*/
-type IsInteger<T extends number> =
-number extends T
-	? false
-	: T extends PositiveInfinity | NegativeInfinity
-		? false
-		: Not<IsFloat<T>>;
 
 /**
 Matches the hidden `Infinity` type.
@@ -93,7 +52,6 @@ export type Finite<T extends number> = T extends PositiveInfinity | NegativeInfi
 
 /**
 A `number` that is an integer.
-You can't pass a `bigint` as they are already guaranteed to be integers.
 
 Use-case: Validating and documenting parameters.
 
@@ -131,14 +89,13 @@ declare function setYear<T extends number>(length: Integer<T>): void;
 */
 // `${bigint}` is a type that matches a valid bigint literal without the `n` (ex. 1, 0b1, 0o1, 0x1)
 // Because T is a number and not a string we can effectively use this to filter out any numbers containing decimal points
-export type Integer<T extends number> =
+export type Integer<T> =
 	T extends unknown // To distributive type
 		? IsInteger<T> extends true ? T : never
 		: never; // Never happens
 
 /**
 A `number` that is not an integer.
-You can't pass a `bigint` as they are already guaranteed to be integers.
 
 Use-case: Validating and documenting parameters.
 
@@ -153,7 +110,7 @@ declare function setPercentage<T extends number>(length: Float<T>): void;
 
 @category Numeric
 */
-export type Float<T extends number> =
+export type Float<T> =
 T extends unknown // To distributive type
 	? IsFloat<T> extends true ? T : never
 	: never; // Never happens

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -105,6 +105,8 @@ A `number` that is not an integer.
 
 Use-case: Validating and documenting parameters.
 
+It does not accept `Infinity`.
+
 @example
 ```
 import type {Float} from 'type-fest';

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -3,6 +3,34 @@ export type Numeric = number | bigint;
 type Zero = 0 | 0n;
 
 /**
+Returns the given number if it is a float, like `1.5` or `-1.5`.
+*/
+type IsFloat<T extends number> = `${T}` extends `${number}.${number}` | `-${number}.${number}` ? true : false;
+
+/**
+Returns the given number if it is an integer, like `-5`, `1` or `100`.
+
+Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
+
+@example
+```ts
+type Integer = IsInteger<1>; // true
+type NegativeInteger = IsInteger<-1>; // true
+type Float = IsInteger<1.5>; // false
+
+// supported non-decimal numbers
+type OctalInteger: IsInteger<0o10>; // true
+type BinaryInteger: IsInteger<0b10>; // true
+type HexadecimalInteger: IsInteger<0x10>; // true
+```
+*/
+type IsInteger<T extends number> =
+number extends T ? false
+	: T extends PositiveInfinity | NegativeInfinity ? false
+		: IsFloat<T> extends true ? false
+			: T;
+
+/**
 Matches the hidden `Infinity` type.
 
 Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/32277) if you want to have this type as a built-in in TypeScript.
@@ -67,7 +95,10 @@ declare function setYear<T extends number>(length: Integer<T>): void;
 */
 // `${bigint}` is a type that matches a valid bigint literal without the `n` (ex. 1, 0b1, 0o1, 0x1)
 // Because T is a number and not a string we can effectively use this to filter out any numbers containing decimal points
-export type Integer<T extends number> = `${T}` extends `${bigint}` ? T : never;
+export type Integer<T extends number> =
+	T extends unknown // To distributive type
+		? IsInteger<T> extends true ? T : never
+		: never; // Never happens
 
 /**
 A `number` that is not an integer.
@@ -86,7 +117,10 @@ declare function setPercentage<T extends number>(length: Float<T>): void;
 
 @category Numeric
 */
-export type Float<T extends number> = T extends Integer<T> ? never : T;
+export type Float<T extends number> =
+T extends unknown // To distributive type
+	? IsFloat<T> extends true ? T : never
+	: never; // Never happens
 
 /**
 A negative (`-∞ < x < 0`) `number` that is not an integer.

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -5,7 +5,16 @@ type Zero = 0 | 0n;
 /**
 Returns the given number if it is a float, like `1.5` or `-1.5`.
 */
-type IsFloat<T extends number> = `${T}` extends `${number}.${number}` | `-${number}.${number}` ? true : false;
+type IsFloat<T extends number> =
+	`${T}` extends `${number}.${infer Decimal extends number}`
+		? Decimal extends Zero
+			? false
+			: true
+		: `${T}` extends `-${number}.${infer Decimal extends number}`
+			? Decimal extends Zero
+				? false
+				: true
+			: false;
 
 /**
 Returns the given number if it is an integer, like `-5`, `1` or `100`.
@@ -15,6 +24,7 @@ Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScr
 @example
 ```ts
 type Integer = IsInteger<1>; // true
+type IntegerWithDecimal = IsInteger<1.0>; // true
 type NegativeInteger = IsInteger<-1>; // true
 type Float = IsInteger<1.5>; // false
 
@@ -27,8 +37,9 @@ type HexadecimalInteger: IsInteger<0x10>; // true
 type IsInteger<T extends number> =
 number extends T ? false
 	: T extends PositiveInfinity | NegativeInfinity ? false
-		: IsFloat<T> extends true ? false
-			: T;
+		: IsFloat<T> extends true
+			? false
+			: true;
 
 /**
 Matches the hidden `Infinity` type.

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -6,15 +6,11 @@ type Zero = 0 | 0n;
 Returns the given number if it is a float, like `1.5` or `-1.5`.
 */
 type IsFloat<T extends number> =
-	`${T}` extends `${number}.${infer Decimal extends number}`
+	`${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
 		? Decimal extends Zero
 			? false
 			: true
-		: `${T}` extends `-${number}.${infer Decimal extends number}`
-			? Decimal extends Zero
-				? false
-				: true
-			: false;
+		: false;
 
 /**
 Returns the given number if it is an integer, like `-5`, `1` or `100`.

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -18,16 +18,23 @@ Returns the given number if it is an integer, like `-5`, `1` or `100`.
 Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
 
 @example
-```ts
-type Integer = IsInteger<1>; // true
-type IntegerWithDecimal = IsInteger<1.0>; // true
-type NegativeInteger = IsInteger<-1>; // true
-type Float = IsInteger<1.5>; // false
+```
+type Integer = IsInteger<1>;
+//=> true
+type IntegerWithDecimal = IsInteger<1.0>;
+//=> true
+type NegativeInteger = IsInteger<-1>;
+//=> true
+type Float = IsInteger<1.5>;
+//=> false
 
-// supported non-decimal numbers
-type OctalInteger: IsInteger<0o10>; // true
-type BinaryInteger: IsInteger<0b10>; // true
-type HexadecimalInteger: IsInteger<0x10>; // true
+//=> supported non-decimal numbers
+type OctalInteger: IsInteger<0o10>;
+//=> true
+type BinaryInteger: IsInteger<0b10>;
+//=> true
+type HexadecimalInteger: IsInteger<0x10>;
+//=> true
 ```
 */
 type IsInteger<T extends number> =
@@ -87,6 +94,26 @@ A `number` that is an integer.
 You can't pass a `bigint` as they are already guaranteed to be integers.
 
 Use-case: Validating and documenting parameters.
+
+@example
+```
+type Integer = Integer<1>;
+//=> 1
+type IntegerWithDecimal = Integer<1.0>;
+//=> 1
+type NegativeInteger = Integer<-1>;
+//=> -1
+type Float = Integer<1.5>;
+//=> never
+
+//=> supported non-decimal numbers
+type OctalInteger: Integer<0o10>;
+//=> 0o10
+type BinaryInteger: Integer<0b10>;
+//=> 0b10
+type HexadecimalInteger: Integer<0x10>;
+//=> 0x10
+```
 
 @example
 ```

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -1,3 +1,5 @@
+import type {Not} from './internal';
+
 export type Numeric = number | bigint;
 
 type Zero = 0 | 0n;
@@ -6,11 +8,11 @@ type Zero = 0 | 0n;
 Returns the given number if it is a float, like `1.5` or `-1.5`.
 */
 type IsFloat<T extends number> =
-	`${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
-		? Decimal extends Zero
-			? false
-			: true
-		: false;
+`${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
+	? Decimal extends Zero
+		? false
+		: true
+	: false;
 
 /**
 Returns the given number if it is an integer, like `-5`, `1` or `100`.
@@ -38,11 +40,11 @@ type HexadecimalInteger: IsInteger<0x10>;
 ```
 */
 type IsInteger<T extends number> =
-number extends T ? false
-	: T extends PositiveInfinity | NegativeInfinity ? false
-		: IsFloat<T> extends true
-			? false
-			: true;
+number extends T
+	? false
+	: T extends PositiveInfinity | NegativeInfinity
+		? false
+		: Not<IsFloat<T>>;
 
 /**
 Matches the hidden `Infinity` type.

--- a/test-d/is-float.ts
+++ b/test-d/is-float.ts
@@ -1,0 +1,17 @@
+import {expectType} from 'tsd';
+import type {IsFloat, PositiveInfinity} from '../index';
+
+expectType<false>({} as IsFloat<0>);
+expectType<false>({} as IsFloat<1>);
+expectType<false>({} as IsFloat<1.0>); // eslint-disable-line unicorn/no-zero-fractions
+expectType<true>({} as IsFloat<1.5>);
+expectType<false>({} as IsFloat<-1>);
+expectType<false>({} as IsFloat<number>);
+expectType<false>({} as IsFloat<0o10>);
+expectType<false>({} as IsFloat<1n>);
+expectType<false>({} as IsFloat<0n>);
+expectType<false>({} as IsFloat<0b10>);
+expectType<false>({} as IsFloat<0x10>);
+expectType<false>({} as IsFloat<1e+100>);
+expectType<false>({} as IsFloat<PositiveInfinity>);
+expectType<false>({} as IsFloat<typeof Number.POSITIVE_INFINITY>);

--- a/test-d/is-integer.ts
+++ b/test-d/is-integer.ts
@@ -15,4 +15,3 @@ expectType<true>({} as IsInteger<0x10>);
 expectType<true>({} as IsInteger<1e+100>);
 expectType<false>({} as IsInteger<PositiveInfinity>);
 expectType<false>({} as IsInteger<typeof Number.POSITIVE_INFINITY>);
-

--- a/test-d/is-integer.ts
+++ b/test-d/is-integer.ts
@@ -1,0 +1,18 @@
+import {expectType} from 'tsd';
+import type {IsInteger, PositiveInfinity} from '../index';
+
+expectType<true>({} as IsInteger<0>);
+expectType<true>({} as IsInteger<1>);
+expectType<true>({} as IsInteger<1.0>); // eslint-disable-line unicorn/no-zero-fractions
+expectType<false>({} as IsInteger<1.5>);
+expectType<true>({} as IsInteger<-1>);
+expectType<false>({} as IsInteger<number>);
+expectType<true>({} as IsInteger<0o10>);
+expectType<true>({} as IsInteger<1n>);
+expectType<true>({} as IsInteger<0n>);
+expectType<true>({} as IsInteger<0b10>);
+expectType<true>({} as IsInteger<0x10>);
+expectType<true>({} as IsInteger<1e+100>);
+expectType<false>({} as IsInteger<PositiveInfinity>);
+expectType<false>({} as IsInteger<typeof Number.POSITIVE_INFINITY>);
+

--- a/test-d/numeric.ts
+++ b/test-d/numeric.ts
@@ -21,6 +21,7 @@ expectType<1>(infinityMixed);
 
 // Integer
 declare const integer: Integer<1>;
+declare const integerWithDecimal: Integer<1.0>; // eslint-disable-line unicorn/no-zero-fractions
 declare const numberType: Integer<number>;
 declare const integerMixed: Integer<1 | 1.5 | -1>;
 declare const bigInteger: Integer<1e+100>;
@@ -31,6 +32,7 @@ declare const nonInteger: Integer<1.5>;
 declare const infinityInteger: Integer<PositiveInfinity | NegativeInfinity>;
 
 expectType<1>(integer);
+expectType<1>(integerWithDecimal);
 expectType<never>(numberType);
 expectType<1 | -1>(integerMixed);
 expectType<1e+100>(bigInteger);

--- a/test-d/numeric.ts
+++ b/test-d/numeric.ts
@@ -21,25 +21,35 @@ expectType<1>(infinityMixed);
 
 // Integer
 declare const integer: Integer<1>;
-declare const integerMixed: Integer<1 | 1.5>;
+declare const numberType: Integer<number>;
+declare const integerMixed: Integer<1 | 1.5 | -1>;
+declare const bigInteger: Integer<1e+100>;
+declare const octalInteger: Integer<0o10>;
+declare const binaryInteger: Integer<0b10>;
+declare const hexadecimalInteger: Integer<0x10>;
 declare const nonInteger: Integer<1.5>;
 declare const infinityInteger: Integer<PositiveInfinity | NegativeInfinity>;
 
 expectType<1>(integer);
-expectType<never>(integerMixed); // This may be undesired behavior
+expectType<never>(numberType);
+expectType<1 | -1>(integerMixed);
+expectType<1e+100>(bigInteger);
+expectType<0o10>(octalInteger);
+expectType<0b10>(binaryInteger);
+expectType<0x10>(hexadecimalInteger);
 expectType<never>(nonInteger);
 expectType<never>(infinityInteger);
 
 // Float
 declare const float: Float<1.5>;
-declare const floatMixed: Float<1 | 1.5>;
+declare const floatMixed: Float<1 | 1.5 | -1.5>;
 declare const nonFloat: Float<1>;
 declare const infinityFloat: Float<PositiveInfinity | NegativeInfinity>;
 
 expectType<1.5>(float);
-expectType<1.5>(floatMixed);
+expectType<1.5 | -1.5>(floatMixed);
 expectType<never>(nonFloat);
-expectType<PositiveInfinity | NegativeInfinity>(infinityFloat); // According to Number.isInteger
+expectType<never>(infinityFloat);
 
 // Negative
 declare const negative: Negative<-1 | -1n | 0 | 0n | 1 | 1n>;

--- a/test-d/numeric.ts
+++ b/test-d/numeric.ts
@@ -30,6 +30,8 @@ declare const binaryInteger: Integer<0b10>;
 declare const hexadecimalInteger: Integer<0x10>;
 declare const nonInteger: Integer<1.5>;
 declare const infinityInteger: Integer<PositiveInfinity | NegativeInfinity>;
+const infinityValue = Number.POSITIVE_INFINITY;
+declare const infinityInteger2: Integer<typeof infinityValue>;
 
 expectType<1>(integer);
 expectType<1>(integerWithDecimal);
@@ -41,6 +43,7 @@ expectType<0b10>(binaryInteger);
 expectType<0x10>(hexadecimalInteger);
 expectType<never>(nonInteger);
 expectType<never>(infinityInteger);
+expectType<never>(infinityInteger2);
 
 // Float
 declare const float: Float<1.5>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
fixed: #637 

Breaking but I think it's the corrent changes:
```ts
type Change1 = Integer<1 | 1.5>
// latest version => never // auther commented: This may be undesired behavior
// this PR        => 1

type Change2 = Integer<1e+100>
// latest version => never
// this PR        => 1e+100 // Number.IsInteger(1e+100) is true

type Change3 = Float<PositiveInfinity>
// latest version => PositiveInfinity
// this PR        => never // Infinity isn't a float.
```

And clarifies how to deal with some special number type like '1.0', '0x10' and negative number