### PR TITLE
`StringSlice`: Fix return type when passing in non-literal

### DIFF
--- a/source/string-slice.d.ts
+++ b/source/string-slice.d.ts
@@ -31,7 +31,7 @@ export type StringSlice<
 	Start extends number = 0,
 	End extends number = StringToArray<S>['length'],
 > = string extends S
-	? string[]
+	? string
 	: ArraySlice<StringToArray<S>, Start, End> extends infer R extends readonly string[]
 		? Join<R, ''>
 		: never;

--- a/test-d/string-slice.ts
+++ b/test-d/string-slice.ts
@@ -12,3 +12,6 @@ expectType<StringSlice<'abcde', -100, -3>>('ab');
 expectType<StringSlice<'abcde', 3, 100>>('de');
 expectType<StringSlice<'abcde', 1, 1>>('');
 expectType<StringSlice<'abcde', 100, 1>>('');
+expectType<StringSlice<string>>(null! as string);
+expectType<StringSlice<string, 1>>(null! as string);
+expectType<StringSlice<string, 1, 2>>(null! as string);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
Closes #1035
This PR modifies the behavior of `StringSlice` so that it returns `string` instead of `string[]` when S is non-literal string.