### PR TITLE
chore(doc): fix MergeDeep default arrayMergeMode value

### DIFF
--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -322,7 +322,7 @@ export type MergeDeepOptions = {
 
 	Note: Top-level arrays and tuples are always spread.
 
-	@default 'spread'
+	@default 'replace'
 	*/
 	arrayMergeMode?: ArrayMergeMode;
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Hey! Thanks for this very helpful lib!

Here is a quick fix to the documentation.
The lines above state:
> When we walk through the properties of the objects and the same key is found and both are array or tuple, a merge mode must be chosen:
> 	- `replace`: Replaces the destination value by the source value. **This is the default mode.**

This seems to be accurate based on this [DefaultMergeDeepOptions type definition](https://github.com/sindresorhus/type-fest/blob/b9838f6d8a4c0e54515b371de82ef1b9e9649628/source/merge-deep.d.ts#L350)

Thanks again!