### PR TITLE
Add ArrayTailDeep type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ export type {ArrayValues} from './source/array-values';
 export type {ArraySlice} from './source/array-slice';
 export type {ArraySplice} from './source/array-splice';
 export type {ArrayTail} from './source/array-tail';
+export type {ArrayTailDeep} from './source/array-tail-deep';
 export type {SetFieldType} from './source/set-field-type';
 export type {Paths} from './source/paths';
 export type {SharedUnionFields} from './source/shared-union-fields';

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@ Click the type names for complete docs.
 - [`ArrayValues`](source/array-values.d.ts) - Provides all values for a constant array or tuple.
 - [`ArraySplice`](source/array-splice.d.ts) - Creates a new array type by adding or removing elements at a specified index range in the original array.
 - [`ArrayTail`](source/array-tail.d.ts) - Extracts the type of an array or tuple minus the first element.
+- [`ArrayTailDeep`](source/array-tail-deep.d.ts) - Extracts the type of an array or tuple minus the first N element, where N is the specified depth.
 - [`SetFieldType`](source/set-field-type.d.ts) - Create a type that changes the type of the given keys.
 - [`Paths`](source/paths.d.ts) - Generate a union of all possible paths to properties in the given object.
 - [`SharedUnionFields`](source/shared-union-fields.d.ts) - Create a type with shared fields from a union of object types.

--- a/source/array-tail-deep.d.ts
+++ b/source/array-tail-deep.d.ts
@@ -1,0 +1,38 @@
+import type {UnknownArrayOrTuple} from './internal';
+import type {ArrayTail} from './array-tail';
+
+/**
+Extracts the type of an array or tuple minus the first N element, where N is the specified depth.
+
+Use-case: This type is useful when you want to rewrap a function and partially modify some of its parameters.
+
+@example
+```
+import type {ArrayTailDeep} from 'type-fest';
+
+type LocalStorageSchema = { id: string, name: string, token: string };
+class LocalStorage {
+	getItem<Key extends keyof LocalStorageSchema>(
+		key: Key,
+		...rest: ArrayTailDeep<Parameters<typeof localStorage.getItem>, 1>
+	) {
+		return localStorage.getItem(key, ...rest);
+	}
+
+	setItem<Key extends keyof LocalStorageSchema>(
+		key: Key,
+		value: LocalStorageSchema[Key],
+		...rest: ArrayTailDeep<Parameters<typeof localStorage.setItem>, 2>
+	) {
+		return localStorage.setItem(key, value, ...rest);
+	}
+}
+```
+
+@category Array
+*/
+export type ArrayTailDeep<TArray extends UnknownArrayOrTuple, Deep extends number = 1, Counter extends unknown[] = []> = Counter['length'] extends Deep
+	? TArray
+	: TArray['length'] extends 0
+		? TArray
+		: ArrayTailDeep<ArrayTail<TArray>, Deep, [unknown, ...Counter]>;

--- a/source/array-tail-deep.d.ts
+++ b/source/array-tail-deep.d.ts
@@ -34,5 +34,5 @@ class LocalStorage {
 export type ArrayTailDeep<TArray extends UnknownArrayOrTuple, Deep extends number = 1, Counter extends unknown[] = []> = Counter['length'] extends Deep
 	? TArray
 	: TArray['length'] extends 0
-		? TArray
+		? []
 		: ArrayTailDeep<ArrayTail<TArray>, Deep, [unknown, ...Counter]>;

--- a/test-d/array-tail-deep.ts
+++ b/test-d/array-tail-deep.ts
@@ -1,0 +1,35 @@
+import {expectType} from 'tsd';
+import type {ArrayTailDeep} from '../index';
+
+declare const getArrayTailDeep: <T extends readonly unknown[], Deep extends number = 1>(array: T, deep?: Deep) => ArrayTailDeep<T, Deep>;
+
+expectType<[]>(getArrayTailDeep([]));
+expectType<[]>(getArrayTailDeep(['a']));
+expectType<[]>(getArrayTailDeep(['a', 'b', 1, 2] as unknown as [string | number]));
+
+expectType<[]>(getArrayTailDeep([] as const));
+expectType<[]>(getArrayTailDeep(['a'] as const));
+expectType<['b', 'c']>(getArrayTailDeep(['a', 'b', 'c'] as const));
+expectType<['c']>(getArrayTailDeep(['a', 'b', 'c'] as const, 2));
+expectType<[]>(getArrayTailDeep(['a', 'b', 'c'] as const, 3));
+expectType<[]>(getArrayTailDeep(['a', 'b', 'c'] as const, 10));
+
+// Optional elements tests
+expectType<[undefined, 'c']>(getArrayTailDeep(['a', 'b', undefined, 'c'] as const, 2));
+
+// Mixed optional/required
+type MixedArray = [string, boolean?, undefined?, number?];
+expectType<[undefined?, number?]>(getArrayTailDeep(['hello'] as MixedArray, 2));
+
+// Optional numbers
+expectType<[undefined, 3]>(getArrayTailDeep([1, 2, undefined, 3] as const, 2));
+
+// Complex mixed case
+type ComplexArray = [string, number, boolean, number?, string?];
+expectType<[boolean, number?, string?]>(getArrayTailDeep(['test', 1, false] as ComplexArray, 2));
+
+// All optional elements
+expectType<['c'?]>([] as ArrayTailDeep<['a'?, 'b'?, 'c'?], 2>);
+
+// Union of tuples
+expectType<[] | ['c']>([] as ArrayTailDeep<[] | ['a', 'b', 'c'], 2>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Add a new type `ArrayTailDeep`.It is useful when you need to rewrap some function and partially modify its parameters.

Here is a localStorage rewrap example:
```ts
import type {ArrayTailDeep} from 'type-fest';

type LocalStorageSchema = { id: string, name: string, token: string };
class LocalStorage {
	getItem<Key extends keyof LocalStorageSchema>(
		key: Key,
		...rest: ArrayTailDeep<Parameters<typeof localStorage.getItem>, 1>
	) {
		return localStorage.getItem(key, ...rest);
	}

	setItem<Key extends keyof LocalStorageSchema>(
		key: Key,
		value: LocalStorageSchema[Key],
		...rest: ArrayTailDeep<Parameters<typeof localStorage.setItem>, 2>
	) {
		return localStorage.setItem(key, value, ...rest);
	}
}
``` 