### PR TITLE
`DelimiterCasedPropertiesDeep` - Remove duplicate code

### DIFF
--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -74,11 +74,9 @@ type DelimiterCasedPropertiesArrayDeep<Value extends UnknownArray, Delimiter ext
 				// Leading spread array
 				: Value extends readonly [...infer U, infer V]
 					? [...DelimiterCasedPropertiesDeep<U, Delimiter>, DelimiterCasedPropertiesDeep<V, Delimiter>]
-					: Value extends readonly [...infer U, infer V]
-						? readonly [...DelimiterCasedPropertiesDeep<U, Delimiter>, DelimiterCasedPropertiesDeep<V, Delimiter>]
-						// Array
-						: Value extends Array<infer U>
-							? Array<DelimiterCasedPropertiesDeep<U, Delimiter>>
-							: Value extends ReadonlyArray<infer U>
-								? ReadonlyArray<DelimiterCasedPropertiesDeep<U, Delimiter>>
-								: never;
+					// Array
+					: Value extends Array<infer U>
+						? Array<DelimiterCasedPropertiesDeep<U, Delimiter>>
+						: Value extends ReadonlyArray<infer U>
+							? ReadonlyArray<DelimiterCasedPropertiesDeep<U, Delimiter>>
+							: never;


### PR DESCRIPTION
Based on this comment:

```ts
// This is a copy of CamelCasedPropertiesArrayDeep (see: camel-cased-properties-deep.d.ts).
// These types should be kept in sync.
```

Follow-up to https://github.com/sindresorhus/type-fest/issues/1062 and counterpart to 5d2199a135b6f3c1b345637b5fe9cced6c5110b9. `DelimiterCasedPropertiesArrayDeep` should stay in sync with `CamelCasedPropertiesArrayDeep`.
