### PR TITLE
Add `UnionToTuple` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ export type {Spread} from './source/spread';
 export type {IsInteger} from './source/is-integer';
 export type {IsFloat} from './source/is-float';
 export type {TupleToUnion} from './source/tuple-to-union';
+export type {UnionToTuple} from './source/union-to-tuple';
 export type {IntRange} from './source/int-range';
 export type {IsEqual} from './source/is-equal';
 export type {

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - [`MultidimensionalReadonlyArray`](source/multidimensional-readonly-array.d.ts) - Create a type that represents a multidimensional readonly array of the given type and dimensions.
 - [`ReadonlyTuple`](source/readonly-tuple.d.ts) - Create a type that represents a read-only tuple of the given type and length.
 - [`TupleToUnion`](source/tuple-to-union.d.ts) - Convert a tuple/array into a union type of its elements.
-- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a union type into a unsorted tuple/array type of its elements.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a union type into an unsorted tuple/array type of its elements.
 
 ### Numeric
 

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - [`MultidimensionalReadonlyArray`](source/multidimensional-readonly-array.d.ts) - Create a type that represents a multidimensional readonly array of the given type and dimensions.
 - [`ReadonlyTuple`](source/readonly-tuple.d.ts) - Create a type that represents a read-only tuple of the given type and length.
 - [`TupleToUnion`](source/tuple-to-union.d.ts) - Convert a tuple/array into a union type of its elements.
-- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a union type into an unsorted tuple/array type of its elements.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a union type into an unordered tuple type of its elements.
 
 ### Numeric
 

--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - [`MultidimensionalReadonlyArray`](source/multidimensional-readonly-array.d.ts) - Create a type that represents a multidimensional readonly array of the given type and dimensions.
 - [`ReadonlyTuple`](source/readonly-tuple.d.ts) - Create a type that represents a read-only tuple of the given type and length.
 - [`TupleToUnion`](source/tuple-to-union.d.ts) - Convert a tuple/array into a union type of its elements.
+- [`UnionToTuple`](source/union-to-tuple.d.ts) - Convert a union type into a unsorted tuple/array type of its elements.
 
 ### Numeric
 

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -1,0 +1,54 @@
+import type {IsNever} from './is-never';
+import type {UnionToIntersection} from './union-to-intersection';
+
+/**
+Returns the last element of a union type.
+
+@example
+```
+type Last = LastOfUnion<1 | 2 | 3>;
+//=> 3
+```
+*/
+type LastOfUnion<T> =
+UnionToIntersection<T extends any ? () => T : never> extends () => (infer R)
+	? R
+	: never;
+
+/**
+Convert a union type into a unsorted tuple/array type of its elements.
+
+This can be useful when you have objects with a finite set of keys and want a type defining only the allowed keys, but do not want to repeat yourself.
+
+@example
+```
+import type {UnionToTuple} from 'type-fest';
+
+type Numbers = 1 | 2 | 3;
+type NumbersTuple = UnionToTuple<Numbers>;
+//=> [1, 2, 3]
+```
+
+@example
+```
+import type {UnionToTuple} from 'type-fest';
+
+const pets = {
+  dog: '🐶',
+  cat: '🐱',
+  snake: '🐍',
+};
+
+type Pet = keyof typeof pets;
+//=> "dog" | "cat" | "snake"
+
+const petList = Object.keys(pets) as UnionToUnsortedTuple<Pet>;
+//=> ["dog", "cat", "snake"]
+```
+
+@category Array
+*/
+export type UnionToTuple<T, L = LastOfUnion<T>> =
+IsNever<T> extends false
+	? [...UnionToTuple<Exclude<T, L>>, L]
+	: [];

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -16,7 +16,7 @@ UnionToIntersection<T extends any ? () => T : never> extends () => (infer R)
 	: never;
 
 /**
-Convert a union type into an unsorted tuple/array type of its elements.
+Convert a union type into an unordered tuple type of its elements.
 
 This can be useful when you have objects with a finite set of keys and want a type defining only the allowed keys, but do not want to repeat yourself.
 

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -16,7 +16,7 @@ UnionToIntersection<T extends any ? () => T : never> extends () => (infer R)
 	: never;
 
 /**
-Convert a union type into a unsorted tuple/array type of its elements.
+Convert a union type into an unsorted tuple/array type of its elements.
 
 This can be useful when you have objects with a finite set of keys and want a type defining only the allowed keys, but do not want to repeat yourself.
 
@@ -40,10 +40,10 @@ const pets = {
 };
 
 type Pet = keyof typeof pets;
-//=> "dog" | "cat" | "snake"
+//=> 'dog' | 'cat' | 'snake'
 
 const petList = Object.keys(pets) as UnionToUnsortedTuple<Pet>;
-//=> ["dog", "cat", "snake"]
+//=> ['dog', 'cat', 'snake']
 ```
 
 @category Array

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -42,7 +42,7 @@ const pets = {
 type Pet = keyof typeof pets;
 //=> 'dog' | 'cat' | 'snake'
 
-const petList = Object.keys(pets) as UnionToUnsortedTuple<Pet>;
+const petList = Object.keys(pets) as UnionToTuple<Pet>;
 //=> ['dog', 'cat', 'snake']
 ```
 

--- a/test-d/union-to-tuple.ts
+++ b/test-d/union-to-tuple.ts
@@ -1,0 +1,13 @@
+import {expectAssignable, expectError, expectType} from 'tsd';
+import type {UnionToTuple} from '../index';
+
+type Options = UnionToTuple<'a' | 'b' | 'c'>;
+// Results unordered
+expectAssignable<['a', 'b', 'c'] | ['a', 'c', 'b'] | ['b', 'a', 'c'] | ['b', 'c', 'a'] | ['c', 'a', 'b'] | ['c', 'b', 'a']>({} as Options);
+expectType<Options[number]>({} as ('a' | 'b' | 'c'));
+
+type Options1 = UnionToTuple<1 | 2 | 3>;
+expectType<Options1[number]>({} as (1 | 2 | 3));
+
+type Options2 = UnionToTuple<boolean | 1>;
+expectType<Options2[number]>({} as (1 | false | true));


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

closed #819 

I removed "unordered" from the name, I don't think unordered is necessary in the name, it can be specified in the docs, after all, no one would specifically need to generate an "unordered" array, it's just that the current limitation of ts leads to unordered arrays, so maybe later on it will be possible to optimise the result to be ordered.
