### PR TITLE
`PartialDeep`: Add `allowUndefinedInArrays` option

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -12,11 +12,14 @@ export type PartialDeepOptions = {
 	readonly recurseIntoArrays?: boolean;
 
 	/**
-	Allows undefined values in non-tuple arrays. When set to `true`, elements of non-tuple arrays can be `undefined`. When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking. Defaults to `true` if not specified.
+	Allows `undefined` values in non-tuple arrays.
+
+	- When set to `true`, elements of non-tuple arrays can be `undefined`.
+	- When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking.
 
 	@default true
 	@example
-	You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
+	You can prevent `undefined` values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
 
 	```
 	interface Settings {

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -18,10 +18,13 @@ export type PartialDeepOptions = {
 	- When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking.
 
 	@default true
+
 	@example
-	You can prevent `undefined` values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
+	You can prevent `undefined` values in non-tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
 
 	```
+	import type {PartialDeep} from 'type-fest';
+
 	type Settings = {
 		languages: string[];
 	};
@@ -48,12 +51,12 @@ import type {PartialDeep} from 'type-fest';
 
 const settings: Settings = {
 	textEditor: {
-		fontSize: 14;
-		fontColor: '#000000';
-		fontWeight: 400;
-	}
-	autocomplete: false;
-	autosave: true;
+		fontSize: 14,
+		fontColor: '#000000',
+		fontWeight: 400
+	},
+	autocomplete: false,
+	autosave: true
 };
 
 const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
@@ -68,7 +71,7 @@ By default, this does not affect elements in array and tuple types. You can chan
 ```
 import type {PartialDeep} from 'type-fest';
 
-interface Settings {
+type Settings = {
 	languages: string[];
 }
 

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,7 +1,7 @@
 import type {BuiltIns} from './internal';
 
 /**
-@see PartialDeep
+@see {@link PartialDeep}
 */
 export type PartialDeepOptions = {
 	/**
@@ -73,6 +73,8 @@ const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 	languages: [undefined]
 };
 ```
+
+@see {@link PartialDeepOptions}
 
 @category Object
 @category Array

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -12,11 +12,11 @@ export type PartialDeepOptions = {
 	readonly recurseIntoArrays?: boolean;
 
 	/**
-	Whether to authorize undefined values in arrays.
+    Allows undefined values in non-tuple arrays. When set to `true`, elements of non-tuple arrays can be `undefined`. When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking. Defaults to `true` if not specified.
 
-	@default true
+    @default true
 	*/
-	readonly allowUndefinedInArrays?: boolean;
+	readonly allowUndefinedInNonTupleArrays?: boolean;
 };
 
 /**
@@ -60,8 +60,7 @@ const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 	languages: [undefined]
 };
 ```
-
-You can prevent undefined values in recurse arrays and tuples by passing `{recurseIntoArrays: true; allowUndefinedInArrays: false}` as the second type argument:
+You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
 
 ```
 import type {PartialDeep} from 'type-fest';
@@ -70,9 +69,9 @@ interface Settings {
 	languages: string[];
 }
 
-const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInArrays: false}> = {
+const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
 	languages: [undefined] 	// Error
-	languages: []			// OK
+	languages: []		// OK
 };
 ```
 
@@ -96,8 +95,8 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 							? Options['recurseIntoArrays'] extends true
 								? ItemType[] extends T // Test for arrays (non-tuples) specifically
 									? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
-										? ReadonlyArray<PartialDeep<Options['allowUndefinedInArrays'] extends false ? ItemType : ItemType | undefined, Options>>
-										: Array<PartialDeep<Options['allowUndefinedInArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										? ReadonlyArray<PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										: Array<PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
 									: PartialObjectDeep<T, Options> // Tuples behave properly
 								: T // If they don't opt into array testing, just use the original type
 							: PartialObjectDeep<T, Options>

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -22,14 +22,14 @@ export type PartialDeepOptions = {
 	You can prevent `undefined` values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
 
 	```
-	interface Settings {
+	type Settings = {
 		languages: string[];
-	}
-
-	const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
-		languages: [undefined]	// Error
-		languages: []		// OK
 	};
+
+	declare const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}>;
+
+	partialSettings.languages = [undefined]; // Error
+	partialSettings.languages = []; // Ok
 	```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -10,6 +10,13 @@ export type PartialDeepOptions = {
 	@default false
 	*/
 	readonly recurseIntoArrays?: boolean;
+
+	/**
+	Whether to authorize undefined values in arrays and tuples.
+
+	@default true
+	*/
+	readonly allowUndefinedInArrays?: boolean;
 };
 
 /**
@@ -54,6 +61,21 @@ const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 };
 ```
 
+You can prevent undefined values in recurse arrays and tuples by passing `{recurseIntoArrays: true; allowUndefinedInArrays: false}` as the second type argument:
+
+```
+import type {PartialDeep} from 'type-fest';
+
+interface Settings {
+	languages: string[];
+}
+
+const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInArrays: false}> = {
+	languages: [undefined] 	// Error
+	languages: []			// OK
+};
+```
+
 @category Object
 @category Array
 @category Set
@@ -74,8 +96,8 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 							? Options['recurseIntoArrays'] extends true
 								? ItemType[] extends T // Test for arrays (non-tuples) specifically
 									? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
-										? ReadonlyArray<PartialDeep<ItemType | undefined, Options>>
-										: Array<PartialDeep<ItemType | undefined, Options>>
+										? ReadonlyArray<PartialDeep<Options['allowUndefinedInArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										: Array<PartialDeep<Options['allowUndefinedInArrays'] extends false ? ItemType : ItemType | undefined, Options>>
 									: PartialObjectDeep<T, Options> // Tuples behave properly
 								: T // If they don't opt into array testing, just use the original type
 							: PartialObjectDeep<T, Options>

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -15,6 +15,19 @@ export type PartialDeepOptions = {
     Allows undefined values in non-tuple arrays. When set to `true`, elements of non-tuple arrays can be `undefined`. When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking. Defaults to `true` if not specified.
 
     @default true
+    @example
+    You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
+
+```
+interface Settings {
+	languages: string[];
+}
+
+const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
+	languages: [undefined] 	// Error
+	languages: []		// OK
+};
+```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;
 };
@@ -58,20 +71,6 @@ interface Settings {
 
 const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 	languages: [undefined]
-};
-```
-You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
-
-```
-import type {PartialDeep} from 'type-fest';
-
-interface Settings {
-	languages: string[];
-}
-
-const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
-	languages: [undefined] 	// Error
-	languages: []		// OK
 };
 ```
 

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -12,7 +12,7 @@ export type PartialDeepOptions = {
 	readonly recurseIntoArrays?: boolean;
 
 	/**
-	Whether to authorize undefined values in arrays and tuples.
+	Whether to authorize undefined values in arrays.
 
 	@default true
 	*/

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -12,22 +12,22 @@ export type PartialDeepOptions = {
 	readonly recurseIntoArrays?: boolean;
 
 	/**
-    Allows undefined values in non-tuple arrays. When set to `true`, elements of non-tuple arrays can be `undefined`. When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking. Defaults to `true` if not specified.
+	Allows undefined values in non-tuple arrays. When set to `true`, elements of non-tuple arrays can be `undefined`. When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking. Defaults to `true` if not specified.
 
-    @default true
-    @example
-    You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
+	@default true
+	@example
+	You can prevent undefined values in non tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
 
-```
-interface Settings {
-	languages: string[];
-}
+	```
+	interface Settings {
+		languages: string[];
+	}
 
-const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
-	languages: [undefined] 	// Error
-	languages: []		// OK
-};
-```
+	const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = {
+		languages: [undefined]	// Error
+		languages: []		// OK
+	};
+	```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;
 };

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -79,6 +79,14 @@ expectAssignable<PartialDeep<RecurseObject>>(recurseObject);
 const partialDeepNoRecurseIntoArraysFoo: PartialDeep<typeof foo> = foo;
 // Check that `{recurseIntoArrays: true}` behaves as intended
 expectType<PartialDeep<typeof foo, {recurseIntoArrays: true}>>(partialDeepFoo);
+
+// Check that `{allowUndefinedInArrays: true}` is the default
+const partialDeepAllowUndefinedInArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true}> = foo;
+expectType<Array<string | undefined> | undefined>(partialDeepAllowUndefinedInArraysFoo.bar!.array);
+// Check that `{allowUndefinedInArrays: false}` behaves as intended
+const partialDeepDoNotAllowUndefinedInArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true; allowUndefinedInArrays: false}> = foo;
+expectType<string[] | undefined>(partialDeepDoNotAllowUndefinedInArraysFoo.bar!.array);
+
 // These are mostly the same checks as before, but the array/tuple types are different.
 // @ts-expect-error
 expectType<Partial<typeof foo>>(partialDeepNoRecurseIntoArraysFoo);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -80,12 +80,12 @@ const partialDeepNoRecurseIntoArraysFoo: PartialDeep<typeof foo> = foo;
 // Check that `{recurseIntoArrays: true}` behaves as intended
 expectType<PartialDeep<typeof foo, {recurseIntoArrays: true}>>(partialDeepFoo);
 
-// Check that `{allowUndefinedInArrays: true}` is the default
-const partialDeepAllowUndefinedInArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true}> = foo;
-expectType<Array<string | undefined> | undefined>(partialDeepAllowUndefinedInArraysFoo.bar!.array);
-// Check that `{allowUndefinedInArrays: false}` behaves as intended
-const partialDeepDoNotAllowUndefinedInArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true; allowUndefinedInArrays: false}> = foo;
-expectType<string[] | undefined>(partialDeepDoNotAllowUndefinedInArraysFoo.bar!.array);
+// Check that `{allowUndefinedInNonTupleArrays: true}` is the default
+const partialDeepAllowUndefinedInNonTupleArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true}> = foo;
+expectType<Array<string | undefined> | undefined>(partialDeepAllowUndefinedInNonTupleArraysFoo.bar!.array);
+// Check that `{allowUndefinedInNonTupleArrays: false}` behaves as intended
+const partialDeepDoNotAllowUndefinedInNonTupleArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = foo;
+expectType<string[] | undefined>(partialDeepDoNotAllowUndefinedInNonTupleArraysFoo.bar!.array);
 
 // These are mostly the same checks as before, but the array/tuple types are different.
 // @ts-expect-error


### PR DESCRIPTION
Add option `allowUndefinedInArrays` to `PartialDeep`, default to true to respect backward compatibility.

PartialDeep with recurseIntoArrays option works like this
```
import type {PartialDeep} from 'type-fest';

interface Settings {
	languages: string[];
}

const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
	languages: [undefined]
};
```
But it can be annoying that `undefined` type could be allowed in an array of string.
So with this new option `allowUndefinedInArrays: false`, the `languages` array is still optional, but type `undefined` is not allowed anymore into the `languages` array.
