### PR TITLE
`SetRequired`: Fix support for removal of optional modifiers from tuples

### DIFF
--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,3 +1,4 @@
+import type {IfNever} from '../if-never';
 import type {UnknownArray} from '../unknown-array';
 
 /**
@@ -90,4 +91,4 @@ T extends readonly [...infer U] ?
 /**
 Returns whether the given array `T` is readonly.
 */
-export type IsArrayReadonly<T extends UnknownArray> = T extends unknown[] ? false : true;
+export type IsArrayReadonly<T extends UnknownArray> = IfNever<T, false, T extends unknown[] ? false : true>;

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -100,12 +100,6 @@ An if-else-like type that resolves depending on whether the given array is reado
 
 @example
 ```
-type ShouldBeTrue = IfArrayReadonly<readonly unknown[]>;
-//=> true
-
-type ShouldBeBar = IfArrayReadonly<unknown[], 'foo', 'bar'>;
-//=> 'bar'
-
 import type {ArrayTail} from 'type-fest';
 
 type ReadonlyPreservingArrayTail<TArray extends readonly unknown[]> =
@@ -118,6 +112,12 @@ type ReadonlyTail = ReadonlyPreservingArrayTail<readonly [string, number, boolea
 
 type NonReadonlyTail = ReadonlyPreservingArrayTail<[string, number, boolean]>;
 //=> [number, boolean]
+
+type ShouldBeTrue = IfArrayReadonly<readonly unknown[]>;
+//=> true
+
+type ShouldBeBar = IfArrayReadonly<unknown[], 'foo', 'bar'>;
+//=> 'bar'
 ```
 */
 export type IfArrayReadonly<T extends UnknownArray, TypeIfArrayReadonly = true, TypeIfNotArrayReadonly = false> =

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -107,16 +107,18 @@ type ShouldBeTrue = IfArrayReadonly<readonly unknown[]>;
 type ShouldBeBar = IfArrayReadonly<unknown[], 'foo', 'bar'>;
 //=> 'bar'
 
+import type {ArrayTail} from 'type-fest';
+
 type ReadonlyPreservingArrayTail<TArray extends readonly unknown[]> =
 	ArrayTail<TArray> extends infer Tail
 		? IfArrayReadonly<TArray, Readonly<Tail>, Tail>
 		: never;
 
-type ReadonlyTail = ReadonlyPreservingArrayTail<readonly [string, number, number]>;
-//=> readonly [number, number]
+type ReadonlyTail = ReadonlyPreservingArrayTail<readonly [string, number, boolean]>;
+//=> readonly [number, boolean]
 
-type NonReadonlyTail = ReadonlyPreservingArrayTail<[string, number, number]>;
-//=> [number, number]
+type NonReadonlyTail = ReadonlyPreservingArrayTail<[string, number, boolean]>;
+//=> [number, boolean]
 ```
 */
 export type IfArrayReadonly<T extends UnknownArray, TypeIfArrayReadonly = true, TypeIfNotArrayReadonly = false> =

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,4 +1,3 @@
-import type {IfAny} from '../if-any';
 import type {IfNever} from '../if-never';
 import type {UnknownArray} from '../unknown-array';
 
@@ -122,8 +121,6 @@ type NonReadonlyTail = ReadonlyPreservingArrayTail<[string, number, boolean]>;
 ```
 */
 export type IfArrayReadonly<T extends UnknownArray, TypeIfArrayReadonly = true, TypeIfNotArrayReadonly = false> =
-	IfNever<T, TypeIfNotArrayReadonly,
-	IfAny<T, TypeIfArrayReadonly | TypeIfNotArrayReadonly,
-	T extends unknown // For distributing `T` when it's a union
-		? IsArrayReadonly<T> extends true ? TypeIfArrayReadonly : TypeIfNotArrayReadonly
-		: never>>;
+	IsArrayReadonly<T> extends infer Result
+		? Result extends true ? TypeIfArrayReadonly : TypeIfNotArrayReadonly
+		: never; // Should never happen

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,3 +1,4 @@
+import type {IfAny} from '../if-any';
 import type {IfNever} from '../if-never';
 import type {UnknownArray} from '../unknown-array';
 
@@ -92,3 +93,35 @@ T extends readonly [...infer U] ?
 Returns whether the given array `T` is readonly.
 */
 export type IsArrayReadonly<T extends UnknownArray> = IfNever<T, false, T extends unknown[] ? false : true>;
