### PR TITLE
`CamelCasedPropertiesDeep` - pass `Options` to nested array objects

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -49,6 +49,7 @@ import type {CamelCase} from 'type-fest';
 // Simple
 
 const someVariable: CamelCase<'foo-bar'> = 'fooBar';
+const preserveConsecutiveUppercase: CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'fooBARBaz';
 
 // Advanced
 

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -41,7 +41,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 
-const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{ fooBAR: { fooBARBiz: [{ fooBARBaz: string }] }}, {preserveConsecutiveUppercase: false}> = {
+const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{fooBAR: { fooBARBiz: [{ fooBARBaz: string }] }}, {preserveConsecutiveUppercase: false}> = {
 	fooBar: {
 		fooBarBiz: [{
 			fooBarBaz: 'string',
@@ -82,7 +82,7 @@ type CamelCasedPropertiesArrayDeep<
 	Options extends Required<CamelCaseOptions>,
 > = Value extends []
 	? []
-	// Tailing spread array
+	// Trailing spread array
 	: Value extends [infer U, ...infer V]
 		? [_CamelCasedPropertiesDeep<U, Options>, ..._CamelCasedPropertiesDeep<V, Options>]
 		: Value extends readonly [infer U, ...infer V]

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -40,6 +40,14 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
+const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{ fooBAR: { fooBARBiz: [{ fooBARBaz: string }] }}, {preserveConsecutiveUppercase: false}> = {
+	fooBar: {
+		fooBarBiz: [{
+			fooBarBaz: 'string',
+		}],
+	},
+};
 ```
 
 @category Change case
@@ -57,7 +65,7 @@ type _CamelCasedPropertiesDeep<
 > = Value extends NonRecursiveType
 	? Value
 	: Value extends UnknownArray
-		? CamelCasedPropertiesArrayDeep<Value>
+		? CamelCasedPropertiesArrayDeep<Value, Options>
 		: Value extends Set<infer U>
 			? Set<_CamelCasedPropertiesDeep<U, Options>>
 			: {
@@ -69,20 +77,22 @@ type _CamelCasedPropertiesDeep<
 
 // This is a copy of DelimiterCasedPropertiesArrayDeep (see: delimiter-cased-properties-deep.d.ts).
 // These types should be kept in sync.
-type CamelCasedPropertiesArrayDeep<Value extends UnknownArray> =
-	Value extends []
-		? []
-		: // Tailing spread array
-		Value extends [infer U, ...infer V]
-			? [CamelCasedPropertiesDeep<U>, ...CamelCasedPropertiesDeep<V>]
-			: Value extends readonly [infer U, ...infer V]
-				? readonly [CamelCasedPropertiesDeep<U>, ...CamelCasedPropertiesDeep<V>]
-				: // Leading spread array
-				Value extends readonly [...infer U, infer V]
-					? [...CamelCasedPropertiesDeep<U>, CamelCasedPropertiesDeep<V>]
-					: // Array
-					Value extends Array<infer U>
-						? Array<CamelCasedPropertiesDeep<U>>
-						: Value extends ReadonlyArray<infer U>
-							? ReadonlyArray<CamelCasedPropertiesDeep<U>>
-							: never;
+type CamelCasedPropertiesArrayDeep<
+	Value extends UnknownArray,
+	Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true},
+> = Value extends []
+	? []
+	// Tailing spread array
+	: Value extends [infer U, ...infer V]
+		? [CamelCasedPropertiesDeep<U, Options>, ...CamelCasedPropertiesDeep<V, Options>]
+		: Value extends readonly [infer U, ...infer V]
+			? readonly [CamelCasedPropertiesDeep<U, Options>, ...CamelCasedPropertiesDeep<V, Options>]
+			: // Leading spread array
+			Value extends readonly [...infer U, infer V]
+				? [...CamelCasedPropertiesDeep<U, Options>, CamelCasedPropertiesDeep<V, Options>]
+				: // Array
+				Value extends Array<infer U>
+					? Array<CamelCasedPropertiesDeep<U, Options>>
+					: Value extends ReadonlyArray<infer U>
+						? ReadonlyArray<CamelCasedPropertiesDeep<U, Options>>
+						: never;

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -79,20 +79,20 @@ type _CamelCasedPropertiesDeep<
 // These types should be kept in sync.
 type CamelCasedPropertiesArrayDeep<
 	Value extends UnknownArray,
-	Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true},
+	Options extends Required<CamelCaseOptions>,
 > = Value extends []
 	? []
 	// Tailing spread array
 	: Value extends [infer U, ...infer V]
-		? [CamelCasedPropertiesDeep<U, Options>, ...CamelCasedPropertiesDeep<V, Options>]
+		? [_CamelCasedPropertiesDeep<U, Options>, ..._CamelCasedPropertiesDeep<V, Options>]
 		: Value extends readonly [infer U, ...infer V]
-			? readonly [CamelCasedPropertiesDeep<U, Options>, ...CamelCasedPropertiesDeep<V, Options>]
+			? readonly [_CamelCasedPropertiesDeep<U, Options>, ..._CamelCasedPropertiesDeep<V, Options>]
 			: // Leading spread array
 			Value extends readonly [...infer U, infer V]
-				? [...CamelCasedPropertiesDeep<U, Options>, CamelCasedPropertiesDeep<V, Options>]
+				? [..._CamelCasedPropertiesDeep<U, Options>, _CamelCasedPropertiesDeep<V, Options>]
 				: // Array
 				Value extends Array<infer U>
-					? Array<CamelCasedPropertiesDeep<U, Options>>
+					? Array<_CamelCasedPropertiesDeep<U, Options>>
 					: Value extends ReadonlyArray<infer U>
-						? ReadonlyArray<CamelCasedPropertiesDeep<U, Options>>
+						? ReadonlyArray<_CamelCasedPropertiesDeep<U, Options>>
 						: never;

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -23,7 +23,7 @@ const result: CamelCasedProperties<User> = {
 	userName: 'Tom',
 };
 
-const preserveConsecutiveUppercase: CamelCasedProperties<{ fooBAR: string }, {preserveConsecutiveUppercase: false}> = {
+const preserveConsecutiveUppercase: CamelCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: false}> = {
 	fooBar: 'string',
 };
 ```

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -22,6 +22,10 @@ const result: CamelCasedProperties<User> = {
 	userId: 1,
 	userName: 'Tom',
 };
+
+const preserveConsecutiveUppercase: CamelCasedProperties<{ fooBAR: string }, {preserveConsecutiveUppercase: false}> = {
+	fooBar: 'string',
+};
 ```
 
 @category Change case

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -11,13 +11,13 @@ expectType<() => {a: string}>(fooBar);
 declare const bar: CamelCasedPropertiesDeep<Set<{fooBar: string}>>;
 expectType<Set<{fooBar: string}>>(bar);
 
-type bazBizDeep = {fooBAR: number; baz: {fooBAR: number; BARFoo: string}};
+type bazBizDeep = {fooBAR: number; baz: {fooBAR: Array<{BARFoo: string}>}};
 
 declare const baz: CamelCasedPropertiesDeep<bazBizDeep>;
-expectType<{fooBAR: number; baz: {fooBAR: number; bARFoo: string}}>(baz);
+expectType<{fooBAR: number; baz: {fooBAR: Array<{bARFoo: string}>}}>(baz);
 
 declare const biz: CamelCasedPropertiesDeep<bazBizDeep, {preserveConsecutiveUppercase: false}>;
-expectType<{fooBar: number; baz: {fooBar: number; barFoo: string}}>(biz);
+expectType<{fooBar: number; baz: {fooBar: Array<{barFoo: string}>}}>(biz);
 
 declare const tuple: CamelCasedPropertiesDeep<{tuple: [number, string, {D: string}]}>;
 expectType<{tuple: [number, string, {d: string}]}>(tuple);


### PR DESCRIPTION
Before this change, properties in nested array objects would not respect the `preserveConsecutiveUppercase` option.

![Screenshot 2025-03-04 at 11 49 11 AM](https://github.com/user-attachments/assets/9e459cfb-4a57-478f-95ac-644b12570f16)

```
test-d/camel-cased-properties-deep.ts:20:70 - error TS2345: Argument of type '{ fooBar: number; baz: { fooBar: { bARFoo: string; }[]; }; }' is not assignable to parameter of type '{ fooBar: number; baz: { fooBar: { barFoo: string; }[]; }; }'.
  The types of 'baz.fooBar' are incompatible between these types.
    Type '{ bARFoo: string; }[]' is not assignable to type '{ barFoo: string; }[]'.
      Property 'barFoo' is missing in type '{ bARFoo: string; }' but required in type '{ barFoo: string; }'.

20 expectType<{fooBar: number; baz: {fooBar: Array<{barFoo: string}>}}>(biz);
                                                                        ~~~

  test-d/camel-cased-properties-deep.ts:20:50
    20 expectType<{fooBar: number; baz: {fooBar: Array<{barFoo: string}>}}>(biz);
                                                        ~~~~~~
    'barFoo' is declared here.


Found 1 error in test-d/camel-cased-properties-deep.ts:20
```

***

Make sure `CamelCaseOptions` are always passed in when using `CamelCasedPropertiesDeep`, including when changing the case of nested array objects.

Update tests to account for this fix.

Add a couple examples to type definitions.