### PR TITLE
Don't make `Tagged` type compatibility dependent on type fest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
 		"compilerOptions": {
 			"noUnusedLocals": false
 		}
+	},
+	"dependencies": {
+		"tagged-tag": "^0.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
 		"json",
 		"generics"
 	],
+	"dependencies": {
+		"tagged-tag": "^0.1.0"
+	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^7.0.0",
 		"expect-type": "^1.2.1",
@@ -96,8 +99,5 @@
 		"compilerOptions": {
 			"noUnusedLocals": false
 		}
-	},
-	"dependencies": {
-		"tagged-tag": "^0.1.0"
 	}
 }

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -1,4 +1,4 @@
-declare const tag: unique symbol;
+import type tag from 'tagged-tag';
 
 export type TagContainer<Token> = {
 	readonly [tag]: Token;
@@ -254,3 +254,5 @@ export type UnwrapOpaque<OpaqueType extends TagContainer<unknown>> =
 		: OpaqueType extends Opaque<infer Type, OpaqueType[typeof tag]>
 			? Type
 			: OpaqueType;
+
+export { type default as tag } from 'tagged-tag';

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -255,4 +255,4 @@ export type UnwrapOpaque<OpaqueType extends TagContainer<unknown>> =
 			? Type
 			: OpaqueType;
 
-export { type default as tag } from 'tagged-tag';
+export {type default as tag} from 'tagged-tag';


### PR DESCRIPTION
Since removing `Opaque`/`UnwrapOpaque` is obviously gonna require a new major version, I wanted to put this PR up now, in case it makes sense to land both changes in the same major version.

This PR switches the `tag` key used by the `Tagged` type to be a string rather than a symbol, undoing [this commit](https://github.com/causaly/type-fest/commit/7f63a6e7e0884cebd11b645c42a17041969add94). The rationale for that, which I've summarized from [this comment](https://github.com/sindresorhus/type-fest/issues/708#issuecomment-1769357978) is:

1. It's easy for two different copies of `type-fest` to end up installed in a project. Consider a dependency tree like:

    ```
    @my-company/app
    ├─┬ @my-company/types
    │ └── type-fest
    ├─┬ @my-company/some-internal-library
    │ └─┬ @my-company/types
    │   └── type-fest
    └── type-fest
    ```

   Depending on the version of `type-fest` installed at the root (i.e., by the `@my-company/app` package) and the version of the `@my-company/types` package used the chosen version of `@my-company/some-internal-library`, npm may be forced to install multiple `type-fest` copies.

2. When multiple type-fest copies are present, a `Tagged` type produced by one copy is not assignable to a `Tagged` type produced by another copy _even if the types have the same tag names, tag metadata, and base/untagged type_, because Typescript sees the `tag` symbol from each copy of `type-fest` as distinct.

   This is weird behavior, as it ends up making assignability dependent on exactly how/when npm chooses to dedupe packages, which isn't even necessarily stable as new packages are installed or as npm is updated or as installed packages are updated.

   In the example dependency tree above, it means that: if `@my-company/some-internal-library` returns a tagged type from its copy of the `@my-company/types` package, that type may not be assignable to the copy of that same type exported by the copy of `@my-company/types` that `@my-company/app` is depending on directly — even if the tagged type hasn't changed (in terms of its tag names/tag metadata/base type).

This also happens to make `Record<string, T>` taggable (solving https://github.com/sindresorhus/type-fest/issues/708), at the expense of `Record<symbol, T>` not being taggable (which seems like a good tradeoff).

Given that type-fest used a string-based key for many years, I don't think this poses any big issues, but there would be some small user-facing changes. For example, `keyof Tagged<{ foo: string }, 'SomeTag'>` would become `'foo' | '__type-fest-tag__'` instead of `'foo' | typeof tag`; that's not fundamentally different, but  it's maybe a tad less clear. It would probably be helpful too, at that point, for `type-fest` to export a string literal type with the name of the magic tag string (i.e., `"__type-fest-tag__"`), so that users can do `Exclude<keyof Tagged, TypeFestTagKey>`, in much the same way they might've had to do `Exclude<keyof Tagged, symbol>` before.