+
+/**
+An if-else-like type that resolves depending on whether the given array is readonly.
+
+@see {@link IsArrayReadonly}
+
+@example
+```
+type ShouldBeTrue = IfArrayReadonly<readonly unknown[]>;
+//=> true
+
+type ShouldBeBar = IfArrayReadonly<unknown[], 'foo', 'bar'>;
+//=> 'bar'
+
+type ReadonlyPreservingArrayTail<TArray extends readonly unknown[]> =
+	ArrayTail<TArray> extends infer Tail
+		? IfArrayReadonly<TArray, Readonly<Tail>, Tail>
+		: never;
+
+type ReadonlyTail = ReadonlyPreservingArrayTail<readonly [string, number, number]>;
+//=> readonly [number, number]
+
+type NonReadonlyTail = ReadonlyPreservingArrayTail<[string, number, number]>;
+//=> [number, number]
+```
+*/
+export type IfArrayReadonly<T extends UnknownArray, TypeIfArrayReadonly = true, TypeIfNotArrayReadonly = false> =
+	IfNever<T, TypeIfNotArrayReadonly,
+	IfAny<T, TypeIfArrayReadonly | TypeIfNotArrayReadonly,
+	T extends unknown // For distributing `T` when it's a union
+		? IsArrayReadonly<T> extends true ? TypeIfArrayReadonly : TypeIfNotArrayReadonly
+		: never>>;

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -1,7 +1,9 @@
 import type {Except} from './except';
-import type {HomomorphicPick} from './internal';
+import type {HomomorphicPick, IfArrayReadonly} from './internal';
 import type {KeysOfUnion} from './keys-of-union';
+import type {OptionalKeysOf} from './optional-keys-of';
 import type {Simplify} from './simplify';
+import type {UnknownArray} from './unknown-array';
 
 /**
 Create a type that makes the given keys required. The remaining keys are kept as is. The sister of the `SetOptional` type.
@@ -29,14 +31,35 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 @category Object
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType> =
-	// `extends unknown` is always going to be the case and is used to convert any
-	// union into a [distributive conditional
-	// type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
-	BaseType extends unknown
-		? Simplify<
+	BaseType extends UnknownArray
+		? SetArrayRequired<BaseType, Keys> extends infer ResultantArray
+			? IfArrayReadonly<BaseType, Readonly<ResultantArray>, ResultantArray>
+			: never
+		: Simplify<
 		// Pick just the keys that are optional from the base type.
 		Except<BaseType, Keys> &
 		// Pick the keys that should be required from the base type and make them required.
 		Required<HomomorphicPick<BaseType, Keys & KeysOfUnion<BaseType>>>
-		>
-		: never;
+		>;
+
+/**
+Remove the optional modifier from the specified keys in an array.
+*/
+type SetArrayRequired<
+	TArray extends UnknownArray,
+	Keys,
+	Counter extends any[] = [],
+	Accumulator extends UnknownArray = [],
+> = TArray extends unknown // For distributing `TArray` when it's a union
+	? keyof TArray & `${number}` extends never // Exit if there are no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+		? [...Accumulator, ...TArray]
+		: TArray extends readonly [(infer First)?, ...infer Rest]
+			? '0' extends OptionalKeysOf<TArray> // If the first element of `TArray` is optional
+				? `${Counter['length']}` extends `${Keys & (string | number)}` // If the current index needs to be required
+					? SetArrayRequired<Rest, Keys, [...Counter, any], [...Accumulator, First]>
+					// If the current element is optional, but it doesn't need to be required,
+					// then we can exit early, since no further elements can now be made required.
+					: [...Accumulator, ...TArray]
+				: SetArrayRequired<Rest, Keys, [...Counter, any], [...Accumulator, TArray[0]]>
+			: never // Should never happen, since `[(infer F)?, ...infer R]` is a top-type for arrays.
+	: never; // Should never happen

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -26,6 +26,10 @@ type SomeRequired = SetRequired<Foo, 'b' | 'c'>;
 // 	b: string; // Was already required and still is.
 // 	c: boolean; // Is now required.
 // }
