### PR TITLE
`SharedUnionFields`: Simplify implementation

### DIFF
--- a/source/shared-union-fields.d.ts
+++ b/source/shared-union-fields.d.ts
@@ -63,21 +63,9 @@ function displayPetInfo(petInfo: SharedUnionFields<Cat | Dog>) {
 @category Union
 */
 export type SharedUnionFields<Union> =
-// If `Union` is not a union type, return `Union` directly.
-IsUnion<Union> extends false
-	? Union
 	// `Union extends` will convert `Union`
 	// to a [distributive conditionaltype](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
 	// But this is not what we want, so we need to wrap `Union` with `[]` to prevent it.
-	: [Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray]
+	[Union] extends [NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray]
 		? Union
-		: [Union] extends [object]
-			// `keyof Union` can extract the same key in union type, if there is no same key, return never.
-			? keyof Union extends infer Keys
-				? IsNever<Keys> extends false
-					? {
-						[Key in keyof Union]: Union[Key]
-					}
-					: {}
-				: Union
-			: Union;
+		: Pick<Union, keyof Union>;

--- a/test-d/shared-union-fields.ts
+++ b/test-d/shared-union-fields.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import type {SharedUnionFields} from '../index';
+import {type NonRecursiveType} from '../source/internal';
 
 type TestingType = {
 	function: (() => void);
@@ -82,3 +83,7 @@ expectType<{union: 'test1' | 'test2' | {a: number}}>(union);
 
 declare const unionWithOptional: SharedUnionFields<{a?: string; foo: number} | {a: string; bar: string}>;
 expectType<{a?: string}>(unionWithOptional);
+
+expectType<Set<string> | Map<string, string>>({} as Set<string> | Map<string, string>);
+expectType<string[] | Set<string>>({} as string[] | Set<string>);
+expectType<NonRecursiveType>({} as NonRecursiveType);

--- a/test-d/shared-union-fields.ts
+++ b/test-d/shared-union-fields.ts
@@ -1,6 +1,6 @@
 import {expectType} from 'tsd';
 import type {SharedUnionFields} from '../index';
-import {type NonRecursiveType} from '../source/internal';
+import type {NonRecursiveType} from '../source/internal';
 
 type TestingType = {
 	function: (() => void);

--- a/test-d/shared-union-fields.ts
+++ b/test-d/shared-union-fields.ts
@@ -84,6 +84,16 @@ expectType<{union: 'test1' | 'test2' | {a: number}}>(union);
 declare const unionWithOptional: SharedUnionFields<{a?: string; foo: number} | {a: string; bar: string}>;
 expectType<{a?: string}>(unionWithOptional);
 
+// Non-recursive types
 expectType<Set<string> | Map<string, string>>({} as Set<string> | Map<string, string>);
 expectType<string[] | Set<string>>({} as string[] | Set<string>);
 expectType<NonRecursiveType>({} as NonRecursiveType);
+
+// Mix of non-recursive and recursive types
+expectType<{a: string | number} | undefined>({} as SharedUnionFields<{a: string} | {a: number; b: true} | undefined>);
+expectType<RegExp | {test: string}>({} as SharedUnionFields<RegExp | {test: string}>);
+expectType<RegExp | null | {test: string | number}>({} as SharedUnionFields<RegExp | null | {test: string} | {test: number; foo: any}>);
+
+// Boundary types
+expectType<any>({} as SharedUnionFields<any>);
+expectType<never>({} as SharedUnionFields<never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Simplifies the implementation of `SharedUnionFields` type, as [mentioned here](https://github.com/sindresorhus/type-fest/pull/994#discussion_r1869150867). `ShareUnionFields` is essentially just `Pick` with an extra conditional for non-recursive types.

Also, adds test cases to cover the non-recursive check, as [mentioned here](https://github.com/sindresorhus/type-fest/pull/994#discussion_r1868923345).