### PR TITLE
Add lint rule to prevent unintended imports in declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,11 @@
 			{
 				"files": "source/*.d.ts",
 				"rules": {
-					"no-restricted-imports": ["error", "tsd", "expect-type"]
+					"no-restricted-imports": [
+						"error",
+						"tsd",
+						"expect-type"
+					]
 				}
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -69,7 +69,15 @@
 				"error",
 				"prefer-top-level"
 			]
-		}
+		},
+		"overrides": [
+			{
+				"files": "source/*.d.ts",
+				"rules": {
+					"no-restricted-imports": ["error", "tsd", "expect-type"]
+				}
+			}
+		]
 	},
 	"tsd": {
 		"compilerOptions": {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

VSCode autocomplete suggests imports from `expect-type` before local modules, leading to unintended imports from `expect-type` in declaration files, like:
- https://github.com/sindresorhus/type-fest/pull/1037#discussion_r1914295743
- https://github.com/sindresorhus/type-fest/issues/1051

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/2084546c-244d-47e4-bd30-e04230589344" /><br><br>

This PR adds a lint rule that will catch such issues, causing [CI to fail](https://github.com/sindresorhus/type-fest/actions/runs/13226754137/job/36918575333?pr=1053).