### PR TITLE
`DelimiterCase` / `SnakeCase` / `ScreamingSnakeCase` / `KebabCase`: Fix default value for `splitOnNumbers` option

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -61,7 +61,7 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 export type DelimiterCase<
 	Value,
 	Delimiter extends string,
-	Options extends WordsOptions = {},
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = Value extends string
 	? IsStringLiteral<Value> extends false
 		? Value

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -39,5 +39,5 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 */
 export type KebabCase<
 	Value,
-	Options extends WordsOptions = {},
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = DelimiterCase<Value, '-', Options>;

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -20,5 +20,5 @@ const someVariableNoSplitOnNumbers: ScreamingSnakeCase<'p2pNetwork', {splitOnNum
  */
 export type ScreamingSnakeCase<
 	Value,
-	Options extends WordsOptions = {},
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = Value extends string ? Uppercase<SnakeCase<Value, Options>> : Value;

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -39,5 +39,5 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 */
 export type SnakeCase<
 	Value,
-	Options extends WordsOptions = {},
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = DelimiterCase<Value, '_', Options>;

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -5,7 +5,7 @@ import type {DelimiterCase} from '../source/delimiter-case';
 const delimiterFromCamel: DelimiterCase<'fooBar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromCamel);
 
-const delimiterFromComplexCamel: DelimiterCase<'fooBarAbc123', '#', {splitOnNumbers: false}> = 'foo#bar#abc123';
+const delimiterFromComplexCamel: DelimiterCase<'fooBarAbc123', '#'> = 'foo#bar#abc123';
 expectType<'foo#bar#abc123'>(delimiterFromComplexCamel);
 
 const delimiterFromComplexCamelSplitOnNumbers: DelimiterCase<
@@ -15,22 +15,13 @@ const delimiterFromComplexCamelSplitOnNumbers: DelimiterCase<
 > = 'foo#bar#abc#123';
 expectType<'foo#bar#abc#123'>(delimiterFromComplexCamelSplitOnNumbers);
 
-const delimiterFromComplexCamelNoSplitOnNumbers: DelimiterCase<
-'fooBarAbc123',
-'#',
-{splitOnNumbers: false}
-> = 'foo#bar#abc123';
+const delimiterFromComplexCamelNoSplitOnNumbers: DelimiterCase<'fooBarAbc123', '#'> = 'foo#bar#abc123';
 expectType<'foo#bar#abc123'>(delimiterFromComplexCamelNoSplitOnNumbers);
 
-const delimiterNumberInTheMiddle: DelimiterCase<'p2pNetwork', '#'>
-	= 'p#2#p#network';
+const delimiterNumberInTheMiddle: DelimiterCase<'p2pNetwork', '#', {splitOnNumbers: true}> = 'p#2#p#network';
 expectType<'p#2#p#network'>(delimiterNumberInTheMiddle);
 
-const delimiterNumberInTheMiddleNoSplitOnNumbers: DelimiterCase<
-'p2pNetwork',
-'#',
-{splitOnNumbers: false}
-> = 'p2p#network';
+const delimiterNumberInTheMiddleNoSplitOnNumbers: DelimiterCase<'p2pNetwork', '#'> = 'p2p#network';
 expectType<'p2p#network'>(delimiterNumberInTheMiddleNoSplitOnNumbers);
 
 const delimiterFromPascal: DelimiterCase<'FooBar', '#'> = 'foo#bar';
@@ -86,50 +77,25 @@ const delimiterFromMixed3: DelimiterCase<'parseHTMLItem', '#'>
 	= 'parse#html#item';
 expectType<'parse#html#item'>(delimiterFromMixed3);
 
-const delimiterFromNumberInTheMiddleSplitOnNumbers: DelimiterCase<
-'foo2bar',
-'#'
-> = 'foo#2#bar';
+const delimiterFromNumberInTheMiddleSplitOnNumbers: DelimiterCase<'foo2bar', '#', {splitOnNumbers: true}> = 'foo#2#bar';
 expectType<'foo#2#bar'>(delimiterFromNumberInTheMiddleSplitOnNumbers);
 
-const delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase: DelimiterCase<
-'foO2Bar',
-'#'
-> = 'fo#o#2#bar';
+const delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase: DelimiterCase<'foO2Bar', '#', {splitOnNumbers: true}> = 'fo#o#2#bar';
 expectType<'fo#o#2#bar'>(delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase);
 
-const delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase2: DelimiterCase<
-'foO2bar',
-'#'
-> = 'fo#o#2#bar';
+const delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase2: DelimiterCase<'foO2bar', '#', {splitOnNumbers: true}> = 'fo#o#2#bar';
 expectType<'fo#o#2#bar'>(delimiterFromNumberInTheMiddleSplitOnNumbersEdgeCase2);
 
-const delimiterFromNumberInTheMiddleNoSplitOnNumbers: DelimiterCase<
-'foo2bar',
-'#',
-{splitOnNumbers: false}
-> = 'foo2bar';
+const delimiterFromNumberInTheMiddleNoSplitOnNumbers: DelimiterCase<'foo2bar', '#'> = 'foo2bar';
 expectType<'foo2bar'>(delimiterFromNumberInTheMiddleNoSplitOnNumbers);
 
-const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: DelimiterCase<
-'foo2Bar',
-'#',
-{splitOnNumbers: false}
-> = 'foo2#bar';
+const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: DelimiterCase<'foo2Bar', '#'> = 'foo2#bar';
 expectType<'foo2#bar'>(delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase);
 
-const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: DelimiterCase<
-'foO2bar',
-'#',
-{splitOnNumbers: false}
-> = 'fo#o2bar';
+const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: DelimiterCase<'foO2bar', '#'> = 'fo#o2bar';
 expectType<'fo#o2bar'>(delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 
-const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: DelimiterCase<
-'FOO22Bar',
-'#',
-{splitOnNumbers: false}
-> = 'foo22#bar';
+const delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: DelimiterCase<'FOO22Bar', '#'> = 'foo22#bar';
 expectType<'foo22#bar'>(
 	delimiterFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3,
 );

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -58,38 +58,23 @@ expectType<'parse-html'>(kebabFromMixed2);
 const kebabFromMixed3: KebabCase<'parseHTMLItem'> = 'parse-html-item';
 expectType<'parse-html-item'>(kebabFromMixed3);
 
-const kebabFromNumberInTheMiddleSplitOnNumbers: KebabCase<'foo2bar'>
-	= 'foo-2-bar';
+const kebabFromNumberInTheMiddleSplitOnNumbers: KebabCase<'foo2bar', {splitOnNumbers: true}> = 'foo-2-bar';
 expectType<'foo-2-bar'>(kebabFromNumberInTheMiddleSplitOnNumbers);
 
-const kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase: KebabCase<'foO2Bar'>
-	= 'fo-o-2-bar';
+const kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase: KebabCase<'foO2Bar', {splitOnNumbers: true}> = 'fo-o-2-bar';
 expectType<'fo-o-2-bar'>(kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase);
 
-const kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase2: KebabCase<'foO2bar'>
-	= 'fo-o-2-bar';
+const kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase2: KebabCase<'foO2bar', {splitOnNumbers: true}> = 'fo-o-2-bar';
 expectType<'fo-o-2-bar'>(kebabFromNumberInTheMiddleSplitOnNumbersEdgeCase2);
 
-const kebabFromNumberInTheMiddleNoSplitOnNumbers: KebabCase<
-'foo2bar',
-{splitOnNumbers: false}
-> = 'foo2bar';
+const kebabFromNumberInTheMiddleNoSplitOnNumbers: KebabCase<'foo2bar'> = 'foo2bar';
 expectType<'foo2bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbers);
 
-const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: KebabCase<
-'foo2Bar',
-{splitOnNumbers: false}
-> = 'foo2-bar';
+const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: KebabCase<'foo2Bar'> = 'foo2-bar';
 expectType<'foo2-bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase);
 
-const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: KebabCase<
-'foO2bar',
-{splitOnNumbers: false}
-> = 'fo-o2bar';
+const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: KebabCase<'foO2bar'> = 'fo-o2bar';
 expectType<'fo-o2bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 
-const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: KebabCase<
-'FOO22Bar',
-{splitOnNumbers: false}
-> = 'foo22-bar';
+const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: KebabCase<'FOO22Bar'> = 'foo22-bar';
 expectType<'foo22-bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);

--- a/test-d/screaming-snake-case.ts
+++ b/test-d/screaming-snake-case.ts
@@ -59,40 +59,25 @@ expectType<'PARSE_HTML'>(snakeFromMixed2);
 const snakeFromMixed3: ScreamingSnakeCase<'parseHTMLItem'> = 'PARSE_HTML_ITEM';
 expectType<'PARSE_HTML_ITEM'>(snakeFromMixed3);
 
-const snakeFromNumberInTheMiddleSplitOnNumbers: ScreamingSnakeCase<'foo2bar'>
-	= 'FOO_2_BAR';
+const snakeFromNumberInTheMiddleSplitOnNumbers: ScreamingSnakeCase<'foo2bar', {splitOnNumbers: true}> = 'FOO_2_BAR';
 expectType<'FOO_2_BAR'>(snakeFromNumberInTheMiddleSplitOnNumbers);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: ScreamingSnakeCase<'foO2Bar'>
-	= 'FO_O_2_BAR';
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: ScreamingSnakeCase<'foO2Bar', {splitOnNumbers: true}> = 'FO_O_2_BAR';
 expectType<'FO_O_2_BAR'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: ScreamingSnakeCase<'foO2bar'>
-	= 'FO_O_2_BAR';
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: ScreamingSnakeCase<'foO2bar', {splitOnNumbers: true}> = 'FO_O_2_BAR';
 expectType<'FO_O_2_BAR'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbers: ScreamingSnakeCase<
-'foo2bar',
-{splitOnNumbers: false}
-> = 'FOO2BAR';
+const snakeFromNumberInTheMiddleNoSplitOnNumbers: ScreamingSnakeCase<'foo2bar'> = 'FOO2BAR';
 expectType<'FOO2BAR'>(snakeFromNumberInTheMiddleNoSplitOnNumbers);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: ScreamingSnakeCase<
-'foo2Bar',
-{splitOnNumbers: false}
-> = 'FOO2_BAR';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: ScreamingSnakeCase<'foo2Bar'> = 'FOO2_BAR';
 expectType<'FOO2_BAR'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: ScreamingSnakeCase<
-'foO2bar',
-{splitOnNumbers: false}
-> = 'FO_O2BAR';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: ScreamingSnakeCase<'foO2bar'> = 'FO_O2BAR';
 expectType<'FO_O2BAR'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: ScreamingSnakeCase<
-'FOO22Bar',
-{splitOnNumbers: false}
-> = 'FOO22_BAR';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: ScreamingSnakeCase<'FOO22Bar'> = 'FOO22_BAR';
 expectType<'FOO22_BAR'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);
 
 const nonStringFromNonString: ScreamingSnakeCase<[]> = [];

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -58,38 +58,26 @@ expectType<'parse_html'>(snakeFromMixed2);
 const snakeFromMixed3: SnakeCase<'parseHTMLItem'> = 'parse_html_item';
 expectType<'parse_html_item'>(snakeFromMixed3);
 
-const snakeFromNumberInTheMiddleSplitOnNumbers: SnakeCase<'foo2bar'>
+const snakeFromNumberInTheMiddleSplitOnNumbers: SnakeCase<'foo2bar', {splitOnNumbers: true}>
 	= 'foo_2_bar';
 expectType<'foo_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbers);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: SnakeCase<'foO2Bar'>
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: SnakeCase<'foO2Bar', {splitOnNumbers: true}>
 	= 'fo_o_2_bar';
 expectType<'fo_o_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: SnakeCase<'foO2bar'>
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: SnakeCase<'foO2bar', {splitOnNumbers: true}>
 	= 'fo_o_2_bar';
 expectType<'fo_o_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbers: SnakeCase<
-'foo2bar',
-{splitOnNumbers: false}
-> = 'foo2bar';
+const snakeFromNumberInTheMiddleNoSplitOnNumbers: SnakeCase<'foo2bar'> = 'foo2bar';
 expectType<'foo2bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbers);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: SnakeCase<
-'foo2Bar',
-{splitOnNumbers: false}
-> = 'foo2_bar';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase: SnakeCase<'foo2Bar'> = 'foo2_bar';
 expectType<'foo2_bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: SnakeCase<
-'foO2bar',
-{splitOnNumbers: false}
-> = 'fo_o2bar';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2: SnakeCase<'foO2bar'> = 'fo_o2bar';
 expectType<'fo_o2bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 
-const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: SnakeCase<
-'FOO22Bar',
-{splitOnNumbers: false}
-> = 'foo22_bar';
+const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: SnakeCase<'FOO22Bar'> = 'foo22_bar';
 expectType<'foo22_bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes https://github.com/sindresorhus/type-fest/pull/930#discussion_r1977964498.

The `Words` type was already splitting on numbers, so for it `splitOnNumbers` correctly defaults to `true`.

However, `DelimiterCase` and its derived types didn't previously split on numbers, so their default value for `splitOnNumbers` should be `false`.