### PR TITLE
Change `Paths` option `maxRecursionDepth` default value.

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -12,9 +12,9 @@ Paths options.
 */
 export type PathsOptions = {
 	/**
-	The maximum depth to recurse when searching for paths.
+	The maximum depth to recurse when searching for paths. Range: 0 ~ 10.
 
-	@default 10
+	@default 5
 	*/
 	maxRecursionDepth?: number;
 
@@ -53,7 +53,7 @@ export type PathsOptions = {
 };
 
 type DefaultPathsOptions = {
-	maxRecursionDepth: 10;
+	maxRecursionDepth: 5;
 	bracketNotation: false;
 };
 

--- a/test-d/paths.ts
+++ b/test-d/paths.ts
@@ -111,7 +111,7 @@ expectAssignable<string>({} as MyEntityPaths);
 
 // By default, the recursion limit should be reasonably long
 type RecursiveFoo = {foo: RecursiveFoo};
-expectAssignable<Paths<RecursiveFoo>>('foo.foo.foo.foo.foo.foo.foo.foo');
+expectAssignable<Paths<RecursiveFoo, {maxRecursionDepth: 10}>>('foo.foo.foo.foo.foo.foo.foo.foo');
 
 declare const recursion0: Paths<RecursiveFoo, {maxRecursionDepth: 0}>;
 expectType<'foo'>(recursion0);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
For performance improvements in most cases, I think we could reduce the default values of `maxRecursionDepth`

PS: In TypeScript, also have a similar function to determine whether a type is deeply-nested or not, that value is `5`(reduced to `3` after Typescript@4.2.5)
![image](https://github.com/user-attachments/assets/c698be24-c86c-4d2e-af10-f82670603e0e)
