### PR TITLE
`ArraySlice`: Fix support for union input

### DIFF
--- a/source/array-slice.d.ts
+++ b/source/array-slice.d.ts
@@ -59,11 +59,13 @@ export type ArraySlice<
 	Array_ extends readonly unknown[],
 	Start extends number = never,
 	End extends number = never,
-> = And<IsEqual<Start, never>, IsEqual<End, never>> extends true
-	? Array_
-	: number extends Array_['length']
-		? VariableLengthArraySliceHelper<Array_, Start, End>
-		: ArraySliceHelper<Array_, IsEqual<Start, never> extends true ? 0 : Start, IsEqual<End, never> extends true ? Array_['length'] : End>;
+> = Array_ extends unknown // To distributive type
+	? And<IsEqual<Start, never>, IsEqual<End, never>> extends true
+		? Array_
+		: number extends Array_['length']
+			? VariableLengthArraySliceHelper<Array_, Start, End>
+			: ArraySliceHelper<Array_, IsEqual<Start, never> extends true ? 0 : Start, IsEqual<End, never> extends true ? Array_['length'] : End>
+	: never; // Never happens
 
 type VariableLengthArraySliceHelper<
 	Array_ extends readonly unknown[],

--- a/test-d/array-slice.ts
+++ b/test-d/array-slice.ts
@@ -2,6 +2,8 @@ import {expectType} from 'tsd';
 import type {ArraySlice} from '../index';
 
 expectType<ArraySlice<[0, 1, 2, 3]>>([0, 1, 2, 3]);
+expectType<ArraySlice<[0, 1, 2] | [0, 1, 2, 3], 0>>({} as [0, 1, 2] | [0, 1, 2, 3]);
+expectType<ArraySlice<[0, 1, 2] | [3, 2, 1, 0], 0, 2>>({} as [0, 1] | [3, 2]);
 expectType<ArraySlice<[0, 1, 2, 3]>>([0, 1, 2, 3]);
 expectType<ArraySlice<[0, 1, 2, 3], 1>>([1, 2, 3]);
 expectType<ArraySlice<[0, 1, 2, 3], 1, 2>>([1]);


### PR DESCRIPTION
fix arraySlice：ArraySlice: wrong type for union of tuples

Fixes https://github.com/sindresorhus/type-fest/issues/982