### PR TITLE
doc: add usage trend link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,8 +76,9 @@
 <br>
 
 [![](https://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://giphy.com/gifs/illustration-rainbow-unicorn-26AHG5KGFxSkUWw1i)
+[![npm version](https://badgen.net/npm/v/type-fest)](https://www.npmjs.com/package/type-fest)
 [![npm dependents](https://badgen.net/npm/dependents/type-fest)](https://www.npmjs.com/package/type-fest?activeTab=dependents)
-[![npm downloads](https://badgen.net/npm/dt/type-fest)](https://www.npmjs.com/package/type-fest)
+[![npm downloads](https://badgen.net/npm/dt/type-fest)](https://npm-compare.com/type-fest/#timeRange=FIVE_YEARS)
 
 Many of the types here should have been built-in. You can help by suggesting some of them to the [TypeScript project](https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md).
 


### PR DESCRIPTION
**Changes**

- Added a version badge for the `type-fest` package, linking to the npm package page.
- Updated the [type-fest](https://npm-compare.com/type-fest/#timeRange=FIVE_YEARS) downloads badge to link to npm-compare.com, allowing users to view the download trend chart for the past five years. The trend chart offers a more intuitive, visual representation, which I believe can help new users make a more informed decision and feel more confident in choosing this package based on its long-term usage and popularity.

By the way, I'm the maintainer of npm-compare.com, If you have any questions or need anything further, please don't hesitate to reach out. I'm always happy to help!
