### PR TITLE
Fix ConditionalKeys - prevent never from being included unintentionally

### DIFF
--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -1,3 +1,5 @@
+import type {IfNever} from './if-never';
+
 /**
 Extract the keys from a type where the value type of the key extends the given `Condition`.
 
@@ -34,18 +36,11 @@ export type ConditionalKeys<Base, Condition> =
 {
 	// Map through all the keys of the given base type.
 	[Key in keyof Base]-?:
-	// Pick only keys with types extending the given `Condition` type.
-	Base[Key] extends Condition
-		// Retain this key since the condition passes
-		?
-			// If the condition extends never, only include the key if the value for that key is also never
-			[Condition] extends [never]
-				? Base[Key] extends never
-					? Key
-					: never
-				// Otherwise, only include the key if the value is not never (since never extends every other type)
-				: Base[Key] extends never ? never : Key
-		// Discard this key since the condition fails.
-		: never;
+		// Pick only keys with types extending the given `Condition` type.
+		Base[Key] extends Condition
+			// If the value for the key extends never, only include it if `Condition` also extends never
+			? IfNever<Base[Key], IfNever<Condition, Key, never>, Key>
+			// Discard this key since the condition fails.
+			: never;
 	// Convert the produced object into a union type of the keys which passed the conditional test.
 }[keyof Base];

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -36,11 +36,11 @@ export type ConditionalKeys<Base, Condition> =
 {
 	// Map through all the keys of the given base type.
 	[Key in keyof Base]-?:
-		// Pick only keys with types extending the given `Condition` type.
-		Base[Key] extends Condition
-			// If the value for the key extends never, only include it if `Condition` also extends never
-			? IfNever<Base[Key], IfNever<Condition, Key, never>, Key>
-			// Discard this key since the condition fails.
-			: never;
+	// Pick only keys with types extending the given `Condition` type.
+	Base[Key] extends Condition
+	// If the value for the key extends never, only include it if `Condition` also extends never
+		? IfNever<Base[Key], IfNever<Condition, Key, never>, Key>
+	// Discard this key since the condition fails.
+		: never;
 	// Convert the produced object into a union type of the keys which passed the conditional test.
 }[keyof Base];

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -37,18 +37,15 @@ export type ConditionalKeys<Base, Condition> =
 	// Pick only keys with types extending the given `Condition` type.
 	Base[Key] extends Condition
 		// Retain this key since the condition passes
-		? (
+		?
 			// If the condition extends never, only include the key if the value for that key is also never
 			Condition extends never
-				? (Base[Key] extends never
+				? Base[Key] extends never
 					? Key
 					: never
-				)
 				// Otherwise, only include the key if the value is not never (since never extends every other type)
 				: Base[Key] extends never ? never : Key
-		)
 		// Discard this key since the condition fails.
 		: never;
-
 	// Convert the produced object into a union type of the keys which passed the conditional test.
 }[keyof Base];

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -36,7 +36,7 @@ export type ConditionalKeys<Base, Condition> =
 	[Key in keyof Base]-?:
 	// Pick only keys with types extending the given `Condition` type.
 	Base[Key] extends Condition
-	// Retain this key since the condition passes.
+	// Retain this key since the condition passes, as long as the key is not never (which extends any other type).
 		? (Base[Key] extends never ? never : Key)
 	// Discard this key since the condition fails.
 		: never;

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -37,7 +37,7 @@ export type ConditionalKeys<Base, Condition> =
 	// Pick only keys with types extending the given `Condition` type.
 	Base[Key] extends Condition
 	// Retain this key since the condition passes.
-		? Key
+		? (Base[Key] extends never ? never : Key)
 	// Discard this key since the condition fails.
 		: never;
 

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -38,6 +38,7 @@ export type ConditionalKeys<Base, Condition> =
 	[Key in keyof Base]-?:
 	// Pick only keys with types extending the given `Condition` type.
 	Base[Key] extends Condition
+	// Retain this key
 	// If the value for the key extends never, only include it if `Condition` also extends never
 		? IfNever<Base[Key], IfNever<Condition, Key, never>, Key>
 	// Discard this key since the condition fails.

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -36,9 +36,18 @@ export type ConditionalKeys<Base, Condition> =
 	[Key in keyof Base]-?:
 	// Pick only keys with types extending the given `Condition` type.
 	Base[Key] extends Condition
-	// Retain this key since the condition passes, as long as the key is not never (which extends any other type).
-		? (Base[Key] extends never ? never : Key)
-	// Discard this key since the condition fails.
+		// Retain this key since the condition passes
+		? (
+			// If the condition extends never, only include the key if the value for that key is also never
+			Condition extends never
+				? (Base[Key] extends never
+					? Key
+					: never
+				)
+				// Otherwise, only include the key if the value is not never (since never extends every other type)
+				: Base[Key] extends never ? never : Key
+		)
+		// Discard this key since the condition fails.
 		: never;
 
 	// Convert the produced object into a union type of the keys which passed the conditional test.

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -39,7 +39,7 @@ export type ConditionalKeys<Base, Condition> =
 		// Retain this key since the condition passes
 		?
 			// If the condition extends never, only include the key if the value for that key is also never
-			Condition extends never
+			[Condition] extends [never]
 				? Base[Key] extends never
 					? Key
 					: never

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -14,3 +14,6 @@ expectType<'a'>(exampleConditionalKeys);
 
 declare const exampleConditionalKeysWithUndefined: ConditionalKeys<Example, string | undefined>;
 expectType<'a' | 'c'>(exampleConditionalKeysWithUndefined);
+
+declare const exampleConditionalKeysTargetingNever: ConditionalKeys<Example, never>;
+expectType<'e'>(exampleConditionalKeysTargetingNever);

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -6,6 +6,7 @@ type Example = {
 	b?: string | number;
 	c?: string;
 	d: Record<string, unknown>;
+	e: never;
 };
 
 declare const exampleConditionalKeys: ConditionalKeys<Example, string>;


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/878

The following minimal example doesn't work as expected with the minimal example, because it includes `d` in the result, even though the value is `never`

```ts
type ConditionalKeys<Base, Condition> =
{
	// Map through all the keys of the given base type.
	[Key in keyof Base]-?:
	// Pick only keys with types extending the given `Condition` type.
	Base[Key] extends Condition
	// Retain this key since the condition passes.
		? Key
	// Discard this key since the condition fails.
		: never;

	// Convert the produced object into a union type of the keys which passed the conditional test.
}[keyof Base];

type MyMap = {
	a: {
		b: string;
	};
	c: {
		html: string;
	};
	d: never;
};

type MyFilteredMap = ConditionalKeys<MyMap, {html: string}>;
```