### PR TITLE
Ensure no implicit `@types/` includes

### DIFF
--- a/source/structured-cloneable.d.ts
+++ b/source/structured-cloneable.d.ts
@@ -17,9 +17,10 @@ type StructuredCloneableData =
 	| Date
 	| Error
 	| RegExp
-	| TypedArray
-	| Blob
-	| File;
+	| TypedArray;
+// Requires DOM or @types/node
+//	| Blob
+//	| File
 // DOM exclusive types
 //	| AudioData
 //	| CropTarget

--- a/test-d/class.ts
+++ b/test-d/class.ts
@@ -2,9 +2,8 @@ import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {Class, Constructor, IsAny} from '../index';
 
 class Foo {
-	constructor(x: number, y: any) {
-		console.log(x, y);
-	}
+	// eslint-disable-next-line @typescript-eslint/no-useless-constructor, @typescript-eslint/no-empty-function
+	constructor(_x: number, _y: any) {}
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	method(): void {}

--- a/test-d/multidimensional-array.ts
+++ b/test-d/multidimensional-array.ts
@@ -6,8 +6,6 @@ function createArray<T extends number>(dimensions: T): MultidimensionalArray<unk
 
 	let array = root;
 	for (let dimension = 1; dimension < dimensions; ++dimension) {
-		console.log(`Initializing dimension #${dimension}`);
-
 		array[0] = [];
 		array = array[0] as unknown[];
 	}

--- a/test-d/multidimensional-readonly-array.ts
+++ b/test-d/multidimensional-readonly-array.ts
@@ -6,8 +6,6 @@ function createArray<T extends number>(dimensions: T): MultidimensionalReadonlyA
 
 	let array = root;
 	for (let dimension = 1; dimension < dimensions; ++dimension) {
-		console.log(`Initializing dimension #${dimension}`);
-
 		array[0] = [];
 		if (dimension < dimensions - 1) {
 			array = array[0] as unknown[];

--- a/test-d/set-parameter-type.ts
+++ b/test-d/set-parameter-type.ts
@@ -5,6 +5,8 @@ function function_(_a: number, _b: string, _c: Object, ..._arguments: boolean[])
 	return null;
 }
 
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore Global requires @types/node
 function functionWithThis(this: Global, _a: number) {
 	return null;
 }
@@ -41,5 +43,9 @@ expectType<(a: string) => null>(test5);
 
 // Test the function that has `this` parameter
 declare const testThis: SetParameterType<typeof functionWithThis, {0: string}>;
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore Global requires @types/node
 expectType<(this: Global, a: string) => null>(testThis);
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore global requires @types/node
 testThis.call(global, '1');

--- a/test-d/set-parameter-type.ts
+++ b/test-d/set-parameter-type.ts
@@ -48,4 +48,5 @@ declare const testThis: SetParameterType<typeof functionWithThis, {0: string}>;
 expectType<(this: Global, a: string) => null>(testThis);
 // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
 // @ts-ignore global requires @types/node
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 testThis.call(global, '1');

--- a/test-d/structured-cloneable.ts
+++ b/test-d/structured-cloneable.ts
@@ -138,7 +138,11 @@ expectAssignable<StructuredCloneable>(new Set<string[]>());
 expectAssignable<StructuredCloneable>(new Set<Set<string>>());
 
 // Web/API types
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore Requires dom or @types/node@>=20
 declare const blob: Blob;
 expectAssignable<StructuredCloneable>(blob);
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore Requires dom or @types/node@>=20
 declare const file: File;
 expectAssignable<StructuredCloneable>(file);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"lib": [
 			"ES2021",
 		],
+		"types": [], // Ensures no @types/ are unintentionally included
 		"exactOptionalPropertyTypes": true,
 		"skipLibCheck": false, // Ensures .d.ts files are checked: https://github.com/sindresorhus/tsconfig/issues/15
 


### PR DESCRIPTION
To avoid the errors seen in #899 as a result of  #897 this is a companion follow up to the #898 that @Emiyaaaaa made that also removes any implicitly includes `@types/` package.

When no [`types`](https://www.typescriptlang.org/tsconfig/#types) is specified in the `tsconfig.json`, then typescript will pull in all types in `./node_modules/@types/`, no matter if those appeared there due to us including it or because it's been hoisted from one of our dependencies.

Since we specify no `@types/` dependencies all such types are hoisted from our dependencies and seems to currently amount to:

![Skärmavbild 2024-07-12 kl  01 56 14](https://github.com/user-attachments/assets/8034c5c1-91aa-4f62-b76c-10e09685fb66)

Most importantly this means that we have been pulling in a random `@types/node` and implicitly relied on it (seemingly by relying on `xo` which relies on `eslint-import-resolver-webpack`  ➡️ `webpack` ➡️ `terser-webpack-plugin` ➡️ `jest-worker` ➡️ `@types/node@*`)

This PR sets `"types": []` to ensure no such implicit types are included, which uncovers the issue mentioned in #899 which it solves the same way as the dom specific types were solved.

Related: #908 