### PR TITLE
`Sum`: Add negative return value support

### DIFF
--- a/source/array-slice.d.ts
+++ b/source/array-slice.d.ts
@@ -91,7 +91,7 @@ type ArraySliceHelper<
 		? Sum<ArrayLength, Start> extends infer AddResult extends number
 			? number extends AddResult // (ArrayLength + Start) < 0
 				? 0
-				: AddResult
+				: GreaterThan<AddResult, 0> extends true ? AddResult : 0
 			: never
 		: Start,
 	PositiveE extends number = IsNegative<End> extends true ? Sum<ArrayLength, End> : End,

--- a/source/sum.d.ts
+++ b/source/sum.d.ts
@@ -36,11 +36,11 @@ export type Sum<A extends number, B extends number> =
 	number extends A | B ? number
 		// Handle cases when A and B are both +/- infinity
 		: A extends B & (PositiveInfinity | NegativeInfinity) ? A // A or B could be used here as they are equal
-			// Handle cases when A is - infinity
-			: A extends NegativeInfinity ? B extends PositiveInfinity ? number : NegativeInfinity
-				// Handle cases when A is + infinity
-				: A extends PositiveInfinity ? B extends NegativeInfinity ? number : PositiveInfinity
-					// Handle cases when B is +/- infinity (we know A is not +/- infinity at this point)
+			// Handle cases when A and B are opposite infinities
+			: A | B extends PositiveInfinity | NegativeInfinity ? number
+				// Handle cases when A is +/- infinity
+				: A extends PositiveInfinity | NegativeInfinity ? A
+					// Handle cases when B is +/- infinity
 					: B extends PositiveInfinity | NegativeInfinity ? B
 						// Handle cases when A or B is 0 or it's the same number with different signs
 						: A extends 0 ? B : B extends 0 ? A : A extends ReverseSign<B> ? 0

--- a/source/sum.d.ts
+++ b/source/sum.d.ts
@@ -7,8 +7,6 @@ Returns the sum of two numbers.
 
 Note:
 - A or B can only support `-999` ~ `999`.
