### PR TITLE
Improve `DelimiterCase`

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,54 +1,21 @@
-import type {UpperCaseCharacters, WordSeparators} from './internal';
+import {SplitWords} from "./split-words";
 
-// Transforms a string that is fully uppercase into a fully lowercase version. Needed to add support for SCREAMING_SNAKE_CASE, see https://github.com/sindresorhus/type-fest/issues/385
-type UpperCaseToLowerCase<T extends string> = T extends Uppercase<T> ? Lowercase<T> : T;
-
-// This implementation does not support SCREAMING_SNAKE_CASE, it is used internally by `SplitIncludingDelimiters`.
-type SplitIncludingDelimiters_<Source extends string, Delimiter extends string> =
-	Source extends '' ? [] :
-		Source extends `${infer FirstPart}${Delimiter}${infer SecondPart}` ?
-			(
-				Source extends `${FirstPart}${infer UsedDelimiter}${SecondPart}`
-					? UsedDelimiter extends Delimiter
-						? Source extends `${infer FirstPart}${UsedDelimiter}${infer SecondPart}`
-							? [...SplitIncludingDelimiters<FirstPart, Delimiter>, UsedDelimiter, ...SplitIncludingDelimiters<SecondPart, Delimiter>]
-							: never
-						: never
-					: never
-			) :
-			[Source];
 
 /**
-Unlike a simpler split, this one includes the delimiter splitted on in the resulting array literal. This is to enable splitting on, for example, upper-case characters.
-
-@category Template literal
+Convert an array of words to delimiter case starting with a delimiter with input capitalization.
 */
-export type SplitIncludingDelimiters<Source extends string, Delimiter extends string> = SplitIncludingDelimiters_<UpperCaseToLowerCase<Source>, Delimiter>;
+type DelimiterCaseFromArray<
+	Words extends string[],
+	Delimiter extends string,
+	OutputString extends string = ''
+> = Words extends [
+		infer FirstWord extends string,
+		...infer RemainingWords extends string[]
+	]
+	? `${Delimiter}${FirstWord}${DelimiterCaseFromArray<RemainingWords, Delimiter>}`
+	: OutputString;
 
-/**
-Format a specific part of the splitted string literal that `StringArrayToDelimiterCase<>` fuses together, ensuring desired casing.
-
-@see StringArrayToDelimiterCase
-*/
-type StringPartToDelimiterCase<StringPart extends string, Start extends boolean, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
-	StringPart extends UsedWordSeparators ? Delimiter :
-		Start extends true ? Lowercase<StringPart> :
-			StringPart extends UsedUpperCaseCharacters ? `${Delimiter}${Lowercase<StringPart>}` :
-				StringPart;
-
-/**
-Takes the result of a splitted string literal and recursively concatenates it together into the desired casing.
-
-It receives `UsedWordSeparators` and `UsedUpperCaseCharacters` as input to ensure it's fully encapsulated.
-
-@see SplitIncludingDelimiters
-*/
-type StringArrayToDelimiterCase<Parts extends readonly any[], Start extends boolean, UsedWordSeparators extends string, UsedUpperCaseCharacters extends string, Delimiter extends string> =
-	Parts extends [`${infer FirstPart}`, ...infer RemainingParts]
-		? `${StringPartToDelimiterCase<FirstPart, Start, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}${StringArrayToDelimiterCase<RemainingParts, false, UsedWordSeparators, UsedUpperCaseCharacters, Delimiter>}`
-		: Parts extends [string]
-			? string
-			: '';
+type RemoveFirstLetter<S extends string> = S extends `${infer _}${infer Rest}` ? Rest : '';
 
 /**
 Convert a string literal to a custom string delimiter casing.
@@ -87,13 +54,9 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 
 @category Change case
 @category Template literal
-*/
-export type DelimiterCase<Value, Delimiter extends string> = string extends Value ? Value : Value extends string
-	? StringArrayToDelimiterCase<
-	SplitIncludingDelimiters<Value, WordSeparators | UpperCaseCharacters>,
-	true,
-	WordSeparators,
-	UpperCaseCharacters,
-	Delimiter
-	>
+ */
+export type DelimiterCase<Value, Delimiter extends string> = Value extends string
+	? string extends Value
+		? Value
+		: Lowercase<RemoveFirstLetter<DelimiterCaseFromArray<SplitWords<Value extends Uppercase<Value> ? Lowercase<Value> : Value>, Delimiter>>>
 	: Value;

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -1,15 +1,4 @@
-import type {SplitIncludingDelimiters} from './delimiter-case';
 import type {SnakeCase} from './snake-case';
