### PR TITLE
Conditionally add node/DOM types to StructuredCloneable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ export type {IfNull} from './source/if-null';
 export type {And} from './source/and';
 export type {Or} from './source/or';
 export type {NonEmptyTuple} from './source/non-empty-tuple';
-export type {FindGlobalType} from './source/find-global-type';
+export type {FindGlobalInstanceType, FindGlobalType} from './source/find-global-type';
 
 // Template literal types
 export type {CamelCase} from './source/camel-case';

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,6 +131,7 @@ export type {IfNull} from './source/if-null';
 export type {And} from './source/and';
 export type {Or} from './source/or';
 export type {NonEmptyTuple} from './source/non-empty-tuple';
+export type {FindGlobalType} from './source/find-global-type';
 
 // Template literal types
 export type {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,8 @@ Click the type names for complete docs.
 - [`And`](source/and.d.ts) - Returns a boolean for whether two given types are both true.
 - [`Or`](source/or.d.ts) - Returns a boolean for whether either of two given types are true.
 - [`NonEmptyTuple`](source/non-empty-tuple.d.ts) - Matches any non-empty tuple.
-- [`FindGlobalType`](source/find-global-type.d.ts) - Tries to find one or more types from their globally-defined constructors.
+- [`FindGlobalType`](source/find-global-type.d.ts) - Tries to find the type of a global with the given name. (See doc comment for limitations)
+- [`FindGlobalInstanceType`](source/find-global-type.d.ts) - Tries to find one or more types from their globally-defined constructors. (See doc comment for limitations)
 
 ### Type Guard
 

--- a/readme.md
+++ b/readme.md
@@ -203,8 +203,8 @@ Click the type names for complete docs.
 - [`And`](source/and.d.ts) - Returns a boolean for whether two given types are both true.
 - [`Or`](source/or.d.ts) - Returns a boolean for whether either of two given types are true.
 - [`NonEmptyTuple`](source/non-empty-tuple.d.ts) - Matches any non-empty tuple.
-- [`FindGlobalType`](source/find-global-type.d.ts) - Tries to find the type of a global with the given name. (See doc comment for limitations)
-- [`FindGlobalInstanceType`](source/find-global-type.d.ts) - Tries to find one or more types from their globally-defined constructors. (See doc comment for limitations)
+- [`FindGlobalType`](source/find-global-type.d.ts) - Tries to find the type of a global with the given name.
+- [`FindGlobalInstanceType`](source/find-global-type.d.ts) - Tries to find one or more types from their globally-defined constructors.
 
 ### Type Guard
 

--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,7 @@ Click the type names for complete docs.
 - [`And`](source/and.d.ts) - Returns a boolean for whether two given types are both true.
 - [`Or`](source/or.d.ts) - Returns a boolean for whether either of two given types are true.
 - [`NonEmptyTuple`](source/non-empty-tuple.d.ts) - Matches any non-empty tuple.
+- [`FindGlobalType`](source/find-global-type.d.ts) - Tries to find one or more types from their globally-defined constructors.
 
 ### Type Guard
 

--- a/source/find-global-type.d.ts
+++ b/source/find-global-type.d.ts
@@ -1,8 +1,7 @@
 /**
 Tries to find the type of a global with the given name.
 
-Limitations: Due to peculiarities with the behavior of `globalThis`, "globally defined" only includes `var`
-declarations in `declare global` blocks, not `let` or `const` declarations.
+Limitations: Due to peculiarities with the behavior of `globalThis`, "globally defined" only includes `var` declarations in `declare global` blocks, not `let` or `const` declarations.
 
 @example
 ```
@@ -27,9 +26,7 @@ Tries to find one or more types from their globally-defined constructors.
 
 Use-case: Conditionally referencing DOM types only when the DOM library present.
 
-*Limitations:* Due to peculiarities with the behavior of `globalThis`, "globally defined" has a narrow definition in
-this case. Declaring a class in a `declare global` block won't work, instead you must declare its type using an
-interface and declare its constructor as a `var` (*not* `let`/`const`) inside the `declare global` block.
+*Limitations:* Due to peculiarities with the behavior of `globalThis`, "globally defined" has a narrow definition in this case. Declaring a class in a `declare global` block won't work, instead you must declare its type using an interface and declare its constructor as a `var` (*not* `let`/`const`) inside the `declare global` block.
 
 @example
 ```

--- a/source/find-global-type.d.ts
+++ b/source/find-global-type.d.ts
@@ -1,0 +1,52 @@
+/**
+Tries to find one or more types from their globally-defined constructors.
+
+Use-case: Conditionally referencing DOM types only when the DOM library present.
+
+*Note:* Globally-defined has a narrow definition in this case due to peculiarities with the behavior of `globalThis`.
+Merely declaring a class in a `declare global` block won't work, instead you must declare its constructor as a `var`
+(not `let`/`const`) inside the `declare global` block. This typically is done using a combination of interface +
+constructor style, rather than the es6 class syntax.
+
+@example
+```
+import type {FindGlobalType} from 'type-fest';
+
+class Point {
+	constructor(public x: number, public y: number) {
+	}
+}
+
+type PointLike = Point | FindGlobalType<'DOMPoint'>;
+
+function doSomething(point: PointLike): number {
+	// ...
+}
+```
+
+@example
+```
+import type {FindGlobalType} from 'type-fest';
+
+declare global {
+	// ES6 class syntax won't add the key to `globalThis`
+	class Foo {}
+
+	// interface + constructor style works
+	interface Bar {}
+	interface BarConstructor {
+		new (): Bar;
+	}
+	var Bar: BarConstructor; // not let or const
+}
+
+type FindFoo = FindGlobalType<'Foo'>; // doesn't work
+type FindBar = FindGlobalType<'Bar'>; // works
+```
+
+@category Utilities
+*/
+export type FindGlobalType<Name extends string> =
+	Name extends string
+		? typeof globalThis extends Record<Name, new (...arguments: any[]) => infer T> ? T : never
+		: never;

--- a/source/find-global-type.d.ts
+++ b/source/find-global-type.d.ts
@@ -1,7 +1,7 @@
 /**
 Tries to find the type of a global with the given name.
 
-*Limitations:* Due to peculiarities with the behavior of `globalThis`, "globally defined" only includes `var`
+Limitations: Due to peculiarities with the behavior of `globalThis`, "globally defined" only includes `var`
 declarations in `declare global` blocks, not `let` or `const` declarations.
 
 @example
@@ -28,7 +28,7 @@ Tries to find one or more types from their globally-defined constructors.
 Use-case: Conditionally referencing DOM types only when the DOM library present.
 
 *Limitations:* Due to peculiarities with the behavior of `globalThis`, "globally defined" has a narrow definition in
-this case. Declaring an ES6 class in a `declare global` block won't work, instead you must declare its type using an
+this case. Declaring a class in a `declare global` block won't work, instead you must declare its type using an
 interface and declare its constructor as a `var` (*not* `let`/`const`) inside the `declare global` block.
 
 @example
@@ -36,8 +36,7 @@ interface and declare its constructor as a `var` (*not* `let`/`const`) inside th
 import type {FindGlobalInstanceType} from 'type-fest';
 
 class Point {
-	constructor(public x: number, public y: number) {
-	}
+	constructor(public x: number, public y: number) {}
 }
 
 type PointLike = Point | FindGlobalInstanceType<'DOMPoint'>;
@@ -48,16 +47,16 @@ type PointLike = Point | FindGlobalInstanceType<'DOMPoint'>;
 import type {FindGlobalInstanceType} from 'type-fest';
 
 declare global {
-	// ES6 class syntax won't add the key to `globalThis`
+	// Class syntax won't add the key to `globalThis`
 	class Foo {}
 
 	// interface + constructor style works
 	interface Bar {}
-	var Bar: new () => Bar; // not let or const
+	var Bar: new () => Bar; // Not let or const
 }
 
-type FindFoo = FindGlobalInstanceType<'Foo'>; // doesn't work
-type FindBar = FindGlobalInstanceType<'Bar'>; // works
+type FindFoo = FindGlobalInstanceType<'Foo'>; // Doesn't work
+type FindBar = FindGlobalInstanceType<'Bar'>; // Works
 ```
 
 @category Utilities

--- a/source/structured-cloneable.d.ts
+++ b/source/structured-cloneable.d.ts
@@ -1,4 +1,5 @@
 import type {TypedArray} from './typed-array';
+import type {FindGlobalType} from './find-global-type';
 
 type StructuredCloneablePrimitive =
 	| string
@@ -17,32 +18,34 @@ type StructuredCloneableData =
 	| Date
 	| Error
 	| RegExp
-	| TypedArray;
-// Requires DOM or @types/node
-//	| Blob
-//	| File
-// DOM exclusive types
-//	| AudioData
-//	| CropTarget
-//	| CryptoKey
-//	| DOMException
-//	| DOMMatrix
-//	| DOMMatrixReadOnly
-//	| DOMPoint
-//	| DOMPointReadOnly
-//	| DOMQuad
-//	| DOMRect
-//	| DOMRectReadOnly
-//	| FileList
-//	| FileSystemDirectoryHandle
-//	| FileSystemFileHandle
-//	| FileSystemHandle
-//	| GPUCompilationInfo
-//	| GPUCompilationMessage
-//	| ImageBitmap
-//	| ImageData
-//	| RTCCertificate
-//	| VideoFrame
+	| TypedArray
+	| FindGlobalType<
+	// DOM or Node types
+	| 'Blob'
+	| 'File'
+	// DOM exclusive types
+	| 'AudioData'
+	| 'CropTarget'
+	| 'CryptoKey'
+	| 'DOMException'
+	| 'DOMMatrix'
+	| 'DOMMatrixReadOnly'
+	| 'DOMPoint'
+	| 'DOMPointReadOnly'
+	| 'DOMQuad'
+	| 'DOMRect'
+	| 'DOMRectReadOnly'
+	| 'FileList'
+	| 'FileSystemDirectoryHandle'
+	| 'FileSystemFileHandle'
+	| 'FileSystemHandle'
+	| 'GPUCompilationInfo'
+	| 'GPUCompilationMessage'
+	| 'ImageBitmap'
+	| 'ImageData'
+	| 'RTCCertificate'
+	| 'VideoFrame'
+	>;
 
 type StructuredCloneableCollection =
 	| readonly StructuredCloneable[]
@@ -55,7 +58,6 @@ Matches a value that can be losslessly cloned using `structuredClone`.
 
 Note:
 - Custom error types will be cloned as the base `Error` type
-- This type doesn't include types exclusive to the TypeScript DOM library (e.g. `DOMRect` and `VideoFrame`)
 
 @see https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 

--- a/source/structured-cloneable.d.ts
+++ b/source/structured-cloneable.d.ts
@@ -1,5 +1,5 @@
 import type {TypedArray} from './typed-array';
-import type {FindGlobalType} from './find-global-type';
+import type {FindGlobalInstanceType} from './find-global-type';
 
 type StructuredCloneablePrimitive =
 	| string
@@ -19,7 +19,7 @@ type StructuredCloneableData =
 	| Error
 	| RegExp
 	| TypedArray
-	| FindGlobalType<
+	| FindGlobalInstanceType<
 	// DOM or Node types
 	| 'Blob'
 	| 'File'

--- a/test-d/find-global-type.ts
+++ b/test-d/find-global-type.ts
@@ -1,54 +1,75 @@
 /* eslint-disable no-var, unicorn/prevent-abbreviations */
 import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
-import type {FindGlobalType} from '..';
+import type {FindGlobalInstanceType, FindGlobalType} from '..';
 
-class NonGlobalClass {}
+declare class NonGlobalES6Class {}
+declare var nonGlobalVar: number;
+declare let nonGlobalLet: number;
+declare const nonGlobalConst: number;
+
 declare global {
-	class GlobalES6Style {
-		foo: string;
-	}
+	class GlobalES6Class {}
+	var globalVar: string;
+	let globalLet: number;
+	const globalConst: number;
 
 	type GlobalClass = {foo: string};
-	var GlobalVarStyle: new () => GlobalClass;
-	let GlobalLetStyle: new () => GlobalClass;
-	const GlobalConstStyle: new () => GlobalClass;
+	var GlobalConstructorVarStyle: new () => GlobalClass;
+	let GlobalConstructorLetStyle: new () => GlobalClass;
+	const GlobalConstructorConstStyle: new () => GlobalClass;
 
-	type GlobalNonClass = {value: string};
+	type GlobalTypeAlias = {value: string};
 
 	var nonConstructorFunction: () => Date;
 }
 
-// Preconditions
-type GlobalThisKey = keyof typeof globalThis;
-expectAssignable<GlobalThisKey>('GlobalVarStyle');
-expectAssignable<GlobalThisKey>('nonConstructorFunction');
-expectNotAssignable<GlobalThisKey>('NotGlobalClass');
-expectNotAssignable<GlobalThisKey>('GlobalES6Style');
-expectNotAssignable<GlobalThisKey>('GlobalLetStyle');
-expectNotAssignable<GlobalThisKey>('GlobalConstStyle');
+// === FindGlobalType ===
 
 // Success
-declare const foundDate: FindGlobalType<'Date'>;
-expectType<Date>(foundDate);
-declare const foundMultiple: FindGlobalType<'Date' | 'Error'>;
-expectType<Date | Error>(foundMultiple);
-declare const foundMultiplePartial: FindGlobalType<'Date' | 'Error' | 'NonExistentType'>;
-expectType<Date | Error>(foundMultiplePartial);
-declare const foundGlobalVarStyle: FindGlobalType<'GlobalVarStyle'>;
-expectType<GlobalClass>(foundGlobalVarStyle);
+declare const foundGlobalVar: FindGlobalType<'globalVar'>;
+expectType<string>(foundGlobalVar);
 
 // Failures
-declare const foundNonExistentType: FindGlobalType<'NonExistentType'>;
-expectType<never>(foundNonExistentType);
-declare const foundNonGlobalClass: FindGlobalType<'NonGlobalClass'>;
-expectType<never>(foundNonGlobalClass);
+declare const foundNonGlobalES6Class: FindGlobalType<'nonGlobalVar'>;
+expectType<never>(foundNonGlobalVar);
+declare const foundNonGlobalVar: FindGlobalType<'nonGlobalVar'>;
+expectType<never>(foundNonGlobalVar);
+declare const foundNonGlobalLet: FindGlobalType<'nonGlobalLet'>;
+expectType<never>(foundNonGlobalLet);
+declare const foundNonGlobalConst: FindGlobalType<'nonGlobalConst'>;
+expectType<never>(foundNonGlobalConst);
 
-declare const foundGlobalNonClass: FindGlobalType<'GlobalNonClass'>;
-expectType<never>(foundGlobalNonClass);
-declare const foundGlobalLetStyle: FindGlobalType<'GlobalLetStyle'>;
-expectType<never>(foundGlobalLetStyle);
-declare const foundGlobalConstStyle: FindGlobalType<'GlobalConstStyle'>;
-expectType<never>(foundGlobalConstStyle);
-declare const foundGlobalNonConstructorFunction: FindGlobalType<'nonConstructorFunction'>;
-expectType<never>(foundGlobalNonConstructorFunction);
+declare const foundGlobalLet: FindGlobalType<'globalLet'>;
+expectType<never>(foundGlobalLet);
+declare const foundGlobalConst: FindGlobalType<'globalConst'>;
+expectType<never>(foundGlobalConst);
+
+// === FindGlobalInstanceType ===
+
+// Success
+declare const foundInstanceDate: FindGlobalInstanceType<'Date'>;
+expectType<Date>(foundInstanceDate);
+declare const foundInstanceMultiple: FindGlobalInstanceType<'Date' | 'Error'>;
+expectType<Date | Error>(foundInstanceMultiple);
+declare const foundInstanceMultiplePartial: FindGlobalInstanceType<'Date' | 'Error' | 'NonExistentType'>;
+expectType<Date | Error>(foundInstanceMultiplePartial);
+declare const foundInstanceGlobalConstructorVarStyle: FindGlobalInstanceType<'GlobalConstructorVarStyle'>;
+expectType<GlobalClass>(foundInstanceGlobalConstructorVarStyle);
+
+// Failures
+declare const foundInstanceNonExistentType: FindGlobalInstanceType<'NonExistentType'>;
+expectType<never>(foundInstanceNonExistentType);
+declare const foundInstanceNonGlobalES6Class: FindGlobalInstanceType<'NonGlobalES6Class'>;
+expectType<never>(foundInstanceNonGlobalES6Class);
+
+declare const foundInstanceGlobalTypeAlias: FindGlobalInstanceType<'GlobalTypeAlias'>;
+expectType<never>(foundInstanceGlobalTypeAlias);
+declare const foundInstanceGlobalES6Class: FindGlobalInstanceType<'GlobalES6Class'>;
+expectType<never>(foundInstanceGlobalES6Class);
+declare const foundInstanceGlobalConstructorLetStyle: FindGlobalInstanceType<'GlobalConstructorLetStyle'>;
+expectType<never>(foundInstanceGlobalConstructorLetStyle);
+declare const foundInstanceGlobalConstructorConstStyle: FindGlobalInstanceType<'GlobalConstructorConstStyle'>;
+expectType<never>(foundInstanceGlobalConstructorConstStyle);
+declare const foundInstanceGlobalNonConstructorFunction: FindGlobalInstanceType<'nonConstructorFunction'>;
+expectType<never>(foundInstanceGlobalNonConstructorFunction);
 

--- a/test-d/find-global-type.ts
+++ b/test-d/find-global-type.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-var, unicorn/prevent-abbreviations */
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
+import type {FindGlobalType} from '..';
+
+class NonGlobalClass {}
+declare global {
+	class GlobalES6Style {
+		foo: string;
+	}
+
+	type GlobalClass = {foo: string};
+	var GlobalVarStyle: new () => GlobalClass;
+	let GlobalLetStyle: new () => GlobalClass;
+	const GlobalConstStyle: new () => GlobalClass;
+
+	type GlobalNonClass = {value: string};
+
+	var nonConstructorFunction: () => Date;
+}
+
+// Preconditions
+type GlobalThisKey = keyof typeof globalThis;
+expectAssignable<GlobalThisKey>('GlobalVarStyle');
+expectAssignable<GlobalThisKey>('nonConstructorFunction');
+expectNotAssignable<GlobalThisKey>('NotGlobalClass');
+expectNotAssignable<GlobalThisKey>('GlobalES6Style');
+expectNotAssignable<GlobalThisKey>('GlobalLetStyle');
+expectNotAssignable<GlobalThisKey>('GlobalConstStyle');
+
+// Success
+declare const foundDate: FindGlobalType<'Date'>;
+expectType<Date>(foundDate);
+declare const foundMultiple: FindGlobalType<'Date' | 'Error'>;
+expectType<Date | Error>(foundMultiple);
+declare const foundMultiplePartial: FindGlobalType<'Date' | 'Error' | 'NonExistentType'>;
+expectType<Date | Error>(foundMultiplePartial);
+declare const foundGlobalVarStyle: FindGlobalType<'GlobalVarStyle'>;
+expectType<GlobalClass>(foundGlobalVarStyle);
+
+// Failures
+declare const foundNonExistentType: FindGlobalType<'NonExistentType'>;
+expectType<never>(foundNonExistentType);
+declare const foundNonGlobalClass: FindGlobalType<'NonGlobalClass'>;
+expectType<never>(foundNonGlobalClass);
+
+declare const foundGlobalNonClass: FindGlobalType<'GlobalNonClass'>;
+expectType<never>(foundGlobalNonClass);
+declare const foundGlobalLetStyle: FindGlobalType<'GlobalLetStyle'>;
+expectType<never>(foundGlobalLetStyle);
+declare const foundGlobalConstStyle: FindGlobalType<'GlobalConstStyle'>;
+expectType<never>(foundGlobalConstStyle);
+declare const foundGlobalNonConstructorFunction: FindGlobalType<'nonConstructorFunction'>;
+expectType<never>(foundGlobalNonConstructorFunction);
+

--- a/test-d/find-global-type.ts
+++ b/test-d/find-global-type.ts
@@ -72,4 +72,3 @@ declare const foundInstanceGlobalConstructorConstStyle: FindGlobalInstanceType<'
 expectType<never>(foundInstanceGlobalConstructorConstStyle);
 declare const foundInstanceGlobalNonConstructorFunction: FindGlobalInstanceType<'nonConstructorFunction'>;
 expectType<never>(foundInstanceGlobalNonConstructorFunction);
-


### PR DESCRIPTION
While investigating #899, I discovered a solution that lets us only include DOM/Node types if they actually exist. Based on [this code](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3263bd44/types/node/globals.d.ts#L406-L411) from the node type declarations, I came up with this solution:

```ts
/** Grab the specified type from its corresponding global constructor, if it's declared */
type ExtractFromGlobalConstructor<Name extends string> =
	typeof globalThis extends Record<Name, new (...args: any[]) => infer T> ? T : never
```

This only works with types that have a public constructor in `globalThis`, but `Blob`, `File`, and all the DOM types appear to have constructors and work like this. In order to verify that all the DOM types have public constructors I added `@webgpu/types`, `@types/dom-webcodecs`, and `@types/webxr`, which got me most of the types I was missing, then I created this file to manually check them:
```ts
type DOMKeys =
	| 'AudioData'
	| 'CropTarget'
	| 'CryptoKey'
	| 'DOMException'
	| 'DOMMatrix'
	| 'DOMMatrixReadOnly'
	| 'DOMPoint'
	| 'DOMPointReadOnly'
	| 'DOMQuad'
	| 'DOMRect'
	| 'DOMRectReadOnly'
	| 'FileList'
	| 'FileSystemDirectoryHandle'
	| 'FileSystemFileHandle'
	| 'FileSystemHandle'
	| 'GPUCompilationInfo'
	| 'GPUCompilationMessage'
	| 'ImageBitmap'
	| 'ImageData'
	| 'RTCCertificate'
	| 'VideoFrame'

/**
- `Name` = found global with valid constructor
- `~Name` = found global, but no constructor found
- `!Name` = global not found
*/
type FindGlobals<Name extends string> =
	Name extends string
		? typeof globalThis extends Record<Name, new (...args: any[]) => any> ? Name
			: typeof globalThis extends Record<Name, any> ? `~${Name}`
				: `!${Name}`
		: never;

import "@webgpu/types"

const found: FindGlobals<DOMKeys>[] = [
	'AudioData',
	'!CropTarget', // no typescript declarations exist for this yet
	'CryptoKey',
	'DOMException',
	'DOMMatrix',
	'DOMMatrixReadOnly',
	'DOMPoint',
	'DOMPointReadOnly',
	'DOMQuad',
	'DOMRect',
	'DOMRectReadOnly',
	'FileList',
	'FileSystemDirectoryHandle',
	'FileSystemFileHandle',
	'FileSystemHandle',
	'GPUCompilationInfo',
	'GPUCompilationMessage',
	'ImageBitmap',
	'ImageData',
	'RTCCertificate',
	'VideoFrame',
]
```

Fixes #899