### PR TITLE
docs(entries): fix code example

### DIFF
--- a/source/entries.d.ts
+++ b/source/entries.d.ts
@@ -42,7 +42,7 @@ const arrayEntries: Entries<typeof arrayExample> = [[0, 'a'], [1, 1]];
 
 // Maps
 const mapExample = new Map([['a', 1]]);
-const mapEntries: Entries<typeof map> = [['a', 1]];
+const mapEntries: Entries<typeof mapExample> = [['a', 1]];
 
 // Sets
 const setExample = new Set(['a', 1]);


### PR DESCRIPTION
Fix `map` example code for `Entries` type.

Similar:
https://github.com/sindresorhus/type-fest/pull/186/files