### PR TITLE
`SharedUnionFields`: Fix missing instantiation in test cases

### DIFF
--- a/test-d/shared-union-fields.ts
+++ b/test-d/shared-union-fields.ts
@@ -85,9 +85,9 @@ declare const unionWithOptional: SharedUnionFields<{a?: string; foo: number} | {
 expectType<{a?: string}>(unionWithOptional);
 
 // Non-recursive types
-expectType<Set<string> | Map<string, string>>({} as Set<string> | Map<string, string>);
-expectType<string[] | Set<string>>({} as string[] | Set<string>);
-expectType<NonRecursiveType>({} as NonRecursiveType);
+expectType<Set<string> | Map<string, string>>({} as SharedUnionFields<Set<string> | Map<string, string>>);
+expectType<string[] | Set<string>>({} as SharedUnionFields<string[] | Set<string>>);
+expectType<NonRecursiveType>({} as SharedUnionFields<NonRecursiveType>);
 
 // Mix of non-recursive and recursive types
 expectType<{a: string | number} | undefined>({} as SharedUnionFields<{a: string} | {a: number; b: true} | undefined>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Some test cases didn't invoke the type, this PR just fixes that.