### PR TITLE
Expose `NonEmptyTuple` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -129,6 +129,7 @@ export type {IsNull} from './source/is-null';
 export type {IfNull} from './source/if-null';
 export type {And} from './source/and';
 export type {Or} from './source/or';
+export type {NonEmptyTuple} from './source/non-empty-tuple';
 
 // Template literal types
 export type {CamelCase} from './source/camel-case';

--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,7 @@ Click the type names for complete docs.
 - [`DistributedPick`](source/distributed-pick.d.ts) - Picks keys from a type, distributing the operation over a union.
 - [`And`](source/and.d.ts) - Returns a boolean for whether two given types are both true.
 - [`Or`](source/or.d.ts) - Returns a boolean for whether either of two given types are true.
+- [`NonEmptyTuple`](source/non-empty-tuple.d.ts) - Matches any non-empty tuple.
 
 ### Type Guard
 

--- a/source/internal.d.ts
+++ b/source/internal.d.ts
@@ -252,11 +252,6 @@ Matches any unknown array or tuple.
 export type UnknownArrayOrTuple = readonly [...unknown[]];
 
 /**
-Matches any non empty tuple.
-*/
-export type NonEmptyTuple = readonly [unknown, ...unknown[]];
-
-/**
 Returns a boolean for whether the two given types extends the base type.
 */
 export type IsBothExtends<BaseType, FirstType, SecondType> = FirstType extends BaseType

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -6,9 +6,9 @@ import type {
 	ArrayTail,
 	FirstArrayElement,
 	IsBothExtends,
-	NonEmptyTuple,
 	UnknownArrayOrTuple,
 } from './internal';
+import type {NonEmptyTuple} from './non-empty-tuple';
 import type {UnknownRecord} from './unknown-record';
 import type {EnforceOptional} from './enforce-optional';
 import type {SimplifyDeep} from './simplify-deep';

--- a/source/non-empty-tuple.d.ts
+++ b/source/non-empty-tuple.d.ts
@@ -1,0 +1,21 @@
+/**
+Matches any non-empty tuple.
+
+@example
+```
+import type {NonEmptyTuple} from 'type-fest';
+
+const sum = (...numbers: NonEmptyTuple<number>) => numbers.reduce((total, value) => total + value, 0);
+
+sum(1, 2, 3);
+//=> 6
+
+sum();
+//=> Error: Expected at least 1 arguments, but got 0.
+```
+
+@see {@link RequireAtLeastOne} for objects
+
+@category Array
+*/
+export type NonEmptyTuple<T = unknown> = readonly [T, ...T[]];

--- a/test-d/non-empty-tuple.ts
+++ b/test-d/non-empty-tuple.ts
@@ -1,0 +1,10 @@
+import {expectType} from 'tsd';
+import type {NonEmptyTuple} from '../index';
+
+declare const sum: (...numbers: NonEmptyTuple<number>) => number;
+
+expectType<number>(sum(1, 2, 3));
+expectType<number>(sum(1));
+
+// @ts-expect-error
+sum();


### PR DESCRIPTION
Closes #420.
Closes #476.
Closes #661.

Exposes internal `NonEmptyTuple` type.

> Matches any non-empty tuple.

```ts
import type {NonEmptyTuple} from 'type-fest';

const sum = (...numbers: NonEmptyTuple<number>) => numbers.reduce((total, value) => total + value, 0);

sum(1, 2, 3);
//=> 6

sum();
//=> Error: Expected at least 1 arguments, but got 0.
```
