### PR TITLE
Fix bad expectNotAssignableCalls calls in unknown-array.ts unit test

### DIFF
--- a/test-d/unknown-array.ts
+++ b/test-d/unknown-array.ts
@@ -12,11 +12,11 @@ expectAssignable<UnknownArray>([]);
 expectAssignable<UnknownArray>(['foo']);
 
 expectNotAssignable<UnknownArray>(null);
-expectNotAssignable(undefined);
-expectNotAssignable({});
-expectNotAssignable({0: 1});
-expectNotAssignable(1);
-expectNotAssignable(Date);
+expectNotAssignable<UnknownArray>(undefined);
+expectNotAssignable<UnknownArray>({});
+expectNotAssignable<UnknownArray>({0: 1});
+expectNotAssignable<UnknownArray>(1);
+expectNotAssignable<UnknownArray>(Date);
 
 type IsArray<T> = T extends UnknownArray ? true : false;
 


### PR DESCRIPTION
There were several `expectNotAssignableCalls` that were not actually testing anything meaningful.