### PR TITLE
fix(Exact): fix type when class present

### DIFF
--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -1,8 +1,8 @@
 import type {ArrayElement, ObjectValue} from './internal';
 import type {IsEqual} from './is-equal';
 import type {KeysOfUnion} from './keys-of-union';
-import type {JsonPrimitive} from './basic';
 import type {IsUnknown} from './is-unknown';
+import type {Primitive} from './primitive';
 
 /**
 Create a type from `ParameterType` and `InputType` and change keys exclusive to `InputType` to `never`.
@@ -54,7 +54,7 @@ onlyAcceptNameImproved(invalidInput); // Compilation error
 */
 export type Exact<ParameterType, InputType> =
 	// If the parameter is a primitive, return it as is immediately to avoid it being converted to a complex type
-	ParameterType extends JsonPrimitive ? ParameterType
+	ParameterType extends Primitive ? ParameterType
 		// If the parameter is an unknown, return it as is immediately to avoid it being converted to a complex type
 		: IsUnknown<ParameterType> extends true ? unknown
 			// If the parameter is a Function, return it as is because this type is not capable of handling function, leave it to TypeScript

--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -1,7 +1,8 @@
 import type {ArrayElement, ObjectValue} from './internal';
 import type {IsEqual} from './is-equal';
 import type {KeysOfUnion} from './keys-of-union';
-import type {JsonObject} from './basic';
+import type {JsonPrimitive} from './basic';
+import type {IsUnknown} from './is-unknown';
 
 /**
 Create a type from `ParameterType` and `InputType` and change keys exclusive to `InputType` to `never`.
@@ -52,11 +53,15 @@ onlyAcceptNameImproved(invalidInput); // Compilation error
 @category Utilities
 */
 export type Exact<ParameterType, InputType> =
-	IsEqual<ParameterType, InputType> extends true ? ParameterType
-		// Convert union of array to array of union: A[] & B[] => (A & B)[]
-		: ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-			// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
-			: ParameterType extends readonly unknown[] ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
-				// Only apply Exact for pure object types. For types from a class, leave it unchanged to TypeScript to handle.
-				: ParameterType extends JsonObject ? ExactObject<ParameterType, InputType>
-					: ParameterType;
+	// If the parameter is a primitive, return it as is immediately to avoid it being converted to a complex type
+	ParameterType extends JsonPrimitive ? ParameterType
+		// If the parameter is an unknown, return it as is immediately to avoid it being converted to a complex type
+		: IsUnknown<ParameterType> extends true ? unknown
+			// If the parameter is a Function, return it as is because this type is not capable of handling function, leave it to TypeScript
+			: ParameterType extends Function ? ParameterType
+				: IsEqual<ParameterType, InputType> extends true ? ParameterType
+					// Convert union of array to array of union: A[] & B[] => (A & B)[]
+					: ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+						// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.
+						: ParameterType extends readonly unknown[] ? ReadonlyArray<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
+							: ExactObject<ParameterType, InputType>;

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -22,6 +22,28 @@ import type {Exact, Opaque} from '../index';
 	}
 }
 
+{ // Spec - bigint type
+	type Type = bigint;
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+
+	{ // It should accept bigint
+		const input = BigInt(9_007_199_254_740_991);
+		function_(input);
+	}
+
+	{ // It should reject number
+		const input = 1;
+		// @ts-expect-error
+		function_(input);
+	}
+
+	{ // It should reject unknown
+		const input = {} as unknown;
+		// @ts-expect-error
+		function_(input);
+	}
+}
+
 { // Spec - array
 	type Type = Array<{code: string; name?: string}>;
 	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -195,7 +195,25 @@ import type {Exact, Opaque} from '../index';
 	}
 
 	{ // It should allow input with excess property
-		const input = {body: {code: '', name: '', excessProperty: ''}};
+		const input = {body: {code: '', name: '', excessProperty: 1}};
+		function_(input);
+	}
+}
+
+{ // Spec - check index signature type
+	type Type = {
+		body: {
+			[k: string]: string;
+			code: string;
+			name?: string;
+		};
+	};
+	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
+
+	{ // It should allow input with excess property
+		const input = {body: {code: '', name: '', excessProperty: 1}};
+		// Expects error because the excess is not string
+		// @ts-expect-error
 		function_(input);
 	}
 }
@@ -466,4 +484,34 @@ import type {Exact, Opaque} from '../index';
 	function_({a: 'a', b: new Date() as Date | null});
 	// @ts-expect-error
 	function_({a: 'a', b: 1});
+}
+
+// Spec - special test case for Date type
+// @see https://github.com/sindresorhus/type-fest/issues/909
+{
+	type UserType = {
+		id: string;
+		name: string;
+		createdAt: Date;
+		email?: string;
+	};
+
+	const function_ = <T extends Exact<UserType, T>>(arguments_: T) => arguments_;
+
+	function_({
+		id: 'asd',
+		name: 'John',
+		createdAt: new Date(),
+	});
+
+	const withExcessSurname = {
+		id: 'asd',
+		name: 'John',
+		createdAt: new Date(),
+		surname: 'Doe',
+	};
+
+	// Expects error due to surname is an excess field
+	// @ts-expect-error
+	function_(withExcessSurname);
 }

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -210,9 +210,9 @@ import type {Exact, Opaque} from '../index';
 	};
 	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
-	{ // It should allow input with excess property
+	{ // It should allow input with an excess property
 		const input = {body: {code: '', name: '', excessProperty: 1}};
-		// Expects error because the excess is not string
+		// Expects error because the excess property is not string
 		// @ts-expect-error
 		function_(input);
 	}


### PR DESCRIPTION
This is an attempt to fix the issue reported in https://github.com/sindresorhus/type-fest/issues/909

I previously attempted to fix the issue in https://github.com/sindresorhus/type-fest/pull/902

My original approach was use JsonObject to determine object with primitive type and assume all types not match are classes. However, I found that JsonObject also rejects normal object containing any class type.

I also can't find a way to reliable determine a class, I used `Class<any>` but it seems can't detect `Date` because `Date` is a built-in type and only interface is available.

# What's changed
- updated the type to leave `Function` check as is
- updated the type to return primitive type early to avoid the generated type becomes too complex.