-import type {Includes} from './includes';
-
-/**
-Returns a boolean for whether the string is screaming snake case.
-*/
-type IsScreamingSnakeCase<Value extends string> = Value extends Uppercase<Value>
-	? Includes<SplitIncludingDelimiters<Lowercase<Value>, '_'>, '_'> extends true
-		? true
-		: false
-	: false;
 
 /**
 Convert a string literal to screaming-snake-case.
@@ -25,9 +14,7 @@ const someVariable: ScreamingSnakeCase<'fooBar'> = 'FOO_BAR';
 
 @category Change case
 @category Template literal
-*/
+ */
 export type ScreamingSnakeCase<Value> = Value extends string
-	? IsScreamingSnakeCase<Value> extends true
-		? Value
-		: Uppercase<SnakeCase<Value>>
+	? Uppercase<SnakeCase<Value>>
 	: Value;

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -1,22 +1,17 @@
 import {expectType, expectAssignable} from 'tsd';
-import type {UpperCaseCharacters, WordSeparators} from '../source/internal';
-import type {SplitIncludingDelimiters, DelimiterCase} from '../source/delimiter-case';
-
-const splitFromCamel: SplitIncludingDelimiters<'fooBar', WordSeparators | UpperCaseCharacters> = ['foo', 'B', 'ar'];
-expectType<['foo', 'B', 'ar']>(splitFromCamel);
-const splitFromComplexCamel: SplitIncludingDelimiters<'fooBarAbc123', WordSeparators | UpperCaseCharacters> = ['foo', 'B', 'ar', 'A', 'bc123'];
-expectType<['foo', 'B', 'ar', 'A', 'bc123']>(splitFromComplexCamel);
-const splitFromWordSeparators: SplitIncludingDelimiters<'foo-bar_car far', WordSeparators> = ['foo', '-', 'bar', '_', 'car', ' ', 'far'];
-expectType<['foo', '-', 'bar', '_', 'car', ' ', 'far']>(splitFromWordSeparators);
-const splitFromScreamingSnakeCase: SplitIncludingDelimiters<'FOO_BAR', WordSeparators | UpperCaseCharacters> = ['foo', '_', 'bar'];
-expectType<['foo', '_', 'bar']>(splitFromScreamingSnakeCase);
+import type {DelimiterCase} from '../source/delimiter-case';
 
 // DelimiterCase
 const delimiterFromCamel: DelimiterCase<'fooBar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromCamel);
 
+// TODO: customize with a parameter
 const delimiterFromComplexCamel: DelimiterCase<'fooBarAbc123', '#'> = 'foo#bar#abc123';
 expectType<'foo#bar#abc123'>(delimiterFromComplexCamel);
+
+// TODO: customize with a parameter
+const delimiterFromComplexCamel2: DelimiterCase<'fooBarAbc123', '#'> = 'foo#bar#abc#123';
+expectType<'foo#bar#abc#123'>(delimiterFromComplexCamel);
 
 const delimiterFromPascal: DelimiterCase<'FooBar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromPascal);
@@ -42,14 +37,14 @@ expectType<'foobar'>(noDelimiterFromMono);
 const delimiterFromMixed: DelimiterCase<'foo-bar_abc xyzBarFoo', '#'> = 'foo#bar#abc#xyz#bar#foo';
 expectType<'foo#bar#abc#xyz#bar#foo'>(delimiterFromMixed);
 
