### PR TITLE
`Replace`: Fix instantiations with unions

### DIFF
--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -68,8 +68,12 @@ type _Replace<
 	Replacement extends string,
 	Options extends ReplaceOptions,
 	Accumulator extends string = '',
-> = Input extends `${infer Head}${Search}${infer Tail}`
-	? Options['all'] extends true
-		? _Replace<Tail, Search, Replacement, Options, `${Accumulator}${Head}${Replacement}`>
-		: `${Head}${Replacement}${Tail}`
-	: `${Accumulator}${Input}`;
+> = Search extends string // For distributing `Search`
+	? Replacement extends string // For distributing `Replacement`
+		? Input extends `${infer Head}${Search}${infer Tail}`
+			? Options['all'] extends true
+				? _Replace<Tail, Search, Replacement, Options, `${Accumulator}${Head}${Replacement}`>
+				: `${Head}${Replacement}${Tail}`
+			: `${Accumulator}${Input}`
+		: never
+	: never;

--- a/test-d/replace.ts
+++ b/test-d/replace.ts
@@ -28,6 +28,31 @@ expectType<'userName'>(replaceAll('__userName__', '__', ''));
 expectType<'MyCoolTitle'>(replaceAll('My Cool Title', ' ', ''));
 expectType<'fobarfobar'>(replaceAll('foobarfoobar', 'ob', 'b'));
 
+// Unions
+expectType<'bcabc' | 'cbcba'>({} as Replace<'abcabc' | 'cbacba', 'a', ''>);
+expectType<'bcabc' | 'acabc'>({} as Replace<'abcabc', 'a' | 'b', ''>);
+expectType<'bcabc' | 'Abcabc'>({} as Replace<'abcabc', 'a', '' | 'A'>);
+
+expectType<'bcabc' | 'acabc' | 'cbcba' | 'cacba'>({} as Replace<'abcabc' | 'cbacba', 'a' | 'b', ''>);
+expectType<'bcabc' | 'Abcabc' | 'cbcba' | 'cbAcba'>({} as Replace<'abcabc' | 'cbacba', 'a', '' | 'A'>);
+expectType<'bcabc' | 'Abcabc' | 'acabc' | 'aAcabc'>({} as Replace<'abcabc', 'a' | 'b', '' | 'A'>);
+
+expectType<'bcabc' | 'Abcabc' | 'acabc' | 'aAcabc' | 'cbcba' | 'cbAcba' | 'cacba' | 'cAacba'>(
+	{} as Replace<'abcabc' | 'cbacba', 'a' | 'b', '' | 'A'>,
+);
+
+expectType<'bcbc' | 'cbcb'>({} as Replace<'abcabc' | 'cbacba', 'a', '', {all: true}>);
+expectType<'bcbc' | 'acac'>({} as Replace<'abcabc', 'a' | 'b', '', {all: true}>);
+expectType<'bcbc' | 'AbcAbc'>({} as Replace<'abcabc', 'a', '' | 'A', {all: true}>);
+
+expectType<'bcbc' | 'acac' | 'cbcb' | 'caca'>({} as Replace<'abcabc' | 'cbacba', 'a' | 'b', '', {all: true}>);
+expectType<'bcbc' | 'AbcAbc' | 'cbcb' | 'cbAcbA'>({} as Replace<'abcabc' | 'cbacba', 'a', '' | 'A', {all: true}>);
+expectType<'bcbc' | 'AbcAbc' | 'acac' | 'aAcaAc'>({} as Replace<'abcabc', 'a' | 'b', '' | 'A', {all: true}>);
+
+expectType<'bcbc' | 'AbcAbc' | 'acac' | 'aAcaAc' | 'cbcb' | 'cbAcbA' | 'caca' | 'cAacAa'>(
+	{} as Replace<'abcabc' | 'cbacba', 'a' | 'b', '' | 'A', {all: true}>,
+);
+
 // Recursion depth at which a non-tail recursive implementation starts to fail.
 type FiftyZeroes = StringRepeat<'0', 50>;
 type FiftyOnes = StringRepeat<'1', 50>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes behaviour of `Replace` when instantiated with unions.

1. When `Search` is a union
    ```ts
    type Current = Replace<'bar', 'a' | 'b', 'z'>;
    //   ^? type Current = "zr" | "zar" | "bzr" | "bzar"
    
    type Updated = Replace<'bar', 'a' | 'b', 'z'>;
    //   ^? type Updated = "bzr" | "zar"
    ```

    ```ts
    type Current = Replace<'barbar', 'a' | 'b', 'z', {all: true}>;
    //   ^? type Current = "zrbzr" | "zrbzzr" | "zrzr" | "zrzzr" | "zzzr" | "zzrbzr" | "zzrbzzr" | "zzrzr" | "zzrzzr" | "zarzzr" | "zarzrbzr" | "zarzrbzzr" | "zarzrzr" | "zarzrzzr" | "bzrbzr" | "bzrbzzr" | ... 11 more ... | "bzarzrzzr"
    
    type Updated = Replace<'barbar', 'a' | 'b', 'z', {all: true}>;
    //   ^? type Updated = "bzrbzr" | "zarzar"
    ```

2. When `Replacement` is a union
    ```ts
    type Current = Replace<'barbar', 'a', 'x' | 'z', {all: true}>;
    //   ^? type Current = "bxrbxr" | "bxrbzr" | "bzrbxr" | "bzrbzr"
    
    type Updated = Replace<'barbar', 'a', 'x' | 'z', {all: true}>;
    //   ^? type Updated = "bxrbxr" | "bzrbzr"
    ```