### PR TITLE
`IsStringLiteral`: Fix instantiations with infinite string types

### DIFF
--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -83,7 +83,7 @@ const output = capitalize('hello, world!');
 @category Type Guard
 @category Utilities
 */
-export type IsStringLiteral<T> = LiteralCheck<T, string>;
+export type IsStringLiteral<T> = T extends string ? {} extends Record<T, never> ? false : true : false;
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -82,6 +82,34 @@ const output = capitalize('hello, world!');
 //=> 'Hello, world!'
 ```
 
+@example
+```
+// String types with infinite set of possible values return `false`.
+
+import type {IsStringLiteral} from 'type-fest';
+
+type AllUppercaseStrings = IsStringLiteral<Uppercase<string>>;
+//=> false
+
+type StringsStartingWithOn = IsStringLiteral<`on${string}`>;
+//=> false
+
+// This behaviour is particularly useful in string manipulation utilities, as infinite string types often require separate handling.
+
+type Length<S extends string, Counter extends never[] = []> =
+	IsStringLiteral<S> extends false
+		? number // return `number` for infinite string types
+		: S extends `${string}${infer Tail}`
+			? Length<Tail, [...Counter, never]>
+			: Counter['length'];
+
+type L1 = Length<Lowercase<string>>;
+//=> number
+
+type L2 = Length<`${number}`>;
+//=> number
+```
+
 @category Type Guard
 @category Utilities
 */

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -65,6 +65,8 @@ Useful for:
 	- constraining strings to be a string literal
 	- type utilities, such as when constructing parsers and ASTs
 
+The implementation of this type is inspired by the trick mentioned in this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747).
+
 @example
 ```
 import type {IsStringLiteral} from 'type-fest';

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -2,6 +2,7 @@ import type {Primitive} from './primitive';
 import type {Numeric} from './numeric';
 import type {IsNotFalse, IsPrimitive} from './internal';
 import type {IsNever} from './is-never';
+import type {IfNever} from './if-never';
 
 /**
 Returns a boolean for whether the given type `T` is the specified `LiteralType`.
@@ -113,13 +114,14 @@ type L2 = Length<`${number}`>;
 @category Type Guard
 @category Utilities
 */
-export type IsStringLiteral<T> = T extends string
-	// If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
-	// and since `{}` extends index signatures, the result becomes `false`.
+export type IsStringLiteral<T> = IfNever<T, false,
+// If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
+// and since `{}` extends index signatures, the result becomes `false`.
+T extends string
 	? {} extends Record<T, never>
 		? false
 		: true
-	: false;
+	: false>;
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -85,7 +85,13 @@ const output = capitalize('hello, world!');
 @category Type Guard
 @category Utilities
 */
-export type IsStringLiteral<T> = T extends string ? {} extends Record<T, never> ? false : true : false;
+export type IsStringLiteral<T> = T extends string
+	// If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
+	// and since `{}` extends index signatures, the result becomes `false`.
+	? {} extends Record<T, never>
+		? false
+		: true
+	: false;
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -44,6 +44,41 @@ expectType<IsLiteral<never>>(false);
 expectType<IsStringLiteral<typeof stringLiteral>>(true);
 expectType<IsStringLiteral<typeof _string>>(false);
 
