### PR TITLE
`Exact`: Fix usage with recursive types and unions

### DIFF
--- a/source/exact.d.ts
+++ b/source/exact.d.ts
@@ -53,13 +53,14 @@ onlyAcceptNameImproved(invalidInput); // Compilation error
 @category Utilities
 */
 export type Exact<ParameterType, InputType> =
-	// If the parameter is a primitive, return it as is immediately to avoid it being converted to a complex type
-	ParameterType extends Primitive ? ParameterType
-		// If the parameter is an unknown, return it as is immediately to avoid it being converted to a complex type
-		: IsUnknown<ParameterType> extends true ? unknown
-			// If the parameter is a Function, return it as is because this type is not capable of handling function, leave it to TypeScript
-			: ParameterType extends Function ? ParameterType
-				: IsEqual<ParameterType, InputType> extends true ? ParameterType
+	// Before distributing, check if the two types are equal and if so, return the parameter type immediately
+	IsEqual<ParameterType, InputType> extends true ? ParameterType
+		// If the parameter is a primitive, return it as is immediately to avoid it being converted to a complex type
+		: ParameterType extends Primitive ? ParameterType
+			// If the parameter is an unknown, return it as is immediately to avoid it being converted to a complex type
+			: IsUnknown<ParameterType> extends true ? unknown
+				// If the parameter is a Function, return it as is because this type is not capable of handling function, leave it to TypeScript
+				: ParameterType extends Function ? ParameterType
 					// Convert union of array to array of union: A[] & B[] => (A & B)[]
 					: ParameterType extends unknown[] ? Array<Exact<ArrayElement<ParameterType>, ArrayElement<InputType>>>
 						// In TypeScript, Array is a subtype of ReadonlyArray, so always test Array before ReadonlyArray.

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -537,3 +537,19 @@ import type {Exact, Opaque} from '../index';
 	// @ts-expect-error
 	function_(withExcessSurname);
 }
+
+// Spec - recursive type with union
+// @see https://github.com/sindresorhus/type-fest/issues/948
+{
+	type A = {
+		a: Expected;
+	};
+	type B = {
+		b: string;
+	};
+	type Expected = A | B;
+
+	const function_ = <T extends Exact<Expected, T>>(arguments_: T) => arguments_;
+
+	function_({} as Expected);
+}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #948

This moves `IsEqual` to be the first check, before any distribution, restoring the behavior before #911.

Wrote a test for it, and all tests are still passing, including those written for #911!