### PR TITLE
`Get`: Fix handling of paths with number template literal

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -127,8 +127,20 @@ type PropertyOf<BaseType, Key extends string, Options extends GetOptions = {}> =
 		? undefined
 		: Key extends keyof BaseType
 			? StrictPropertyOf<BaseType, Key, Options>
-			: BaseType extends readonly [] | readonly [unknown, ...unknown[]]
-				? unknown // It's a tuple, but `Key` did not extend `keyof BaseType`. So the index is out of bounds.
+			// Handle arrays and tuples
+			: BaseType extends readonly unknown[]
+				? Key extends `${number}`
+					// For arrays with unknown length (regular arrays)
+					? number extends BaseType['length']
+						? Strictify<BaseType[number], Options>
+						// For tuples: check if the index is valid
+						: Key extends keyof BaseType
+							? Strictify<BaseType[Key & keyof BaseType], Options>
+							// Out-of-bounds access for tuples
+							: unknown
+					// Non-numeric string key for arrays/tuples
+					: unknown
+				// Handle array-like objects
 				: BaseType extends {
 					[n: number]: infer Item;
 					length: number; // Note: This is needed to avoid being too lax with records types using number keys like `{0: string; 1: boolean}`.

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -148,4 +148,7 @@ expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, readonly []>>()
 
 	type FooPaths = `array.${number}`;
 	expectTypeOf<Get<Foo, FooPaths>>().toEqualTypeOf<string | undefined>();
+
+	type FooPaths2 = 'array.1';
+	expectTypeOf<Get<Foo, FooPaths2>>().toEqualTypeOf<string | undefined>();
 }

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -139,3 +139,13 @@ expectTypeOf<Get<{a: readonly []}, 'a[0]'>>().toEqualTypeOf<unknown>();
 // Test empty path array
 expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, []>>();
 expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, readonly []>>();
+
+// eslint-disable-next-line no-lone-blocks
+{
+	type Foo = {
+		array: string[];
+	};
+
+	type FooPaths = `array.${number}`;
+	expectTypeOf<Get<Foo, FooPaths>>().toEqualTypeOf<string | undefined>();
+}


### PR DESCRIPTION
Fixes #967

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