+
+// Set specific indices in an array to be required.
+type ArrayExample = SetRequired<[number?, number?, number?], 0 | 1>;
+//=> [number, number, number?]
 ```
 
 @category Object

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -51,7 +51,9 @@ type SetArrayRequired<
 	Counter extends any[] = [],
 	Accumulator extends UnknownArray = [],
 > = TArray extends unknown // For distributing `TArray` when it's a union
-	? keyof TArray & `${number}` extends never // Exit if there are no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+	? keyof TArray & `${number}` extends never
+		// Exit if `TArray` is empty (e.g., []), or
+		// `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
 		? [...Accumulator, ...TArray]
 		: TArray extends readonly [(infer First)?, ...infer Rest]
 			? '0' extends OptionalKeysOf<TArray> // If the first element of `TArray` is optional

--- a/test-d/internal/if-array-readonly.ts
+++ b/test-d/internal/if-array-readonly.ts
@@ -1,0 +1,34 @@
+import {expectType} from 'tsd';
+import type {IfArrayReadonly} from '../../source/internal';
+
+// Non-readonly arrays
+expectType<IfArrayReadonly<[]>>(false);
+expectType<IfArrayReadonly<number[], string, number>>({} as number);
+expectType<IfArrayReadonly<[string?, number?], string>>(false);
+expectType<IfArrayReadonly<[string, number, ...string[]], false, true>>(true);
+
+// Readonly arrays
+expectType<IfArrayReadonly<readonly []>>(true);
+expectType<IfArrayReadonly<readonly number[], string, number>>({} as string);
+expectType<IfArrayReadonly<readonly [string?, number?], string>>({} as string);
+expectType<IfArrayReadonly<readonly [string, number, ...string[]], false, true>>(false);
+
+// Union
+expectType<IfArrayReadonly<[] | [string, number]>>(false);
+expectType<IfArrayReadonly<[] | [string, number], string, number>>({} as number);
+expectType<IfArrayReadonly<readonly [] | readonly [string, number]>>(true);
+expectType<IfArrayReadonly<readonly [] | readonly [string, number], string, number>>({} as string);
+
+// Returns union of `TypeIfArrayReadonly` and `TypeIfNotArrayReadonly` when `T` is a union of readonly and non-readonly arrays.
+expectType<IfArrayReadonly<[] | readonly []>>({} as boolean);
+expectType<IfArrayReadonly<[string, number] | readonly [string, number, ...string[]], string, number>>({} as string | number);
+expectType<IfArrayReadonly<[string, number] | readonly [string, number, ...string[]], string>>({} as string | false);
+
+// Returns union of `TypeIfArrayReadonly` and `TypeIfNotArrayReadonly` when `T` is `any`.
+expectType<IfArrayReadonly<any>>({} as boolean);
+expectType<IfArrayReadonly<any, string, number>>({} as string | number);
+expectType<IfArrayReadonly<any, string>>({} as string | false);
+
+// Returns `TypeIfNotArrayReadonly` when `T` is `never`.
+expectType<IfArrayReadonly<never>>(false);
+expectType<IfArrayReadonly<never, string, number>>({} as number);

--- a/test-d/internal/is-array-readonly.ts
+++ b/test-d/internal/is-array-readonly.ts
@@ -1,0 +1,26 @@
+import {expectType} from 'tsd';
+import type {IsArrayReadonly} from '../../source/internal';
+
+// Non-readonly arrays
+expectType<IsArrayReadonly<[]>>(false);
+expectType<IsArrayReadonly<number[]>>(false);
+expectType<IsArrayReadonly<[string, number?, ...string[]]>>(false);
+expectType<IsArrayReadonly<[x: number, y: number, z?: number]>>(false);
+expectType<IsArrayReadonly<[...string[], number, string]>>(false);
+
+// Readonly arrays
+expectType<IsArrayReadonly<readonly []>>(true);
+expectType<IsArrayReadonly<readonly number[]>>(true);
+expectType<IsArrayReadonly<readonly [string, number?, ...string[]]>>(true);
+expectType<IsArrayReadonly<readonly [x: number, y: number, z?: number]>>(true);
+expectType<IsArrayReadonly<readonly [...string[], number, string]>>(true);
+
+// Union
+expectType<IsArrayReadonly<[] | readonly []>>({} as boolean);
+expectType<IsArrayReadonly<[string, number] | readonly [string, number, ...string[]]>>({} as boolean);
+expectType<IsArrayReadonly<[] | [string, number]>>(false);
+expectType<IsArrayReadonly<readonly [] | readonly [string, number]>>(true);
+
+// Boundary types
+expectType<IsArrayReadonly<any>>({} as boolean);
+expectType<IsArrayReadonly<never>>(false);

