### PR TITLE
Ensure all `RequireX` types' second param is optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -347,7 +347,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - `PartialBy` - See [`SetOptional`](source/set-optional.d.ts)
 - `RecordDeep`- See [`Schema`](source/schema.d.ts)
 - `Mutable`- See [`Writable`](source/writable.d.ts)
-- `RequireOnlyOne` - See [`RequireExactlyOne`](source/require-exactly-one.d.ts)
+- `RequireOnlyOne`, `OneOf` - See [`RequireExactlyOne`](source/require-exactly-one.d.ts)
 - `AtMostOne` - See [`RequireOneOrNone`](source/require-one-or-none.d.ts)
 - `AllKeys` - See [`KeysOfUnion`](source/keys-of-union.d.ts)
 - `Branded` - See [`Tagged`](source/opaque.d.ts)

--- a/source/require-all-or-none.d.ts
+++ b/source/require-all-or-none.d.ts
@@ -36,7 +36,7 @@ const responder2: RequireAllOrNone<Responder, 'text' | 'json'> = {
 
 @category Object
 */
-export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = never> = (
+export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> = (
 	| RequireAll<ObjectType, KeysType>
 	| RequireNone<KeysType>
 ) & Omit<ObjectType, KeysType>; // The rest of the keys.

--- a/test-d/require-all-or-none.ts
+++ b/test-d/require-all-or-none.ts
@@ -1,4 +1,3 @@
-import {expectAssignable} from 'tsd';
 import type {RequireAllOrNone} from '../index';
 
 type SystemMessages = {
@@ -11,7 +10,7 @@ type SystemMessages = {
 };
 
 type ValidMessages = RequireAllOrNone<SystemMessages, 'macos' | 'linux'>;
-const test = (_: ValidMessages): void => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+declare const test: (_: ValidMessages) => void;
 
 test({default: 'hello'});
 test({macos: 'yo', linux: 'sup', optional: 'howdy', default: 'hello'});
@@ -23,5 +22,12 @@ test({macos: 'hey', default: 'hello'});
 // @ts-expect-error
 test({linux: 'hey', default: 'hello'});
 
-declare const oneWithoutKeys: RequireAllOrNone<{a: number; b: number}>;
-expectAssignable<{a: number; b: number}>(oneWithoutKeys);
+declare const testWithoutKeys: (_: RequireAllOrNone<{a: number; b: number}>) => void;
+
+testWithoutKeys({});
+testWithoutKeys({a: 1, b: 2});
+
+// @ts-expect-error
+testWithoutKeys({a: 1});
+// @ts-expect-error
+testWithoutKeys({b: 2});

--- a/test-d/require-at-least-one.ts
+++ b/test-d/require-at-least-one.ts
@@ -11,13 +11,8 @@ type SystemMessages = {
 	optional?: string;
 };
 
-type MessageBoard<M> = (messages: M) => string;
-
-type ValidMessages = RequireAtLeastOne<
-SystemMessages,
-'macos' | 'linux' | 'windows'
->;
-const test = (_: ValidMessages): void => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+type ValidMessages = RequireAtLeastOne<SystemMessages, 'macos' | 'linux' | 'windows'>;
+declare const test: (_: ValidMessages) => void;
 
 test({macos: 'hey', default: 'hello'});
 test({linux: 'sup', default: 'hello', optional: 'howdy'});
@@ -30,13 +25,16 @@ test({macos: 'hey'});
 // @ts-expect-error
 test({default: 'hello'});
 
-declare const atLeastOneWithoutKeys: RequireAtLeastOne<{
-	a: number;
-	b: number;
-}>;
-expectAssignable<{a: number; b?: number} | {a?: number; b: number}>(
-	atLeastOneWithoutKeys,
-);
+declare const testWithoutKeys: (_: RequireAtLeastOne<{a: number; b: number}>) => void;
+
+testWithoutKeys({a: 1});
+testWithoutKeys({b: 2});
+testWithoutKeys({a: 1, b: 2});
+
+// @ts-expect-error
+testWithoutKeys({});
+
+type MessageBoard<M> = (messages: M) => string;
 
 expectAssignable<MessageBoard<ValidMessages>>(
 	({macos = '', linux = '🐧', windows = '⊞'}) =>

--- a/test-d/require-exactly-one.ts
+++ b/test-d/require-exactly-one.ts
@@ -1,4 +1,3 @@
-import {expectAssignable} from 'tsd';
 import type {RequireExactlyOne} from '../index';
 
 type SystemMessages = {
@@ -11,7 +10,7 @@ type SystemMessages = {
 };
 
 type ValidMessages = RequireExactlyOne<SystemMessages, 'macos' | 'linux'>;
-const test = (_: ValidMessages): void => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+declare const test: (_: ValidMessages) => void;
 
 test({macos: 'hey', default: 'hello'});
 test({linux: 'sup', optional: 'howdy', default: 'hello'});
@@ -21,7 +20,12 @@ test({});
 // @ts-expect-error
 test({macos: 'hey', linux: 'sup', default: 'hello'});
 
-declare const oneWithoutKeys: RequireExactlyOne<{a: number; b: number}>;
-expectAssignable<{a: number} | {b: number}>(oneWithoutKeys);
+declare const testWithoutKeys: (_: RequireExactlyOne<{a: number; b: number}>) => void;
+
+testWithoutKeys({a: 1});
+testWithoutKeys({b: 2});
+
 // @ts-expect-error
-expectAssignable<{a: number; b: number}>(oneWithoutKeys);
+testWithoutKeys({});
+// @ts-expect-error
+testWithoutKeys({a: 1, b: 2});


### PR DESCRIPTION
Fixes #847.

Makes the second param (`KeysType`) of `RequireAllOrNone` optional and updates tests accordingly. Also documents an additional alternative type (`OneOf` for `RequireExactlyOne`).