### PR TITLE
`KeysOfUnion`: Fix assignability with `keyof`

### DIFF
--- a/source/keys-of-union.d.ts
+++ b/source/keys-of-union.d.ts
@@ -1,3 +1,5 @@
+import type {UnionToIntersection} from './union-to-intersection';
+
 /**
 Create a union of all keys from a given type, even those exclusive to specific union members.
 
@@ -35,6 +37,6 @@ type AllKeys = KeysOfUnion<Union>;
 
 @category Object
 */
-export type KeysOfUnion<ObjectType> = ObjectType extends unknown
-	? keyof ObjectType
-	: never;
+export type KeysOfUnion<ObjectType> =
+  // Hack to fix https://github.com/sindresorhus/type-fest/issues/1008
+  keyof UnionToIntersection<ObjectType extends unknown ? Record<keyof ObjectType, never> : never>;

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -34,6 +34,6 @@ export type SetOptional<BaseType, Keys extends keyof BaseType> =
 		// Pick just the keys that are readonly from the base type.
 		Except<BaseType, Keys> &
 		// Pick the keys that should be mutable from the base type and make them mutable.
-		Partial<HomomorphicPick<BaseType, Keys & KeysOfUnion<BaseType>>>
+		Partial<HomomorphicPick<BaseType, Keys>>
 		>
 		: never;

--- a/source/set-readonly.d.ts
+++ b/source/set-readonly.d.ts
@@ -35,6 +35,6 @@ export type SetReadonly<BaseType, Keys extends keyof BaseType> =
 	BaseType extends unknown
 		? Simplify<
 		Except<BaseType, Keys> &
-		Readonly<HomomorphicPick<BaseType, Keys & KeysOfUnion<BaseType>>>
+		Readonly<HomomorphicPick<BaseType, Keys>>
 		>
 		: never;

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -43,7 +43,7 @@ export type SetRequired<BaseType, Keys extends keyof BaseType> =
 		// Pick just the keys that are optional from the base type.
 		Except<BaseType, Keys> &
 		// Pick the keys that should be required from the base type and make them required.