-const delimiterFromVendorPrefixedCssProperty: DelimiterCase<'-webkit-animation', '#'> = '#webkit#animation';
-expectType<'#webkit#animation'>(delimiterFromVendorPrefixedCssProperty);
+const delimiterFromVendorPrefixedCssProperty: DelimiterCase<'-webkit-animation', '#'> = 'webkit#animation';
+expectType<'webkit#animation'>(delimiterFromVendorPrefixedCssProperty);
 
-const delimiterFromDoublePrefixedKebab: DelimiterCase<'--very-prefixed', '#'> = '##very#prefixed';
-expectType<'##very#prefixed'>(delimiterFromDoublePrefixedKebab);
+const delimiterFromDoublePrefixedKebab: DelimiterCase<'--very-prefixed', '#'> = 'very#prefixed';
+expectType<'very#prefixed'>(delimiterFromDoublePrefixedKebab);
 
-const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'> = 'foo####bar';
-expectType<'foo####bar'>(delimiterFromRepeatedSeparators);
+const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'> = 'foo#bar';
+expectType<'foo#bar'>(delimiterFromRepeatedSeparators);
 
 const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
 expectType<string>(delimiterFromString);

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -18,3 +18,33 @@ expectType<'foo_bar'>(snakeFromSnake);
 
 const noSnakeFromMono: SnakeCase<'foobar'> = 'foobar';
 expectType<'foobar'>(noSnakeFromMono);
+
+const snakeFromCamelPascal: SnakeCase<'FooBar'> = 'foo_bar';
+expectType<'foo_bar'>(snakeFromCamelPascal);
+
+const snakeFromComplexKebab: SnakeCase<'foo-bar-abc-123'> = 'foo_bar_abc_123';
+expectType<'foo_bar_abc_123'>(snakeFromComplexKebab);
+
+const snakeFromMixed: SnakeCase<'foo-bar_abc xyzBarFoo'> = 'foo_bar_abc_xyz_bar_foo';
+expectType<'foo_bar_abc_xyz_bar_foo'>(snakeFromMixed);
+
+const snakeFromVendorPrefixedCssProperty: SnakeCase<'-webkit-animation'> = 'webkit_animation';
+expectType<'webkit_animation'>(snakeFromVendorPrefixedCssProperty);
+
+const snakeFromDoublePrefixedKebab: SnakeCase<'--very-prefixed'> = 'very_prefixed';
+expectType<'very_prefixed'>(snakeFromDoublePrefixedKebab);
+
+const snakeFromRepeatedSeparators: SnakeCase<'foo____bar'> = 'foo_bar';
+expectType<'foo_bar'>(snakeFromRepeatedSeparators);
+
+const snakeFromUppercase: SnakeCase<'FOO'> = 'foo';
+expectType<'foo'>(snakeFromUppercase);
+
+const snakeFromLowercase: SnakeCase<'foo'> = 'foo';
+expectType<'foo'>(snakeFromLowercase);
+
+const snakeFromScreamingSnakeCase: SnakeCase<'FOO_BAR'> = 'foo_bar';
+expectType<'foo_bar'>(snakeFromScreamingSnakeCase);
+
+const snakeFromScreamingKebabCase: SnakeCase<'FOO-BAR'> = 'foo_bar';
+expectType<'foo_bar'>(snakeFromScreamingKebabCase);


### PR DESCRIPTION
I made some changes that pass more test cases than the current solution. I was heavily inspired by `CamelCase` implementation

Let me know if this is something worth investing more time into or if I'm doing some basic mistake and butchering performance for example

Also, what should be the behavior of `string1` conversion 
* `string1` - this is the current behavior
* `string_1` - another valid behavior
* either one customizable with an option object like `camelCase` - in that case there's still a question of what should be the default (most likely `string1` for backwards compatibility)

Related issues:
https://github.com/sindresorhus/type-fest/issues/223
https://github.com/sindresorhus/type-fest/issues/336