### PR TITLE
Fix file pattern for `no-restricted-imports` lint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		},
 		"overrides": [
 			{
-				"files": "source/*.d.ts",
+				"files": "**/*.d.ts",
 				"rules": {
 					"no-restricted-imports": [
 						"error",


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR updates the file pattern for the `no-restricted-imports` line rule added in #1053. The updated pattern will also catch errors in `index.d.ts` and declaration files within `source/internal` directory.