### PR TITLE
Expose `ArrayTail` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,7 @@ export type {ArrayIndices} from './source/array-indices';
 export type {ArrayValues} from './source/array-values';
 export type {ArraySlice} from './source/array-slice';
 export type {ArraySplice} from './source/array-splice';
+export type {ArrayTail} from './source/array-tail';
 export type {SetFieldType} from './source/set-field-type';
 export type {Paths} from './source/paths';
 export type {SharedUnionFieldsDeep} from './source/shared-union-fields-deep';

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Click the type names for complete docs.
 - [`ArrayIndices`](source/array-indices.d.ts) - Provides valid indices for a constant array or tuple.
 - [`ArrayValues`](source/array-values.d.ts) - Provides all values for a constant array or tuple.
 - [`ArraySplice`](source/array-splice.d.ts) - Creates a new array type by adding or removing elements at a specified index range in the original array.
+- [`ArrayTail`](source/array-tail.d.ts) - Extracts the type of an array or tuple minus the first element.
 - [`SetFieldType`](source/set-field-type.d.ts) - Create a type that changes the type of the given keys.
 - [`Paths`](source/paths.d.ts) - Generate a union of all possible paths to properties in the given object.
 - [`SharedUnionFieldsDeep`](source/shared-union-fields-deep.d.ts) - Create a type with shared fields from a union of object types, deeply traversing nested structures.

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -7,10 +7,10 @@ Extracts the type of an array or tuple minus the first element.
 ```
 import type {ArrayTail} from 'type-fest';
 
-declare const curry: <TArguments extends unknown[], TReturn>(
-	fn: (...args: TArguments) => TReturn,
-	...args: ArrayTail<TArguments>
-) => (...args: ArrayTail<TArguments>) => TReturn;
+declare const curry: <Arguments extends unknown[], Return>(
+	function_: (...arguments_: Arguments) => Return,
+	...arguments_: ArrayTail<Arguments>
+) => (...arguments_: ArrayTail<Arguments>) => Return;
 
 const add = (a: number, b: number) => a + b;
 
@@ -22,4 +22,4 @@ add3(4);
 
 @category Array
 */
-export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown, ...infer TTail] ? TTail : [];
+export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown, ...infer Tail] ? Tail : [];

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -1,0 +1,25 @@
+import type {UnknownArrayOrTuple} from './internal';
+
+/**
+Extracts the type of an array or tuple minus the first element.
+
+@example
+```
+import type {ArrayTail} from 'type-fest';
+
+declare const curry: <TArguments extends unknown[], TReturn>(
+	fn: (...args: TArguments) => TReturn,
+	...args: ArrayTail<TArguments>
+) => (...args: ArrayTail<TArguments>) => TReturn;
+
+const add = (a: number, b: number) => a + b;
+
+const add3 = curry(add, 3);
+
+add3(4);
+//=> 7
+```
+
+@category Array
+*/
+export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown, ...infer TTail] ? TTail : [];

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -273,11 +273,6 @@ export type FirstArrayElement<TArray extends UnknownArrayOrTuple> = TArray exten
 	: never;
 
 /**
-Extracts the type of an array or tuple minus the first element.
-*/
-export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown, ...infer TTail] ? TTail : [];
-
-/**
 Extract the element of an array that also works for array union.
 
 Returns `never` if T is not an array.

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -3,12 +3,12 @@ import type {OmitIndexSignature} from './omit-index-signature';
 import type {PickIndexSignature} from './pick-index-signature';
 import type {Merge} from './merge';
 import type {
-	ArrayTail,
 	FirstArrayElement,
 	IsBothExtends,
 	NonEmptyTuple,
 	UnknownArrayOrTuple,
 } from './internal';
+import type {ArrayTail} from './array-tail';
 import type {UnknownRecord} from './unknown-record';
 import type {EnforceOptional} from './enforce-optional';
 import type {SimplifyDeep} from './simplify-deep';

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -1,0 +1,12 @@
+import {expectType} from 'tsd';
+import type {ArrayTail} from '../index';
+
+declare const getArrayTail: <T extends readonly unknown[]>(array: T) => ArrayTail<T>;
+
+expectType<[]>(getArrayTail([]));
+expectType<[]>(getArrayTail(['a']));
+expectType<[]>(getArrayTail(['a', 'b', 'c']));
+
+expectType<[]>(getArrayTail([] as const));
+expectType<[]>(getArrayTail(['a'] as const));
+expectType<['b', 'c']>(getArrayTail(['a', 'b', 'c'] as const));


### PR DESCRIPTION
Closes #135.

Exposes internal `ArrayTail` type:

> Extracts the type of an array or tuple minus the first element.

```ts
import type {ArrayTail} from 'type-fest';

declare const curry: <TArguments extends unknown[], TReturn>(
	fn: (...args: TArguments) => TReturn,
	...args: ArrayTail<TArguments>
) => (...args: ArrayTail<TArguments>) => TReturn;

const add = (a: number, b: number) => a + b;

const add3 = curry(add, 3);

add3(4);
//=> 7
```