### PR TITLE
`SharedUnionFieldsDeep`: Fix propagation for non union root types

### DIFF
--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -83,7 +83,15 @@ function displayPetInfo(petInfo: SharedUnionFieldsDeep<Cat | Dog>['info']) {
 export type SharedUnionFieldsDeep<Union, Options extends SharedUnionFieldsDeepOptions = {recurseIntoArrays: false}> =
 // If `Union` is not a union type, return `Union` directly.
 IsUnion<Union> extends false
-	? Union
+	? Union extends NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+		? Union
+		: Union extends UnknownArray
+			? Options['recurseIntoArrays'] extends true
+				? SetArrayAccess<SharedArrayUnionFieldsDeep<Union, Options>, IsArrayReadonly<Union>>
+				: Union
+			: Union extends object
+				? SharedObjectUnionFieldsDeep<Union, Options>
+				: Union
 	// `Union extends` will convert `Union`
 	// to a [distributive conditionaltype](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
 	// But this is not what we want, so we need to wrap `Union` with `[]` to prevent it.

--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -81,21 +81,10 @@ function displayPetInfo(petInfo: SharedUnionFieldsDeep<Cat | Dog>['info']) {
 @category Union
 */
 export type SharedUnionFieldsDeep<Union, Options extends SharedUnionFieldsDeepOptions = {recurseIntoArrays: false}> =
-// If `Union` is not a union type, return `Union` directly.
-IsUnion<Union> extends false
-	? Union extends NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
-		? Union
-		: Union extends UnknownArray
-			? Options['recurseIntoArrays'] extends true
-				? SetArrayAccess<SharedArrayUnionFieldsDeep<Union, Options>, IsArrayReadonly<Union>>
-				: Union
-			: Union extends object
-				? SharedObjectUnionFieldsDeep<Union, Options>
-				: Union
 	// `Union extends` will convert `Union`
 	// to a [distributive conditionaltype](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
 	// But this is not what we want, so we need to wrap `Union` with `[]` to prevent it.
-	: [Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>]
+	[Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>]
 		? Union
 		: [Union] extends [UnknownArray]
 			? Options['recurseIntoArrays'] extends true

--- a/test-d/shared-union-fields-deep.ts
+++ b/test-d/shared-union-fields-deep.ts
@@ -128,3 +128,7 @@ expectType<{tuple: [number, string, ...Array<string | boolean>]}>(nonFixedLength
 type TestingType2 = TestingType & {foo: any};
 declare const same: SharedUnionFieldsDeepRecurseIntoArrays<TestingType | TestingType2>;
 expectType<TestingType>(same);
+
+// Test for propagation with non union root object
+declare const nonUnionRootType: SharedUnionFieldsDeep<{union: {number: number; boolean: boolean} | {number: number}}>;
+expectType<{union: {number: number}}>(nonUnionRootType);


### PR DESCRIPTION
`SharedUnionFieldsDeep` is not propagating deeply when root type is not a union type.

This PR aims to fix this.