### PR TITLE
Add `Add` and `Or` to `index.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,8 @@ export type {ArraySplice} from './source/array-splice';
 export type {SetFieldType} from './source/set-field-type';
 export type {Paths} from './source/paths';
 export type {SharedUnionFieldsDeep} from './source/shared-union-fields-deep';
+export type {IsNull} from './source/is-null';
+export type {IfNull} from './source/if-null';
 export type {And} from './source/and';
 export type {Or} from './source/or';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,8 @@ export type {ArraySplice} from './source/array-splice';
 export type {SetFieldType} from './source/set-field-type';
 export type {Paths} from './source/paths';
 export type {SharedUnionFieldsDeep} from './source/shared-union-fields-deep';
+export type {And} from './source/and';
+export type {Or} from './source/or';
 
 // Template literal types
 export type {CamelCase} from './source/camel-case';


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

fixes: #877

Before this PR
```ts
import { And } from "type-fest"; // 1. Module '"type-fest"' has no exported member 'And'.

type A = And<true,true> // any
```

After this PR
```ts
import { And } from "type-fest";

type A = And<true,true> // true
```

