### PR TITLE
Refactor `Paths` to leverage recent improvements in `Subtract`

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -246,13 +246,7 @@ type InternalPaths<T, Options extends Required<PathsOptions>> =
 										bracketNotation: Options['bracketNotation'];
 										maxRecursionDepth: Subtract<MaxDepth, 1>;
 										leavesOnly: Options['leavesOnly'];
-										depth: Options['depth'] extends infer Depth extends number // For distributing `Options['depth']`
-											? Depth extends 0 // Don't subtract further if `Depth` has reached `0`
-												? never
-												: ToString<Depth> extends `-${number}` // Don't subtract if `Depth` is -ve
-													? never
-													: Subtract<Options['depth'], 1> // If `Subtract` supported -ve numbers, then `depth` could have simply been `Subtract<Options['depth'], 1>`
-											: never; // Should never happen
+										depth: Subtract<Options['depth'], 1>;
 									}> extends infer SubPath
 										? SubPath extends string | number
 											? (


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Simplify `depth` updation logic to leverage `Subtract`'s supports for -ve numbers.