### PR TITLE
`Jsonify`: Convert `undefined` to `null` in union element of array

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -12,7 +12,7 @@ import type {UnknownArray} from './unknown-array';
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
 type NeverToNull<T> = IsNever<T> extends true ? null : T;
-
+type UndefinedToNull<T> = T extends undefined ? null : T;
 // Handles tuples and arrays
 type JsonifyList<T extends UnknownArray> = T extends readonly []
 	? []
@@ -20,7 +20,7 @@ type JsonifyList<T extends UnknownArray> = T extends readonly []
 		? [NeverToNull<Jsonify<F>>, ...JsonifyList<R>]
 		: IsUnknown<T[number]> extends true
 			? []
-			: Array<T[number] extends NotJsonable ? null : Jsonify<T[number]>>;
+			: Array<T[number] extends NotJsonable ? null : Jsonify<UndefinedToNull<T[number]>>>;
 
 type FilterJsonableKeys<T extends object> = {
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -13,6 +13,7 @@ type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;
 
 type NeverToNull<T> = IsNever<T> extends true ? null : T;
 type UndefinedToNull<T> = T extends undefined ? null : T;
+
 // Handles tuples and arrays
 type JsonifyList<T extends UnknownArray> = T extends readonly []
 	? []

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -192,6 +192,9 @@ expectType<never>(plainSymbol);
 declare const arrayMemberUndefined: Jsonify<Array<typeof undefined>>;
 expectType<null[]>(arrayMemberUndefined);
 
+declare const arrayMemberUnionWithUndefined: Jsonify<Array<typeof undefined | typeof number>>;
+expectType<Array<null | number>>(arrayMemberUnionWithUndefined);
+
 declare const arrayMemberFunction: Jsonify<Array<typeof function_>>;
 expectType<null[]>(arrayMemberFunction);
 

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -195,6 +195,9 @@ expectType<null[]>(arrayMemberUndefined);
 declare const arrayMemberUnionWithUndefined: Jsonify<Array<typeof undefined | typeof number>>;
 expectType<Array<null | number>>(arrayMemberUnionWithUndefined);
 
+declare const arrayMemberUnionWithUndefinedDeep: Jsonify<Array<Array<typeof undefined | typeof number>> | {foo: Array<typeof undefined | typeof number>}>;
+expectType<Array<Array<null | number>> | {foo: Array<null | number>}>(arrayMemberUnionWithUndefinedDeep);
+
 declare const arrayMemberFunction: Jsonify<Array<typeof function_>>;
 expectType<null[]>(arrayMemberFunction);
 


### PR DESCRIPTION
`Jsonify` doesn't handle correctly union type with undefined in array.
You get `[1, null]` from `JSON.parse(JSON.stringify([1, undefined]))`.
Like tuple type, `Array<undefined | T>` should be converted to `Array<null | T>`