### PR TITLE
`Except`: Add example to JSDoc

### DIFF
--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -69,6 +69,26 @@ type FooWithoutB = Except<Foo, 'b', {requireExactProps: true}>;
 
 const fooWithoutB: FooWithoutB = {a: 1, b: '2'};
 //=> errors at 'b': Type 'string' is not assignable to type 'undefined'.
+
+// The `Omit` utility type doesn't work when omitting specific keys from objects containing index signatures.
+
+// Consider the following example:
+
+type UserData = {
+	[metadata: string]: string;
+	email: string;
+	name: string;
+	role: 'admin' | 'user';
+};
+
+// `Omit` clearly doesn't behave as expected in this case:
+type PostPayload = Omit<UserData, 'email'>;
+//=> type PostPayload = { [x: string]: string; [x: number]: string; }
+
+// In situations like this, `Except` works better.
+// It simply removes the `email` key while preserving all the other keys.
+type PostPayload = Except<UserData, 'email'>;
+//=> type PostPayload = { [x: string]: string; name: string; role: "admin" | "user"; }
 ```
 
 @category Object


### PR DESCRIPTION
Adds an example usage for `Except`, similar to the one mentioned in #1038.