### PR TITLE
fix(Exact): fix support for Date in union

### DIFF
--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -1,7 +1,7 @@
 import type {ArrayElement, ObjectValue} from './internal';
-import type {Opaque, TagContainer} from './opaque';
 import type {IsEqual} from './is-equal';
 import type {KeysOfUnion} from './keys-of-union';
+import type {JsonObject} from './basic';
 
 /**
 Create a type from `ParameterType` and `InputType` and change keys exclusive to `InputType` to `never`.
@@ -57,7 +57,6 @@ export type Exact<ParameterType, InputType> =
 		: ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
 			// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
 			: ParameterType extends readonly unknown[] ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-				// Leave tagged types as-is. We could try to make the untagged part Exact, and just leave the tag as-is, but that seems to create instanitation excessively deep errors.
-				: ParameterType extends TagContainer<unknown> ? ParameterType
-					: ParameterType extends object ? ExactObject<ParameterType, InputType>
-						: ParameterType;
+				// Only apply Exact for pure object types. For types from a class, leave it unchanged to TypeScript to handle.
+				: ParameterType extends JsonObject ? ExactObject<ParameterType, InputType>
+					: ParameterType;

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -450,3 +450,20 @@ import type {Exact, Opaque} from '../index';
 		},
 	});
 }
+
+// Spec - special test case for Date type + union
+// @see https://github.com/sindresorhus/type-fest/issues/896
+{
+	type A = {
+		a: string;
+		b?: Date | null;
+	};
+
+	const function_ = <T extends Exact<A, T>>(arguments_: T) => arguments_;
+
+	function_({a: 'a'});
+	function_({a: 'a', b: new Date()});
+	function_({a: 'a', b: new Date() as Date | null});
+	// @ts-expect-error
+	function_({a: 'a', b: 1});
+}


### PR DESCRIPTION
## What's changed

- Use JsonObject to only apply Exact check for simple object. Type from a class should rely on the native TypeScript check

## Why?

- Fix #896