+// Strings with infinite set of possible values return `false`
+expectType<IsStringLiteral<Uppercase<string>>>(false);
+expectType<IsStringLiteral<Lowercase<string>>>(false);
+expectType<IsStringLiteral<Capitalize<string>>>(false);
+expectType<IsStringLiteral<Uncapitalize<string>>>(false);
+expectType<IsStringLiteral<Capitalize<Lowercase<string>>>>(false);
+expectType<IsStringLiteral<Uncapitalize<Uppercase<string>>>>(false);
+expectType<IsStringLiteral<`abc${string}`>>(false);
+expectType<IsStringLiteral<`${string}abc`>>(false);
+expectType<IsStringLiteral<`${number}:${string}`>>(false);
+expectType<IsStringLiteral<`abc${Uppercase<string>}`>>(false);
+expectType<IsStringLiteral<`${Lowercase<string>}abc`>>(false);
+expectType<IsStringLiteral<`${number}`>>(false);
+expectType<IsStringLiteral<`${number}${string}`>>(false);
+expectType<IsStringLiteral<`${number}` | Uppercase<string>>>(false);
+expectType<IsStringLiteral<Capitalize<string> | Uppercase<string>>>(false);
+expectType<IsStringLiteral<`abc${string}` | `${string}abc`>>(false);
+
+// Strings with finite set of possible values return `true`
+expectType<IsStringLiteral<'a' | 'b'>>(true);
+expectType<IsStringLiteral<Uppercase<'a'>>>(true);
+expectType<IsStringLiteral<Lowercase<'a'>>>(true);
+expectType<IsStringLiteral<Uppercase<'a' | 'b'>>>(true);
+expectType<IsStringLiteral<Lowercase<'a' | 'b'>>>(true);
+expectType<IsStringLiteral<Capitalize<'abc' | 'xyz'>>>(true);
+expectType<IsStringLiteral<Uncapitalize<'Abc' | 'Xyz'>>>(true);
+expectType<IsStringLiteral<`ab${'c' | 'd' | 'e'}`>>(true);
+expectType<IsStringLiteral<Uppercase<'a' | 'b'> | 'C' | 'D'>>(true);
+expectType<IsStringLiteral<Lowercase<'xyz'> | Capitalize<'abc'>>>(true);
+
+// Strings with union of literals and non-literals return `boolean`
+expectType<IsStringLiteral<Uppercase<string> | 'abc'>>({} as boolean);
+expectType<IsStringLiteral<Lowercase<string> | 'Abc'>>({} as boolean);
+expectType<IsStringLiteral<null | '1' | '2' | '3'>>({} as boolean);
+
 expectType<IsNumericLiteral<typeof numberLiteral>>(true);
 expectType<IsNumericLiteral<typeof bigintLiteral>>(true);
 expectType<IsNumericLiteral<typeof _number>>(false);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -79,6 +79,10 @@ expectType<IsStringLiteral<Uppercase<string> | 'abc'>>({} as boolean);
 expectType<IsStringLiteral<Lowercase<string> | 'Abc'>>({} as boolean);
 expectType<IsStringLiteral<null | '1' | '2' | '3'>>({} as boolean);
 
+// Boundary types
+expectType<IsStringLiteral<any>>(false);
+expectType<IsStringLiteral<never>>(false);
+
 expectType<IsNumericLiteral<typeof numberLiteral>>(true);
 expectType<IsNumericLiteral<typeof bigintLiteral>>(true);
 expectType<IsNumericLiteral<typeof _number>>(false);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1032 

Found a really nice trick to solve this! Refer to the code comments explaining how it works:
https://github.com/sindresorhus/type-fest/blob/06037a9b8bd241185a215e801fade7af566e7afb/source/is-literal.d.ts#L116-L122

<br>

This fix will make this type quite useful because almost all string utilities will require an `IsStringLiteral` check. For example:

```ts
import { Split, Words, StringSlice } from "type-fest";

type T1 = Split<Uppercase<string>, "">;
// Actual: [Uppercase<string>]
// Ideal: string[]

type T2 = Split<`${string}-${string}`, "">;
// Actual: [string, "-", string]
// Idea: string[]

type T3 = Words<Uppercase<string>>;
// Actual: []
// Ideal: string[]

type T4 = Words<`${string}-${string}`>;
// Actual: [string]
// Ideal: string[]

type T5 = StringSlice<Uppercase<string>>;
// Actual: ""
// Ideal: string[]
```
I'll open up a separate PR fixing all the above mentioned cases.

I've mentioned the same as an example in the documentation:
https://github.com/sindresorhus/type-fest/blob/06037a9b8bd241185a215e801fade7af566e7afb/source/is-literal.d.ts#L97-L110

<br>

**NOTE**: If `IsStringLiteral` is instantiated with a union of literal strings and non-string types, it currently returns `false` because not all union members are literal strings. However, after this PR, cases like these would instead return `boolean`.

```ts
type T1 = IsStringLiteral<null | "a">
//   ^? type T6 = false // Current behaviour

type T2 = IsStringLiteral<null | "a">
//   ^? type T6 = boolean // Updated behaviour
```

To me, the current behaviour seems more like a bug than an intentional choice, as returning `boolean` makes more sense and allows users to decide how to handle mixed union cases.