### PR TITLE
Add options to `Paths`

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -13,7 +13,7 @@ Paths options.
 */
 export type PathsOptions = {
 	/**
-	Maximum recursions before stopping to search deeper paths.
+	The maximum depth to recurse when searching for paths.
 
 	@default 10
 	*/

--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -3,8 +3,22 @@ import type {EmptyObject} from './empty-object';
 import type {IsAny} from './is-any';
 import type {IsNever} from './is-never';
 import type {UnknownArray} from './unknown-array';
-import type {Sum} from './sum';
-import type {LessThan} from './less-than';
+import type {Subtract} from './subtract';
+import type {GreaterThan} from './greater-than';
+
+/**
+Paths options.
+
+@see {@link Paths}
+*/
+export type PathsOptions = {
+	/**
+	Maximum recursions before stopping to search deeper paths.
+
+	@default 10
+	*/
+	maxRecursionDepth?: number;
+};
 
 /**
 Generate a union of all possible paths to properties in the given object.
@@ -47,9 +61,7 @@ open('listB.1'); // TypeError. Because listB only has one element.
 @category Object
 @category Array
 */
-export type Paths<T> = Paths_<T>;
-
-type Paths_<T, Depth extends number = 0> =
+export type Paths<T, Options extends PathsOptions = {}> =
 	T extends NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
 		? never
 		: IsAny<T> extends true
@@ -57,29 +69,33 @@ type Paths_<T, Depth extends number = 0> =
 			: T extends UnknownArray
 				? number extends T['length']
 					// We need to handle the fixed and non-fixed index part of the array separately.
-					? InternalPaths<StaticPartOfArray<T>, Depth>
-					| InternalPaths<Array<VariablePartOfArray<T>[number]>, Depth>
-					: InternalPaths<T, Depth>
+					? InternalPaths<StaticPartOfArray<T>, Options>
+					| InternalPaths<Array<VariablePartOfArray<T>[number]>, Options>
+					: InternalPaths<T, Options>
 				: T extends object
-					? InternalPaths<T, Depth>
+					? InternalPaths<T, Options>
 					: never;
 
-export type InternalPaths<_T, Depth extends number = 0, T = Required<_T>> =
-	T extends EmptyObject | readonly []
-		? never
-		: {
-			[Key in keyof T]:
-			Key extends string | number // Limit `Key` to string or number.
-				// If `Key` is a number, return `Key | `${Key}``, because both `array[0]` and `array['0']` work.
-				?
-				| Key
-				| ToString<Key>
-				| (
-					LessThan<Depth, 15> extends true // Limit the depth to prevent infinite recursion
-						? IsNever<Paths_<T[Key], Sum<Depth, 1>>> extends false
-							? `${Key}.${Paths_<T[Key], Sum<Depth, 1>>}`
-							: never
+type InternalPaths<T, Options extends PathsOptions = {}> =
+	(Options['maxRecursionDepth'] extends number ? Options['maxRecursionDepth'] : 10) extends infer MaxDepth extends number
+		? Required<T> extends infer T
+			? T extends EmptyObject | readonly []
+				? never
+				: {
+					[Key in keyof T]:
+					Key extends string | number // Limit `Key` to string or number.
+						// If `Key` is a number, return `Key | `${Key}``, because both `array[0]` and `array['0']` work.
+						?
+						| Key
+						| ToString<Key>
+						| (
+							GreaterThan<MaxDepth, 0> extends true // Limit the depth to prevent infinite recursion
+								? IsNever<Paths<T[Key], {maxRecursionDepth: Subtract<MaxDepth, 1>}>> extends false
+									? `${Key}.${Paths<T[Key], {maxRecursionDepth: Subtract<MaxDepth, 1>}>}`
+									: never
+								: never
+						)
 						: never
-				)
-				: never
-		}[keyof T & (T extends UnknownArray ? number : unknown)];
+				}[keyof T & (T extends UnknownArray ? number : unknown)]
+			: never
+		: never;

--- a/test-d/paths.ts
+++ b/test-d/paths.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectType} from 'tsd';
-import type {Paths, PickDeep} from '../index';
+import type {Paths} from '../index';
 
 declare const normal: Paths<{foo: string}>;
 expectType<'foo'>(normal);
@@ -108,3 +108,13 @@ type MyOtherEntity = {
 };
 type MyEntityPaths = Paths<MyEntity>;
 expectAssignable<string>({} as MyEntityPaths);
+
+// By default, the recursion limit should be reasonably long
+type RecursiveFoo = {foo: RecursiveFoo};
+expectAssignable<Paths<RecursiveFoo>>('foo.foo.foo.foo.foo.foo.foo.foo');
+
+declare const recursion0: Paths<RecursiveFoo, {maxRecursionDepth: 0}>;
+expectType<'foo'>(recursion0);
+
+declare const recursion1: Paths<RecursiveFoo, {maxRecursionDepth: 1}>;
+expectType<'foo' | 'foo.foo'>(recursion1);


### PR DESCRIPTION
Fixes #917

Introduce `PathsOptions` with `maxRecursionDepth`.

## Things up for debate
- By introducing the new options parameter, which adds a bit more complexity, the previous test-case
https://github.com/sindresorhus/type-fest/blob/8a45ba048767aaffcebc7d190172d814a739feb0/test-d/paths.ts#L109
worked fine with the old recursion limit of 15 but now throws an error _"Type instantiation is excessively deep and possibly infinite"_. Setting the limit to 14 fixes it. Technically, this introduces a small breaking change.
In my experience, most paths that are more than 4 levels deep do not really add value most of the time. So I would suggest having a smaller default like 8 or 10. This would speed up type checking times for users and slightly reduce the bloated wall of intellisense suggestions. If users need more, they can set `maxRecursionDepth` manually.
- I'm not sure why `InternalPaths` is currently exported. Perhaps so that users have a way to get their hands on the `Depth` parameter. If that is the only reason, we could consider not exporting it now that `Paths` supports it.
