### PR TITLE
`PickIndexSignature`/`OmitIndexSignature`: Clean up JSDoc comments

### DIFF
--- a/source/omit-index-signature.d.ts
+++ b/source/omit-index-signature.d.ts
@@ -61,18 +61,6 @@ type OmitIndexSignature<ObjectType> = {
 
 If `{}` is assignable, it means that `KeyType` is an index signature and we want to remove it. If it is not assignable, `KeyType` is a "real" key and we want to keep it.
 
-```
-import type {OmitIndexSignature} from 'type-fest';
-
-type OmitIndexSignature<ObjectType> = {
-	[KeyType in keyof ObjectType
-		as {} extends Record<KeyType, unknown>
-			? never // => Remove this `KeyType`.
-			: KeyType // => Keep this `KeyType` as it is.
-	]: ObjectType[KeyType];
-};
-```
-
 @example
 ```
 import type {OmitIndexSignature} from 'type-fest';

--- a/source/pick-index-signature.d.ts
+++ b/source/pick-index-signature.d.ts
@@ -3,8 +3,6 @@ Pick only index signatures from the given object type, leaving out all explicitl
 
 This is the counterpart of `OmitIndexSignature`.
 
-When you use a type that will iterate through an object that has indexed keys and explicitly defined keys you end up with a type where only the indexed keys are kept. This is because `keyof` of an indexed type always returns `string | number | symbol`, because every key is possible in that object. With this type, you can save the indexed keys and reinject them later, like in the second example below.
-
 @example
 ```
 import type {PickIndexSignature} from 'type-fest';
@@ -39,56 +37,6 @@ type ExampleIndexSignature = PickIndexSignature<Example>;
 // 	[x: `head-${string}-tail`]: string;
 // 	[x: `${bigint}`]: string;
 // 	[x: `embedded-${number}`]: string;
-// }
-```
-
-@example
-```
-import type {OmitIndexSignature, PickIndexSignature, Simplify} from 'type-fest';
-
-type Foo = {
-	[x: string]: string;
-	foo: string;
-	bar: number;
-};
-
-// Imagine that you want a new type `Bar` that comes from `Foo`.
-// => {
-// 	[x: string]: string;
-// 	bar: number;
-// };
-
-type Bar = Omit<Foo, 'foo'>;
-// This is not working because `Omit` returns only indexed keys.
-// => {
-// 	[x: string]: string;
-// 	[x: number]: string;
-// }
-
-// One solution is to save the indexed signatures to new type.
-type FooIndexSignature = PickIndexSignature<Foo>;
-// => {
-// 	[x: string]: string;
-// }
-
-// Get a new type without index signatures.
-type FooWithoutIndexSignature = OmitIndexSignature<Foo>;
-// => {
-// 	foo: string;
-// 	bar: number;
-// }
-
-// At this point we can use Omit to get our new type.
-type BarWithoutIndexSignature = Omit<FooWithoutIndexSignature, 'foo'>;
-// => {
-// 	bar: number;
-// }
-
-// And finally we can merge back the indexed signatures.
-type BarWithIndexSignature = Simplify<BarWithoutIndexSignature & FooIndexSignature>;
-// => {
-// 	[x: string]: string;
-// 	bar: number;
 // }
 ```
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1038 

<br>

Also, noticed that the implementation of `OmitIndexSignature` was present in it's JSDoc, removed that, don't think that it's necessary.