-- A and B can only be small integers, less than 1000.
-- If the result is negative, you can only get `number`.
 
 @example
 ```
@@ -21,7 +19,7 @@ Sum<-111, 222>;
 //=> 111
 
 Sum<111, -222>;
-//=> number
+//=> -111
 
 Sum<PositiveInfinity, -9999>;
 //=> PositiveInfinity
@@ -32,7 +30,7 @@ Sum<PositiveInfinity, NegativeInfinity>;
 
 @category Numeric
 */
-// TODO: Support big integer and negative number.
+// TODO: Support big integer.
 export type Sum<A extends number, B extends number> =
 	// Handle cases when A or B is the actual "number" type
 	number extends A | B ? number
@@ -44,22 +42,23 @@ export type Sum<A extends number, B extends number> =
 				: A extends PositiveInfinity ? B extends NegativeInfinity ? number : PositiveInfinity
 					// Handle cases when B is +/- infinity (we know A is not +/- infinity at this point)
 					: B extends PositiveInfinity | NegativeInfinity ? B
-						// Handle cases when A or B is 0 or numbers have different signs
+						// Handle cases when A or B is 0 or it's the same number with different signs
 						: A extends 0 ? B : B extends 0 ? A : A extends ReverseSign<B> ? 0
 							// Handle remaining regular cases
 							: SumPostChecks<A, B>;
 
 /**
-Adds two numbers A and B, such that they are not equal and neither of them are 0, +/- infinity or the `number` type
+Adds two numbers A and B, such that they are not equal with different signs and neither of them are 0, +/- infinity or the `number` type
 */
 type SumPostChecks<A extends number, B extends number, AreNegative = [IsNegative<A>, IsNegative<B>]> =
 	AreNegative extends [false, false]
+		// When both numbers are positive we can add them together
 		? SumPositives<A, B>
 		: AreNegative extends [true, true]
 			// When both numbers are negative we add the absolute values and then reverse the sign
 			? ReverseSign<SumPositives<NumberAbsolute<A>, NumberAbsolute<B>>>
 			// When the signs are different we can subtract the absolute values, remove the sign
-			// and then reverse the sign if larger absolute value is negative
+			// and then reverse the sign if the larger absolute value is negative
 			: NumberAbsolute<Subtract<NumberAbsolute<A>, NumberAbsolute<B>>> extends infer Result extends number
 				? TupleMax<[NumberAbsolute<A>, NumberAbsolute<B>]> extends infer Max_ extends number
 					? Max_ extends A | B

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -28,8 +28,10 @@ expectType<-1998>({} as Sum<-999, -999>);
 // Infinity
 expectType<PositiveInfinity>({} as Sum<PositiveInfinity, -999>);
 expectType<PositiveInfinity>({} as Sum<-999, PositiveInfinity>);
+expectType<PositiveInfinity>({} as Sum<PositiveInfinity, PositiveInfinity>);
 expectType<NegativeInfinity>({} as Sum<NegativeInfinity, 999>);
 expectType<NegativeInfinity>({} as Sum<999, NegativeInfinity>);
+expectType<NegativeInfinity>({} as Sum<NegativeInfinity, NegativeInfinity>);
 
 // Number
 expectType<number>({} as Sum<number, 1>);

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -2,24 +2,24 @@ import {expectType} from 'tsd';
 import type {Sum} from '../index';
 import type {NegativeInfinity, PositiveInfinity} from '../source/numeric';
 
-expectType<Sum<1, 2>>(3);
-expectType<Sum<10, -2>>(8);
-expectType<Sum<2, -2>>(0);
+expectType<3>({} as Sum<1, 2>);
+expectType<8>({} as Sum<10, -2>);
+expectType<0>({} as Sum<2, -2>);
 
-expectType<Sum<-1, -2>>(null! as number); // Note: you can only get `number` for now
+expectType<number>({} as Sum<-1, -2>); // Note: you can only get `number` for now
 
-expectType<Sum<PositiveInfinity, -999>>(null! as PositiveInfinity);
-expectType<Sum<-999, PositiveInfinity>>(null! as PositiveInfinity);
-expectType<Sum<NegativeInfinity, 999>>(null! as NegativeInfinity);
-expectType<Sum<999, NegativeInfinity>>(null! as NegativeInfinity);
-expectType<Sum<NegativeInfinity, PositiveInfinity>>(null! as number);
+expectType<PositiveInfinity>({} as Sum<PositiveInfinity, -999>);
+expectType<PositiveInfinity>({} as Sum<-999, PositiveInfinity>);
+expectType<NegativeInfinity>({} as Sum<NegativeInfinity, 999>);
+expectType<NegativeInfinity>({} as Sum<999, NegativeInfinity>);
+expectType<number>({} as Sum<NegativeInfinity, PositiveInfinity>);
 
-expectType<Sum<number, 1>>(null! as number);
-expectType<Sum<1, number>>(null! as number);
-expectType<Sum<number, number>>(null! as number);
-expectType<Sum<number, PositiveInfinity>>(null! as number);
+expectType<number>({} as Sum<number, 1>);
+expectType<number>({} as Sum<1, number>);
+expectType<number>({} as Sum<number, number>);
+expectType<number>({} as Sum<number, PositiveInfinity>);
 
 // Union
-expectType<Sum<1, 2 | 3>>({} as 3 | 4);
-expectType<Sum<1 | 2, 3>>({} as 4 | 5);
-expectType<Sum<1 | 2 | 3, 4 | 5>>({} as 5 | 6 | 7 | 8);
+expectType<3 | 4>({} as Sum<1, 2 | 3>);
+expectType<4 | 5>({} as Sum<1 | 2, 3>);
+expectType<5 | 6 | 7 | 8>({} as Sum<1 | 2 | 3, 4 | 5>);

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -44,4 +44,4 @@ expectType<number>({} as Sum<PositiveInfinity, NegativeInfinity>);
 expectType<3 | 4>({} as Sum<1, 2 | 3>);
 expectType<4 | 5>({} as Sum<1 | 2, 3>);
 expectType<5 | 6 | 7 | 8>({} as Sum<1 | 2 | 3, 4 | 5>);
-expectType<2 | -3 | 6 | -1 | -6 | 3 | 4 | 8>({} as Sum<1 | -2 | 3, 1 | -4 | 5>);
+expectType<2 | 4 | 5 | 7 | 9 | -2 | -4 | -7>({} as Sum<1 | -2 | 3, 4 | -5 | 6>);

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -2,24 +2,46 @@ import {expectType} from 'tsd';
 import type {Sum} from '../index';
 import type {NegativeInfinity, PositiveInfinity} from '../source/numeric';
 
+// Positive result
+expectType<0>({} as Sum<-999, 999>);
+expectType<0>({} as Sum<999, -999>);
+expectType<0>({} as Sum<0, 0>);
+expectType<0>({} as Sum<2, -2>);
+expectType<0>({} as Sum<-2, 2>);
 expectType<3>({} as Sum<1, 2>);
 expectType<8>({} as Sum<10, -2>);
-expectType<0>({} as Sum<2, -2>);
+expectType<8>({} as Sum<-2, 10>);
+expectType<57>({} as Sum<-20, 77>);
+expectType<998>({} as Sum<-1, 999>);
+expectType<1000>({} as Sum<999, 1>);
+expectType<1998>({} as Sum<999, 999>);
 
+// Negative result
 expectType<-3>({} as Sum<-1, -2>);
+expectType<-8>({} as Sum<-10, 2>);
+expectType<-8>({} as Sum<2, -10>);
+expectType<-57>({} as Sum<20, -77>);
+expectType<-998>({} as Sum<-999, 1>);
+expectType<-998>({} as Sum<1, -999>);
+expectType<-1998>({} as Sum<-999, -999>);
 
+// Infinity
 expectType<PositiveInfinity>({} as Sum<PositiveInfinity, -999>);
 expectType<PositiveInfinity>({} as Sum<-999, PositiveInfinity>);
 expectType<NegativeInfinity>({} as Sum<NegativeInfinity, 999>);
 expectType<NegativeInfinity>({} as Sum<999, NegativeInfinity>);
-expectType<number>({} as Sum<NegativeInfinity, PositiveInfinity>);
 
+// Number
 expectType<number>({} as Sum<number, 1>);
 expectType<number>({} as Sum<1, number>);
 expectType<number>({} as Sum<number, number>);
 expectType<number>({} as Sum<number, PositiveInfinity>);
+expectType<number>({} as Sum<NegativeInfinity, number>);
+expectType<number>({} as Sum<NegativeInfinity, PositiveInfinity>);
+expectType<number>({} as Sum<PositiveInfinity, NegativeInfinity>);
 
 // Union
 expectType<3 | 4>({} as Sum<1, 2 | 3>);
 expectType<4 | 5>({} as Sum<1 | 2, 3>);
 expectType<5 | 6 | 7 | 8>({} as Sum<1 | 2 | 3, 4 | 5>);
+expectType<2 | -3 | 6 | -1 | -6 | 3 | 4 | 8>({} as Sum<1 | -2 | 3, 1 | -4 | 5>);

--- a/test-d/sum.ts
+++ b/test-d/sum.ts
@@ -6,7 +6,7 @@ expectType<3>({} as Sum<1, 2>);
 expectType<8>({} as Sum<10, -2>);
 expectType<0>({} as Sum<2, -2>);
 
-expectType<number>({} as Sum<-1, -2>); // Note: you can only get `number` for now
+expectType<-3>({} as Sum<-1, -2>);
 
 expectType<PositiveInfinity>({} as Sum<PositiveInfinity, -999>);
 expectType<PositiveInfinity>({} as Sum<-999, PositiveInfinity>);


### PR DESCRIPTION
Adds negative return value support to `Sum`.

Follows same pattern as https://github.com/sindresorhus/type-fest/pull/1061