### PR TITLE
`Sum`/`Subtract`: Fix instantiations with unions

### DIFF
--- a/source/internal/tuple.d.ts
+++ b/source/internal/tuple.d.ts
@@ -37,9 +37,11 @@ If `<Fill>` is not provided, it will default to `unknown`.
 
 @link https://itnext.io/implementing-arithmetic-within-typescripts-type-system-a1ef140a6f6f
 */
-export type BuildTuple<L extends number, Fill = unknown, T extends readonly unknown[] = []> = T['length'] extends L
-	? T
-	: BuildTuple<L, Fill, [...T, Fill]>;
+export type BuildTuple<L extends number, Fill = unknown, T extends readonly unknown[] = []> = number extends L
+	? Fill[]
+	: L extends T['length']
+		? T
+		: BuildTuple<L, Fill, [...T, Fill]>;
 
 /**
 Returns the maximum value from a tuple of integers.

--- a/test-d/internal/build-tuple.ts
+++ b/test-d/internal/build-tuple.ts
@@ -4,3 +4,5 @@ import type {BuildTuple} from '../../source/internal';
 expectType<BuildTuple<3, null>>([null, null, null]);
 expectType<BuildTuple<5, 0>>([0, 0, 0, 0, 0]);
 expectType<BuildTuple<0, 0>>([]);
+expectType<BuildTuple<2 | 3, 0>>({} as [0, 0] | [0, 0, 0]);
+expectType<BuildTuple<number, 0>>({} as Array<0>);

--- a/test-d/subtract.ts
+++ b/test-d/subtract.ts
@@ -20,3 +20,8 @@ expectType<Subtract<number, 2>>(null! as number);
 expectType<Subtract<2, number>>(null! as number);
 expectType<Subtract<number, number>>(null! as number);
 expectType<Subtract<number, PositiveInfinity>>(null! as number);
+
+// Union
+expectType<Subtract<10, 1 | 2>>({} as 9 | 8);
+expectType<Subtract<10 | 5, 1>>({} as 9 | 4);
+expectType<Subtract<10 | 5, 1 | 2>>({} as 9 | 8 | 4 | 3);

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -18,3 +18,8 @@ expectType<Sum<number, 1>>(null! as number);
 expectType<Sum<1, number>>(null! as number);
 expectType<Sum<number, number>>(null! as number);
 expectType<Sum<number, PositiveInfinity>>(null! as number);
+
+// Union
+expectType<Sum<1, 2 | 3>>({} as 3 | 4);
+expectType<Sum<1 | 2, 3>>({} as 4 | 5);
+expectType<Sum<1 | 2 | 3, 4 | 5>>({} as 5 | 6 | 7 | 8);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1033 

The issue was that `BuildTuple` didn’t handle unions properly.

Additionally, noticed that `BuildTuple<number, string>` currently returns `[]`, fixed it to instead return `string[]`, which makes more sense, in my opinion.