--- a/test-d/set-required.ts
+++ b/test-d/set-required.ts
@@ -40,3 +40,110 @@ expectType<{a?: number; readonly b?: string; readonly c: boolean}>(variation9);
 // Works with index signatures
 declare const variation10: SetRequired<{[k: string]: unknown; a?: number; b: string}, 'a' | 'b'>;
 expectType<{[k: string]: unknown; a: number; b: string}>(variation10);
+
+// =================
+// Works with arrays
+// =================
+
+// Empty array
+expectType<[]>({} as SetRequired<[], never>);
+expectType<readonly []>({} as SetRequired<readonly [], never>);
+
+// All optional elements
+expectType<[string, number?]>({} as SetRequired<[string?, number?], '0'>);
+expectType<[string, number, boolean]>({} as SetRequired<[string?, number?, boolean?], '0' | '1' | '2'>);
+expectType<[(string | number)]>({} as SetRequired<[(string | number)?], '0'>);
+
+// Works with number `Keys`, string `Keys`, and union of them.
+expectType<[string, number, boolean?]>({} as SetRequired<[string, number?, boolean?], 1>);
+expectType<[string, number, boolean, ...number[]]>({} as SetRequired<[string, number?, boolean?, ...number[]], '1' | '2'>);
+expectType<readonly [string, number, boolean]>({} as SetRequired<readonly [string?, number?, boolean?], '0' | 1 | 2>);
+
+// Mix of optional and required elements
+expectType<[string, number, boolean?]>({} as SetRequired<[string, number?, boolean?], '1'>);
+expectType<readonly [string, number, boolean]>({} as SetRequired<readonly [string, number?, boolean?], '1' | '2'>);
+
+// Mix of optional and rest elements
+expectType<[string, number?, boolean?, ...number[]]>({} as SetRequired<[string?, number?, boolean?, ...number[]], '0'>);
+expectType<[string, number, boolean, ...number[]]>({} as SetRequired<[string?, number?, boolean?, ...number[]], '0' | '1' | 2>);
+
+// Mix of optional, required, and rest elements
+expectType<readonly [string, number, boolean?, ...number[]]>({} as SetRequired<readonly [string, number?, boolean?, ...number[]], '1'>);
+expectType<[string, number, boolean, ...string[]]>({} as SetRequired<[string, number?, boolean?, ...string[]], '1' | 2>);
+
+// Works with readonly arrays
+expectType<readonly [(string | number)]>({} as SetRequired<readonly [(string | number)?], '0'>);
+expectType<readonly [string, number, boolean?]>({} as SetRequired<readonly [string, number?, boolean?], '1'>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string?, number?, boolean?, ...number[]], '0' | '1' | 2>);
+expectType<readonly [string, number, boolean, ...string[]]>({} as SetRequired<readonly [string, number?, boolean?, ...string[]], '1' | 2>);
+
+// Ignores `Keys` that are already required
+expectType<[string, number?, boolean?]>({} as SetRequired<[string, number?, boolean?], '0'>);
+expectType<readonly [string, number, boolean]>({} as SetRequired<readonly [string, number, boolean], 1 | 2>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string, number, boolean, ...number[]], 1 | 2>);
+expectType<[string, number, boolean, ...number[]]>({} as SetRequired<[string, number?, boolean?, ...number[]], '0' | '1' | '2'>);
+
+// Ignores `Keys` that are out of bounds
+expectType<[]>({} as SetRequired<[], 1>);
+expectType<[string, number?, boolean?]>({} as SetRequired<[string, number?, boolean?], 10>);
+expectType<[string, number, boolean]>({} as SetRequired<[string?, number?, boolean?], 0 | 1 | 2 | 3 | 4>);
+expectType<readonly [string, number, boolean?, ...number[]]>({} as SetRequired<readonly [string, number?, boolean?, ...number[]], 10 | 1>);
+
+// Marks all keys as required, if `Keys` is `any`.
+expectType<[string, number, boolean]>({} as SetRequired<[string?, number?, boolean?], any>);
+expectType<[string, number, boolean, ...number[]]>({} as SetRequired<[string, number?, boolean?, ...number[]], any>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string, number, boolean, ...number[]], any>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string, number?, boolean?, ...number[]], any>);
+
+// Marks all keys as required, if `Keys` is `number`.
+expectType<[string, number, boolean]>({} as SetRequired<[string?, number?, boolean?], number>);
+expectType<[string, number, boolean, ...number[]]>({} as SetRequired<[string, number?, boolean?, ...number[]], number>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string, number, boolean, ...number[]], number>);
+expectType<readonly [string, number, boolean, ...number[]]>({} as SetRequired<readonly [string, number?, boolean?, ...number[]], number>);
+
+// Returns the array as-is, if `Keys` is `never`.
+expectType<[string?, number?]>({} as SetRequired<[string?, number?], never>);
+expectType<readonly [string?, number?, ...number[]]>({} as SetRequired<readonly [string?, number?, ...number[]], never>);
+
+// Arrays where non-rest elements appear after the rest element are left unchanged, because they can never have optional elements.
+expectType<[...string[], string | undefined, number]>({} as SetRequired<[...string[], string | undefined, number], any>);
+expectType<[boolean, ...string[], string, number]>({} as SetRequired<[boolean, ...string[], string, number], any>);
+
+// Preserves `| undefined`, similar to how built-in `Required` works.
+expectType<[string | undefined, number | undefined, boolean]>({} as SetRequired<[string | undefined, (number | undefined)?, boolean?], 0 | 1 | 2>);
+expectType<readonly [string | undefined, (number | undefined)?, boolean?]>({} as SetRequired<readonly [(string | undefined)?, (number | undefined)?, boolean?], 0>);
+
+// Optional elements cannot appear after required ones, `Keys` leading to such situations are ignored.
+expectType<[string?, number?, boolean?]>({} as SetRequired<[string?, number?, boolean?], 1 | 2>); // `1` and `2` can't be required when `0` is optional
+expectType<[string, number, boolean?, string?, string?]>(
+	{} as SetRequired<[string?, number?, boolean?, string?, string?], 0 | 1 | 3>, // `3` can't be required when `2` is optional
+);
+expectType<readonly [string | undefined, number?, boolean?, ...string[]]>(
+	{} as SetRequired<readonly [string | undefined, number?, boolean?, ...string[]], 2>, // `2` can't be required when `1` is optional
+);
+
+// Works with unions of arrays
+expectType<readonly [] | []>({} as SetRequired<readonly [] | [], never>);
+expectType<[] | readonly [(string | number)]>({} as SetRequired<[] | readonly [(string | number)?], 0>);
+expectType<[string] | [string, number, boolean?, ...number[]] | readonly [string, number, boolean?]>(
+	{} as SetRequired<[string?] | [string, number?, boolean?, ...number[]] | readonly [string, number?, boolean?], 0 | 1>,
+);
+expectType<readonly [number, string] | [string, boolean, ...number[]] | readonly [string, number | undefined, boolean?, string?]>(
+	{} as SetRequired<readonly [number, string] | [string, boolean?, ...number[]] | readonly [string, (number | undefined)?, boolean?, string?], 1 | 3>,
+);
+expectType<readonly [...number[], number] | [string, boolean, ...number[]] | readonly [string, number | undefined, boolean, string]>(
+	{} as SetRequired<readonly [...number[], number] | [string, boolean?, ...number[]] | readonly [string, (number | undefined)?, boolean?, string?], any>,
+);
+expectType<readonly string[] | [x: number, y: number] | [string, number, ...string[]]>(
+	{} as SetRequired<readonly string[] | [x: number, y?: number] | [string?, number?, ...string[]], number>,
+);
+
+// Works with labelled tuples
+expectType<[x: string, y: number]>({} as SetRequired<[x?: string, y?: number], '0' | '1'>);
+expectType<readonly [x: number, y: number, z?: number]>({} as SetRequired<readonly [x?: number, y?: number, z?: number], 0 | 1>);
+expectType<readonly [x: number, y: number, z?: number, ...rest: number[]]>({} as SetRequired<readonly [x?: number, y?: number, z?: number, ...rest: number[]], 0 | 1>);
+
+// Non tuple arrays are left unchanged
+expectType<string[]>({} as SetRequired<string[], number>);
+expectType<ReadonlyArray<string | number>>({} as SetRequired<ReadonlyArray<string | number>, number>);
+expectType<number[]>({} as SetRequired<[...number[]], never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR:
1. Fixes `SetRequired`, enabling it to remove optional modifiers from tuples, for eg.,

     ```ts
     SetRequired<[number?, number?], 0> //=> [number, number?]
     ```
     This fix will allow us to solve #1026.
2. Fixes minor issues with `IsArrayReadonly` and adds tests for it.
3. Adds an internal `IfArrayReadonly` type.