### PR TITLE
Correct "snake-case" vs "kebab-case" comments

### DIFF
--- a/source/pick-index-signature.d.ts
+++ b/source/pick-index-signature.d.ts
@@ -21,7 +21,7 @@ type Example = {
 	[x: `embedded-${number}`]: string;
 
 	// These explicitly defined keys will be removed.
-	['snake-case-key']: string;
+	['kebab-case-key']: string;
 	[symbolKey]: string;
 	foo: 'bar';
 	qux?: 'baz';

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -6,7 +6,7 @@ type ReplaceOptions = {
 Represents a string with some or all matches replaced by a replacement.
 
 Use-case:
-- `snake-case-path` to `dotted.path.notation`
+- `kebab-case-path` to `dotted.path.notation`
 - Changing date/time format: `01-08-2042` → `01/08/2042`
 - Manipulation of type properties, for example, removal of prefixes
 

--- a/test-d/pick-index-signature.ts
+++ b/test-d/pick-index-signature.ts
@@ -15,7 +15,7 @@ type Foo = {
 };
 
 type Bar = {
-	['snake-case-key']: string;
+	['kebab-case-key']: string;
 	[symbolKey]: string;
 	foo: 'bar';
 	qux?: 'baz';


### PR DESCRIPTION
Updates two comments and one test fixture where strings that start with `"snake-case-"` are actually in kebab case.