### PR TITLE
Enable lint rule to enforce consistent import style

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
 					"multiline": true,
 					"consistent": true
 				}
-			]
+			],
+			"import/consistent-type-specifier-style": ["error", "prefer-top-level"]
 		}
 	},
 	"tsd": {

--- a/test-d/writable-deep.ts
+++ b/test-d/writable-deep.ts
@@ -1,7 +1,7 @@
 import {expectType, expectAssignable} from 'tsd';
 import type {JsonValue, Opaque, ReadonlyDeep, WritableDeep} from '../index';
 import type {WritableObjectDeep} from '../source/writable-deep';
-import {type tag} from '../source/tagged';
+import type {tag} from '../source/tagged';
 
 type Overloaded = {
 	(foo: number): string;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Enables the [consistent-type-specifier-style](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md) lint rule from the [import plugin](https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file).

This ensures feedbacks like [this](https://github.com/sindresorhus/type-fest/pull/1000#discussion_r1877580045) are taken care of by the linter. This rule is also automatically fixable:

https://github.com/user-attachments/assets/329eb6da-1108-420f-8487-16e2656b0d07