-		Required<HomomorphicPick<BaseType, Keys & KeysOfUnion<BaseType>>>
+		Required<HomomorphicPick<BaseType, Keys>>
 		>;
 
 /**

--- a/test-d/keys-of-union.ts
+++ b/test-d/keys-of-union.ts
@@ -35,3 +35,25 @@ type Expected2 = 'common' | 'a' | 'b' | 'c';
 declare const actual2: KeysOfUnion<Example2>;
 
 expectType<Expected2>(actual2);
+
+// With property modifiers
+declare const actual3: KeysOfUnion<{a?: string; readonly b: number} | {a: number; b: string}>;
+expectType<'a' | 'b'>(actual3);
+
+// KeysOfUnion<T> should NOT be assignable to keyof T
+type Assignability1<T, _K extends keyof T> = unknown;
+// @ts-expect-error
+type Test1<T> = Assignability1<T, KeysOfUnion<T>>;
+
+// Keyof T should be assignable to KeysOfUnion<T>
+type Assignability2<T, _K extends KeysOfUnion<T>> = unknown;
+type Test2<T> = Assignability2<T, keyof T>;
+
+// KeysOfUnion<T> should be assignable to PropertyKey
+type Assignability3<_T, _K extends PropertyKey> = unknown;
+type Test3<T> = Assignability3<T, KeysOfUnion<T>>;
+
+// PropertyKey should NOT be assignable to KeysOfUnion<T>
+type Assignability4<T, _K extends KeysOfUnion<T>> = unknown;
+// @ts-expect-error
+type Test4<T> = Assignability4<T, PropertyKey>;

--- a/test-d/keys-of-union.ts
+++ b/test-d/keys-of-union.ts
@@ -40,20 +40,20 @@ expectType<Expected2>(actual2);
 declare const actual3: KeysOfUnion<{a?: string; readonly b: number} | {a: number; b: string}>;
 expectType<'a' | 'b'>(actual3);
 
-// KeysOfUnion<T> should NOT be assignable to keyof T
+// `KeysOfUnion<T>` should NOT be assignable to `keyof T`
 type Assignability1<T, _K extends keyof T> = unknown;
 // @ts-expect-error
 type Test1<T> = Assignability1<T, KeysOfUnion<T>>;
 
-// Keyof T should be assignable to KeysOfUnion<T>
+// `keyof T` should be assignable to `KeysOfUnion<T>`
 type Assignability2<T, _K extends KeysOfUnion<T>> = unknown;
 type Test2<T> = Assignability2<T, keyof T>;
 
-// KeysOfUnion<T> should be assignable to PropertyKey
+// `KeysOfUnion<T>` should be assignable to `PropertyKey`
 type Assignability3<_T, _K extends PropertyKey> = unknown;
 type Test3<T> = Assignability3<T, KeysOfUnion<T>>;
 
-// PropertyKey should NOT be assignable to KeysOfUnion<T>
+// `PropertyKey` should NOT be assignable to `KeysOfUnion<T>`
 type Assignability4<T, _K extends KeysOfUnion<T>> = unknown;
 // @ts-expect-error
 type Test4<T> = Assignability4<T, PropertyKey>;

--- a/test-d/keys-of-union.ts
+++ b/test-d/keys-of-union.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {KeysOfUnion} from '../index';
+import type {KeysOfUnion, UnknownRecord} from '../index';
 
 // When passing types that are not unions, it behaves exactly as the `keyof` operator.
 
@@ -57,3 +57,30 @@ type Test3<T> = Assignability3<T, KeysOfUnion<T>>;
 type Assignability4<T, _K extends KeysOfUnion<T>> = unknown;
 // @ts-expect-error
 type Test4<T> = Assignability4<T, PropertyKey>;
+
+// `keyof T` should be assignable to `KeysOfUnion<T>` even when `T` is constrained to `Record<string, unknown>`
+type Assignability5<T extends Record<string, unknown>, _K extends KeysOfUnion<T>> = unknown;
+type Test5<T extends Record<string, unknown>> = Assignability5<T, keyof T>;
+
+// `keyof T` should be assignable to `KeysOfUnion<T>` even when `T` is constrained to `object`
+type Assignability6<T extends object, _K extends KeysOfUnion<T>> = unknown;
+type Test6<T extends object> = Assignability6<T, keyof T>;
+
+// `keyof T` should be assignable to `KeysOfUnion<T>` even when `T` is constrained to `UnknownRecord`
+type Assignability7<T extends UnknownRecord, _K extends KeysOfUnion<T>> = unknown;
+type Test7<T extends UnknownRecord> = Assignability7<T, keyof T>;
+
+// `KeysOfUnion<T>` should NOT be assignable to `keyof T` even when `T` is constrained to `Record<string, unknown>`
+type Assignability8<T extends Record<string, unknown>, _K extends keyof T> = unknown;
+// @ts-expect-error
+type Test8<T extends Record<string, unknown>> = Assignability8<T, KeysOfUnion<T>>;
+
+// `KeysOfUnion<T>` should NOT be assignable to `keyof T` even when `T` is constrained to `object`
+type Assignability9<T extends object, _K extends keyof T> = unknown;
+// @ts-expect-error
+type Test9<T extends object> = Assignability9<T, KeysOfUnion<T>>;
+
+// `KeysOfUnion<T>` should NOT be assignable to `keyof T` even when `T` is constrained to `UnknownRecord`
+// type Assignability10<T extends UnknownRecord, _K extends keyof T> = unknown;
+// The following line should error but it doesn't, this is an issue with the existing implementation of `KeysOfUnion`
+// type Test10<T extends UnknownRecord> = Assignability10<T, KeysOfUnion<T>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1008

To make `keyof T` assignable to `KeysOfUnion<T>`, we can simply add an union with `keyof ObjectType` to the existing type, as shown below. 

```ts
type KeysOfUnion<ObjectType> =
 | keyof ObjectType
 | ObjectType extends unknown ? keyof ObjectType : never;
```

However, I couldn’t find a straightforward way to prevent `KeysOfUnion<T>` from being assignable to `keyof T`. So, I reworked the implementation to use `UnionToIntersection`, which resolves both issues.

<hr>

There's another hack I figured out while experimenting, this also solves both the issues, but it's very hacky:
```ts
type KeysOfUnion<ObjectType> =
  | keyof ObjectType // Convinces TS that keyof T is part of KeysOfUnion<T>
  | ObjectType extends unknown ? keyof ObjectType: never
  | Extract<Uppercase<string>, Lowercase<ObjectType & string>>; // Convinces TS that KeysOfUnion<T> is broader than keyof T

// keyof T should be assignable to KeysOfUnion<T>
type Assignability2<T, K extends KeysOfUnion<T>> = unknown;
type Test2<T> = Assignability2<T, keyof T>; // doesn't error now

// KeysOfUnion<T> should not be assignable to keyof T
type Assignability1<T, K extends keyof T> = unknown;
type Test1<T> = Assignability1<T, KeysOfUnion<T>>; // does error now
```
[Playground](https://tsplay.dev/mZRl4m)