### PR TITLE
`Split`: Fix instantiations with unions and add `strictLiteralChecks` option

### DIFF
--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -10,7 +10,7 @@ Split options.
 */
 type SplitOptions = {
 	/**
-	When enabled, instantiations with non-literal string types (e.g., `string`, `Uppercase<string>`, `on${string}`) simply return back `string[]` without performing any splitting.
+	When enabled, instantiations with non-literal string types (e.g., `string`, `Uppercase<string>`, `on${string}`) simply return back `string[]` without performing any splitting, as the exact structure cannot be statically determined.
 
 	Note: In the future, this option might be enabled by default, so if you currently rely on this being disabled, you should consider explicitly enabling it.
 

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -1,3 +1,43 @@
+import type {And} from './and';
+import type {Not} from './internal';
+import type {IsStringLiteral} from './is-literal';
+import type {Or} from './or';
+
+/**
+Split options.
+
+@see {@link Split}
+*/
+type SplitOptions = {
+	/**
+	When enabled, instantiations with non-literal string types (e.g., `string`, `Uppercase<string>`, `on${string}`) simply return back `string[]` without performing any splitting.
+
+	Note: In the future, this option might be enabled by default, so if you currently rely on this being disabled, you should consider explicitly enabling it.
+
+	@default false
+
+	@example
+	```ts
+	type Example1 = Split<`foo.${string}.bar`, '.', {strictLiteralChecks: false}>;
+	//=> ['foo', string, 'bar']
+
+	type Example2 = Split<`foo.${string}`, '.', {strictLiteralChecks: true}>;
+	//=> string[]
+
+	type Example3 = Split<'foobarbaz', `b${string}`, {strictLiteralChecks: false}>;
+	//=> ['foo', 'r', 'z']
+
+	type Example4 = Split<'foobarbaz', `b${string}`, {strictLiteralChecks: true}>;
+	//=> string[]
+	```
+	*/
+	strictLiteralChecks?: boolean;
+};
+
+type DefaultSplitOptions = {
+	strictLiteralChecks: false;
+};
+
 /**
 Represents an array of strings split using a given character or character set.
 
@@ -16,20 +56,34 @@ let array: Item[];
 array = split(items, ',');
 ```
 
+@see {@link SplitOptions}
+
 @category String
 @category Template literal
 */
 export type Split<
 	S extends string,
 	Delimiter extends string,
-> = SplitHelper<S, Delimiter>;
+	Options extends SplitOptions = {},
+> = SplitHelper<S, Delimiter, {
+	strictLiteralChecks: Options['strictLiteralChecks'] extends boolean ? Options['strictLiteralChecks'] : DefaultSplitOptions['strictLiteralChecks'];
+}>;
 
 type SplitHelper<
 	S extends string,
 	Delimiter extends string,
+	Options extends Required<SplitOptions>,
 	Accumulator extends string[] = [],
-> = S extends `${infer Head}${Delimiter}${infer Tail}`
-	? SplitHelper<Tail, Delimiter, [...Accumulator, Head]>
-	: Delimiter extends ''
-		? Accumulator
-		: [...Accumulator, S];
+> = S extends string // For distributing `S`
+	? Delimiter extends string // For distributing `Delimeter`
+		// If `strictLiteralChecks` is `false` OR `S` and `Delimiter` both are string literals, then perform the split
+		? Or<Not<Options['strictLiteralChecks']>, And<IsStringLiteral<S>, IsStringLiteral<Delimiter>>> extends true
+			? S extends `${infer Head}${Delimiter}${infer Tail}`
+				? SplitHelper<Tail, Delimiter, Options, [...Accumulator, Head]>
+				: Delimiter extends ''
+					? Accumulator
+					: [...Accumulator, S]
+			// Otherwise, return `string[]`
+			: string[]
+		: never // Should never happen
+	: never; // Should never happen

--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -30,6 +30,29 @@ expectType<[]>(split('', ''));
 // Split empty string by any string.
 expectType<['']>(split('', ' '));
 
+// Unions
+expectType<['a', 'b', 'c'] | ['x', 'y', 'z']>({} as Split<'a,b,c' | 'x,y,z', ','>);
+expectType<['a', 'b', 'c'] | ['a,', ',c']>({} as Split<'a,b,c', ',' | 'b'>);
+expectType<['a', 'b', 'c'] | ['a,b,c'] | ['x', 'y', 'z'] | ['x:y:z']>({} as Split<'a,b,c' | 'x:y:z', ',' | ':'>);
+
+// -- strictLiteralChecks: false --
+// NOTE: The behaviour covered in the test below is not acurate because the `a.b.${string}` type might hold a value like `a.b.c.d`,
+// which, when split by `.`, would result in `['a', 'b', 'c', 'd']`, which wouldn't conform to the output type of `['a', 'b', string]`.
+expectType<['a', 'b', string]>(split('a.b.c.d' as `a.b.${string}`, '.'));
+
+// -- strictLiteralChecks: true --
+expectType<string[]>({} as Split<string, '', {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<Uppercase<string>, '-', {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<`on${string}`, 'n', {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<'a,b,c', string, {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<'a,b,c', Lowercase<string>, {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<'a,b,c', `,${string}`, {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<`on${string}`, Lowercase<string>, {strictLiteralChecks: true}>);
+
+expectType<['a', 'b', 'c'] | string[]>({} as Split<'a,b,c' | `bye, ${string}`, ',', {strictLiteralChecks: true}>);
+expectType<['a', 'b', 'c'] | string[]>({} as Split<'a,b,c', ',' | `b${string}`, {strictLiteralChecks: true}>);
+expectType<['a', 'b', 'c'] | string[]>({} as Split<'a,b,c' | `bye, ${string}`, ',' | `b${string}`, {strictLiteralChecks: true}>);
+
 // Recursion depth at which a non-tail recursive implementation starts to fail.
 type FiftyZeroes = StringRepeat<'0', 50>;
 expectType<BuildTuple<50, '0'>>({} as Split<FiftyZeroes, ''>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR introduces a new `strictLiteralChecks` option for the `Split` type based on the discussions made in #1047.

This option currently defaults to `false` for backward compatibility but in the next major release it'd be better to update the default to `true`.

**Why is defaulting to `true` better?**
When non-literal strings are involved, the result produced by `Split` will most-likely be inaccurate. Consider this example:

```ts
import {Split} from "type-fest";

declare function split<
	S extends string,
	Delimiter extends string,
>(string: S, separator: Delimiter): Split<S, Delimiter, {strictLiteralChecks: false}>;

const result = split('a.b.c.d' as `a.b.${string}`, '.');
//    ^? const result: ["a", "b", string]
``` 

So, when `strictLiteralChecks` is disabled, splitting `a.b.${string}` by `'.'` returns `['a', string, 'z']`, which is not accurate because the `a.b.${string}` type might hold a value like `a.b.c.d`, which, when split by `,`, would result in `['a', 'b', 'c', 'd']`, which wouldn't conform to the output type of `['a', 'b', string]`.

So, by default, it's better to prioritise accuracy over precision and simply return `string[]` in cases involving non-string literals.

<hr>

This PR also fixes cases where `Delimiter` is a union:
```ts
type Current = Split<"a,b,c", "," | "b">;
//   ^? type Current = ["a" | "a,", "" | "b", "", "c"] | ["a" | "a,", "" | "b", "c"] | ["a" | "a,", "", "c"]

type Updated = Split<"a,b,c", "," | "b">;
//   ^? type Updated = ["a", "b", "c"] | ["a,", ",c"]
```

---

Closes #1047