### PR TITLE
`TsConfigJson`: Add TypeScript 5.8 fields

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         typescript-version:
           - "latest"
+          - "~5.8.0"
           - "~5.7.0"
           - "~5.6.0"
           - "~5.5.0"

--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -18,6 +18,7 @@ declare namespace TsConfigJson {
 			| 'ES2022'
 			| 'ESNext'
 			| 'Node16'
+			| 'Node18'
 			| 'NodeNext'
 			| 'Preserve'
 			| 'None'
@@ -32,6 +33,7 @@ declare namespace TsConfigJson {
 			| 'es2022'
 			| 'esnext'
 			| 'node16'
+			| 'node18'
 			| 'nodenext'
 			| 'preserve'
 			| 'none';
@@ -1109,6 +1111,20 @@ declare namespace TsConfigJson {
 		Suppress deprecation warnings
 		*/
 		ignoreDeprecations?: CompilerOptions.IgnoreDeprecations;
+
+		/**
+		Do not allow runtime constructs that are not part of ECMAScript.
+
+		@default false
+		*/
+		erasableSyntaxOnly?: boolean;
+
+		/**
+		Enable lib replacement.
+
+		@default true
+		*/
+		libReplacement?: boolean;
 	};
 
 	namespace WatchOptions {
@@ -1160,12 +1176,12 @@ declare namespace TsConfigJson {
 		synchronousWatchDirectory?: boolean;
 
 		/**
-		Specifies a list of directories to exclude from watch
+		Specifies a list of directories to exclude from watch.
 		*/
 		excludeDirectories?: string[];
 
 		/**
-		Specifies a list of files to exclude from watch
+		Specifies a list of files to exclude from watch.
 		*/
 		excludeFiles?: string[];
 	};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR adds support for TypeScript 5.8:

- Add new option `node18` to `compilerOptions.module`
- Add new options  to `compilerOptions`
	- `erasableSyntaxOnly`
	-  `libReplacement`
- Add TypeScript 5.8 to CI

Refs:

- [Announcing TypeScript 5.8](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/)