### PR TITLE
`ArrayTail`: Fix support for optional parameters

### DIFF
--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -22,4 +22,8 @@ add3(4);
 
 @category Array
 */
-export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown, ...infer Tail] ? Tail : [];
+export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown?, ...infer Tail]
+	? keyof TArray & `${number}` extends never
+		? []
+		: Tail
+	: [];

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -10,3 +10,17 @@ expectType<[]>(getArrayTail(['a', 'b', 'c']));
 expectType<[]>(getArrayTail([] as const));
 expectType<[]>(getArrayTail(['a'] as const));
 expectType<['b', 'c']>(getArrayTail(['a', 'b', 'c'] as const));
+
+// Optional elements tests
+expectType<[undefined, 'c']>(getArrayTail(['a', undefined, 'c'] as const));
+
+// Mixed optional/required
+type MixedArray = [string, undefined?, number?];
+expectType<[undefined?, number?]>(getArrayTail(['hello'] as MixedArray));
+
+// Optional numbers
+expectType<[undefined, 3]>(getArrayTail([1, undefined, 3] as const));
+
+// Complex mixed case
+type ComplexArray = [string, boolean, number?, string?];
+expectType<[boolean, number?, string?]>(getArrayTail(['test', false] as ComplexArray));


### PR DESCRIPTION
Fixes #978
