### PR TITLE
`OmitDeep`: Fix removal of multiple paths within arrays

### DIFF
--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -1,10 +1,10 @@
+import type {UnionToTuple} from 'expect-type';
 import type {ArraySplice} from './array-splice';
 import type {ExactKey, IsArrayReadonly, NonRecursiveType, SetArrayAccess, ToString} from './internal';
 import type {IsEqual} from './is-equal';
 import type {IsNever} from './is-never';
 import type {LiteralUnion} from './literal-union';
 import type {Paths} from './paths';
-import type {SharedUnionFieldsDeep} from './shared-union-fields-deep';
 import type {SimplifyDeep} from './simplify-deep';
 import type {UnknownArray} from './unknown-array';
 
@@ -92,10 +92,18 @@ type AddressInfo = OmitDeep<Info1, 'address.1.foo'>;
 */
 export type OmitDeep<T, PathUnion extends LiteralUnion<Paths<T>, string>> =
 	SimplifyDeep<
-	SharedUnionFieldsDeep<
-	{[P in PathUnion]: OmitDeepWithOnePath<T, P>}[PathUnion]
-	>,
+	OmitDeepHelper<T, UnionToTuple<PathUnion>>,
 	UnknownArray>;
+
+/**
+Internal helper for {@link OmitDeep}.
+
+Recursively transforms `T` by applying {@link OmitDeepWithOnePath} for each path in `PathTuple`.
+*/
+type OmitDeepHelper<T, PathTuple extends UnknownArray> =
+	PathTuple extends [infer Path, ...infer RestPaths]
+		? OmitDeepHelper<OmitDeepWithOnePath<T, Path & (string | number)>, RestPaths>
+		: T;
 
 /**
 Omit one path from the given object/array.

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -135,3 +135,9 @@ expectType<{array: [
 
 declare const tuple: OmitDeep<{array: BaseType['tuples']}, 'array.0'>;
 expectType<{array: [unknown, 'bar']}>(tuple);
+
+declare const arrayWithMultiplePaths: OmitDeep<{array: Array<{a: string; b: number; c: string}>}, `array.${number}.a` | `array.${number}.b`>;
+expectType<{array: Array<{c: string}>}>(arrayWithMultiplePaths);
+
+declare const tupleWithMultiplePaths: OmitDeep<{tuple: [{a: string; b: number; c: string}]}, 'tuple.0.a' | 'tuple.0.b'>;
+expectType<{tuple: [{c: string}]}>(tupleWithMultiplePaths);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes https://github.com/sindresorhus/type-fest/issues/959#issuecomment-2643290328

Just enabling `recurseIntoArrays` for `SharedUnionDeep` within `OmitDeep` fixes the above issue, however, it causes some existing test cases to fail, as `SharedUnionDeep` currently fails when instantiated with arrays where the non-fixed part precedes the fixed part (will open an issue for this).
```ts
import { SharedUnionFieldsDeep } from "type-fest";

type Test = SharedUnionFieldsDeep<{a: [...{a: 1}[], {b: 1}]}, {recurseIntoArrays: true}>
//   ^? type Test = { a: {}[]; }
```

So, this PR removes usage of `SharedUnionDeep` from `OmitDeep` and replaces it with logic similar to what is used in `SetRequiredDeep`.
https://github.com/sindresorhus/type-fest/blob/81a05404c6c60583ff3dfcc0e4b992c62e052626/source/set-required-deep.d.ts#L47-L55