### PR TITLE
Add test cases for `ArrayTail` type

### DIFF
--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -24,3 +24,7 @@ expectType<[undefined, 3]>(getArrayTail([1, undefined, 3] as const));
 // Complex mixed case
 type ComplexArray = [string, boolean, number?, string?];
 expectType<[boolean, number?, string?]>(getArrayTail(['test', false] as ComplexArray));
+
+// All optional elements
+expectType<['b'?]>([] as ArrayTail<['a'?, 'b'?]>);
+

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -28,3 +28,5 @@ expectType<[boolean, number?, string?]>(getArrayTail(['test', false] as ComplexA
 // All optional elements
 expectType<['b'?]>([] as ArrayTail<['a'?, 'b'?]>);
 
+// Union of tuples
+expectType<[] | ['b']>([] as ArrayTail<[] | ['a', 'b']>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

The behaviour of `ArrayTail` with tuples containing all optional elements was recently fixed in [this PR](https://github.com/sindresorhus/type-fest/pull/977). However, as mentioned [here](https://github.com/sindresorhus/type-fest/pull/977#discussion_r1866189549), there are no tests currently covering this scenario.