### PR TITLE
Add `StringRepeat` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,6 +155,7 @@ export type {Join} from './source/join';
 export type {Split} from './source/split';
 export type {Trim} from './source/trim';
 export type {Replace} from './source/replace';
+export type {StringRepeat} from './source/string-repeat';
 export type {Includes} from './source/includes';
 export type {Get} from './source/get';
 export type {LastArrayElement} from './source/last-array-element';

--- a/readme.md
+++ b/readme.md
@@ -269,6 +269,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
 - [`Replace`](source/replace.d.ts) - Represents a string with some or all matches replaced by a replacement.
 - [`StringSlice`](source/string-slice.d.ts) - Returns a string slice of a given range, just like `String#slice()`.
+- [`StringRepeat`](source/string-repeat.d.ts) - Returns a new string which contains the specified number of copies of a given string, just like `String#repeat()`.
 
 ### Array
 

--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -1,0 +1,43 @@
+import type {IsNegative} from './numeric';
+import type {Subtract} from './subtract';
+
+/**
+Returns a new string which contains the specified number of copies of a given string, just like `String#repeat()`.
+
+@example
+```
+import {StringRepeat} from 'type-fest';
+
+declare function stringRepeat<
+	Input extends string,
+	Count extends number
+>(input: Input, count: Count): StringRepeat<Input, Count>;
+
+// The return type is the exact string literal, not just `string`.
+
+stringRepeat('foo', 2);
+//=> 'foofoo'
+
+stringRepeat('=', 3);
+//=> '==='
+```
+
+@category String
+@category Template literal
+*/
+export type StringRepeat<
+	Input extends string,
+	Count extends number,
+> = number extends Count
+	? Input extends ''
+		? ''
+		: string
+	: IsNegative<Count> extends true
+		? never
+		: Count extends 0
+			? ''
+			: string extends Input
+				? string
+				: StringRepeat<Input, Subtract<Count, 1>> extends infer R extends string
+					? `${Input}${R}`
+					: never;

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -1,0 +1,19 @@
+import {expectType} from 'tsd';
+import type {StringRepeat} from '../index';
+
+declare const unknown: unknown;
+
+expectType<StringRepeat<'', 0>>('');
+expectType<StringRepeat<'', -1>>(unknown as never);
+expectType<StringRepeat<string, 0>>('');
+expectType<StringRepeat<string, -1>>(unknown as never);
+expectType<StringRepeat<'', number>>('');
+expectType<StringRepeat<string, number>>(unknown as string);
+expectType<StringRepeat<'0', number>>(unknown as string);
+expectType<StringRepeat<'0', -1>>(unknown as never);
+expectType<StringRepeat<'0', 0>>('');
+expectType<StringRepeat<'0', 1>>('0');
+expectType<StringRepeat<'0', 5>>('00000');
+expectType<StringRepeat<'012345-', 0>>('');
+expectType<StringRepeat<'012345-', 1>>('012345-');
+expectType<StringRepeat<'012345-', 5>>('012345-012345-012345-012345-012345-');


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
Closes #827

I saw that the issue has a `help wanted` tag, and I have some free time, so I finished it. 
Note that I renamed it to `StringRepeat` instead of `RepeatString` to make it compatible with `StringSlice`...