### PR TITLE
`Arrayable`: Make it more usable by removing `readonly`

### DIFF
--- a/source/arrayable.d.ts
+++ b/source/arrayable.d.ts
@@ -23,4 +23,4 @@ bundle('src/index.js', ['dist/index.cjs', 'dist/index.mjs']);
 
 @category Array
 */
-export type Arrayable<T> = T | readonly T[];
+export type Arrayable<T> = T | T[];

--- a/source/arrayable.d.ts
+++ b/source/arrayable.d.ts
@@ -23,4 +23,7 @@ bundle('src/index.js', ['dist/index.cjs', 'dist/index.mjs']);
 
 @category Array
 */
-export type Arrayable<T> = T | T[];
+export type Arrayable<T> =
+T
+// TODO: Use `readonly T[]` when this issue is resolved: https://github.com/microsoft/TypeScript/issues/17002
+| T[];

--- a/source/arrayable.d.ts
+++ b/source/arrayable.d.ts
@@ -13,7 +13,7 @@ function bundle(input: string, output: Arrayable<string>) {
 	// …
 
 	for (const output of outputList) {
-	  console.log(`write to: ${output}`);
+		console.log(`write to: ${output}`);
 	}
 }
 

--- a/test-d/arrayable.ts
+++ b/test-d/arrayable.ts
@@ -3,7 +3,22 @@ import type {Arrayable} from '../index';
 
 declare const unknown: unknown;
 
-expectType<Arrayable<string>>(unknown as string | readonly string[]);
-expectType<Arrayable<string | {foo: number}>>(unknown as (string | {foo: number}) | ReadonlyArray<string | {foo: number}>);
-expectType<Arrayable<never>>(unknown as /* never | */ readonly never[]);
-expectType<Arrayable<string[]>>(unknown as string[] | readonly string[][]);
+expectType<Arrayable<string>>(unknown as string | string[]);
+expectType<Arrayable<string | {foo: number}>>(unknown as (string | {foo: number}) | Array<string | {foo: number}>);
+expectType<Arrayable<never>>(unknown as /* never | */ never[]);
+expectType<Arrayable<string[]>>(unknown as string[] | string[][]);
+
+// Test for issue https://github.com/sindresorhus/type-fest/issues/952
+type Item = number;
+function castArray1(value: Arrayable<Item>): Item[] {
+	return Array.isArray(value) ? value : [value];
+}
+
+expectType<Item[]>(unknown as ReturnType<typeof castArray1>);
+
+function castArray2<T>(value: Arrayable<T>): T[] {
+	return Array.isArray(value) ? value : [value];
+}
+
+expectType<number[]>(castArray2(1));
+expectType<number[]>(castArray2([1, 2, 3]));


### PR DESCRIPTION
fix: #952 
