### PR TITLE
Link the licenses from the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1051,4 +1051,4 @@ You can find some examples in the [TypeScript docs](https://www.typescriptlang.o
 
 ## License
 
-SPDX-License-Identifier: (MIT OR CC0-1.0)
+SPDX-License-Identifier: ([MIT](license-mit) OR [CC0-1.0](license-cc0))

--- a/readme.md
+++ b/readme.md
@@ -1051,4 +1051,7 @@ You can find some examples in the [TypeScript docs](https://www.typescriptlang.o
 
 ## License
 
-SPDX-License-Identifier: ([MIT](license-mit) OR [CC0-1.0](license-cc0))
+- [MIT](license-mit)
+- [CC0-1.0](license-cc0)
+
+SPDX-License-Identifier: (MIT OR CC0-1.0)


### PR DESCRIPTION
## Description

This PR adds links to the MIT and CC0 license files in the readme's license section. This makes it easier for users to directly access the full license texts.