### PR TITLE
Update single-key-object.d.ts to use direct import path

### DIFF
--- a/source/single-key-object.d.ts
+++ b/source/single-key-object.d.ts
@@ -1,4 +1,4 @@
-import type {IfEmptyObject} from '../index';
+import type {IfEmptyObject} from './if-empty-object';
 import type {IsUnion} from './internal';
 
 /**


### PR DESCRIPTION
In general, it doesn't make sense for source files to cyclically import the root index file.