### PR TITLE
`IsAny`: Fix circular constraint error on TypeScript 5.4+

### DIFF
--- a/source/is-any.d.ts
+++ b/source/is-any.d.ts
@@ -1,3 +1,7 @@
+// Can eventually be replaced with the built-in once this library supports
+// TS5.4+ only. Tracked in https://github.com/sindresorhus/type-fest/issues/848
+type NoInfer<T> = T extends infer U ? U : never;
+
 /**
 Returns a boolean for whether the given type is `any`.
 

--- a/source/is-any.d.ts
+++ b/source/is-any.d.ts
@@ -26,4 +26,4 @@ const anyA = get(anyObject, 'a');
 @category Type Guard
 @category Utilities
 */
-export type IsAny<T> = 0 extends 1 & T ? true : false;
+export type IsAny<T> = 0 extends 1 & NoInfer<T> ? true : false;

--- a/test-d/is-any.ts
+++ b/test-d/is-any.ts
@@ -19,7 +19,7 @@ expectType<IsAny<void>>(false);
 // @ts-expect-error
 type A = IsAny;
 
-// Verify that are no circular reference issues   
+// Verify that are no circular reference issues
 // https://github.com/sindresorhus/type-fest/issues/846
 type OnlyAny<T extends IsAny<T> extends true ? any : never> = T;
 type B = OnlyAny<any>;

--- a/test-d/is-any.ts
+++ b/test-d/is-any.ts
@@ -18,3 +18,10 @@ expectType<IsAny<void>>(false);
 // Missing generic parameter
 // @ts-expect-error
 type A = IsAny;
+
+// Verify that are no circular reference issues   
+// https://github.com/sindresorhus/type-fest/issues/846
+type OnlyAny<T extends IsAny<T> extends true ? any : never> = T;
+type B = OnlyAny<any>
+// @ts-expect-error
+type C = OnlyAny<string>

--- a/test-d/is-any.ts
+++ b/test-d/is-any.ts
@@ -22,6 +22,6 @@ type A = IsAny;
 // Verify that are no circular reference issues   
 // https://github.com/sindresorhus/type-fest/issues/846
 type OnlyAny<T extends IsAny<T> extends true ? any : never> = T;
-type B = OnlyAny<any>
+type B = OnlyAny<any>;
 // @ts-expect-error
-type C = OnlyAny<string>
+type C = OnlyAny<string>;


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/846

Applied the solution suggested in https://github.com/sindresorhus/type-fest/issues/846#issuecomment-2024296549. 

Open to feedback on if the test is easy to follow. It was tricky to find a failing case using only the type system as noted [here](https://github.com/sindresorhus/type-fest/issues/846#issuecomment-2024934767). I did verify that it is broken before the fix!