### PR TITLE
`DelimiterCase` - Pass `Options` generic to all related types (#1072)

### DIFF
--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -92,7 +92,7 @@ type DelimiterCasedPropertiesArrayDeep<
 		: Value extends readonly [infer U, ...infer V]
 			? readonly [_DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ..._DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 			// Leading spread array
-			: Value extends readonly [...infer U, infer V]
+			: Value extends [...infer U, infer V]
 				? [..._DelimiterCasedPropertiesDeep<U, Delimiter, Options>, _DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 				: Value extends readonly [...infer U, infer V]
 					? readonly [..._DelimiterCasedPropertiesDeep<U, Delimiter, Options>, _DelimiterCasedPropertiesDeep<V, Delimiter, Options>]

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -1,5 +1,5 @@
-import type {DelimiterCase} from './delimiter-case';
-import type {NonRecursiveType} from './internal';
+import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case';
+import type {ApplyDefaultOptions, NonRecursiveType} from './internal';
 import type {UnknownArray} from './unknown-array';
 import type {WordsOptions} from './words';
 
@@ -58,18 +58,24 @@ const splitOnNumbers: DelimiterCasedPropertiesDeep<{ line1: { line2: [{ line3: s
 export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
-	Options extends WordsOptions = {splitOnNumbers: false},
+	Options extends WordsOptions = {},
+> = _DelimiterCasedPropertiesDeep<Value, Delimiter, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+
+type _DelimiterCasedPropertiesDeep<
+	Value,
+	Delimiter extends string,
+	Options extends Required<WordsOptions>,
 > = Value extends NonRecursiveType
 	? Value
 	: Value extends UnknownArray
 		? DelimiterCasedPropertiesArrayDeep<Value, Delimiter, Options>
 		: Value extends Set<infer U>
-			? Set<DelimiterCasedPropertiesDeep<U, Delimiter, Options>> : {
+			? Set<_DelimiterCasedPropertiesDeep<U, Delimiter, Options>> : {
 				[K in keyof Value as DelimiterCase<
 				K,
 				Delimiter,
 				Options
-				>]: DelimiterCasedPropertiesDeep<Value[K], Delimiter, Options>;
+				>]: _DelimiterCasedPropertiesDeep<Value[K], Delimiter, Options>;
 			};
 
 // This is a copy of CamelCasedPropertiesArrayDeep (see: camel-cased-properties-deep.d.ts).
@@ -77,22 +83,22 @@ export type DelimiterCasedPropertiesDeep<
 type DelimiterCasedPropertiesArrayDeep<
 	Value extends UnknownArray,
 	Delimiter extends string,
-	Options extends WordsOptions = {splitOnNumbers: false},
+	Options extends Required<WordsOptions>,
 > = Value extends []
 	? []
 	// Tailing spread array
 	:	Value extends [infer U, ...infer V]
-		? [DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ...DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+		? [_DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ..._DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 		: Value extends readonly [infer U, ...infer V]
-			? readonly [DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ...DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+			? readonly [_DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ..._DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 			// Leading spread array
 			: Value extends readonly [...infer U, infer V]
-				? [...DelimiterCasedPropertiesDeep<U, Delimiter, Options>, DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+				? [..._DelimiterCasedPropertiesDeep<U, Delimiter, Options>, _DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 				: Value extends readonly [...infer U, infer V]
-					? readonly [...DelimiterCasedPropertiesDeep<U, Delimiter, Options>, DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+					? readonly [..._DelimiterCasedPropertiesDeep<U, Delimiter, Options>, _DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 					// Array
 					: Value extends Array<infer U>
-						? Array<DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
+						? Array<_DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
 						: Value extends ReadonlyArray<infer U>
-							? ReadonlyArray<DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
+							? ReadonlyArray<_DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
 							: never;

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -42,11 +42,13 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 	],
 };
 
-const splitOnNumbers: DelimiterCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, '-', {splitOnNumbers: true}> = {
+const splitOnNumbers: DelimiterCasedPropertiesDeep<{line1: { line2: [{ line3: string }] }}, '-', {splitOnNumbers: true}> = {
 	'line-1': {
-		'line-2': [{
-			'line-3': 'string',
-		}],
+		'line-2': [
+			{
+				'line-3': 'string',
+			},
+		],
 	},
 };
 ```
@@ -86,7 +88,7 @@ type DelimiterCasedPropertiesArrayDeep<
 	Options extends Required<WordsOptions>,
 > = Value extends []
 	? []
-	// Tailing spread array
+	// Trailing spread array
 	:	Value extends [infer U, ...infer V]
 		? [_DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ..._DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 		: Value extends readonly [infer U, ...infer V]

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -1,6 +1,7 @@
 import type {DelimiterCase} from './delimiter-case';
 import type {NonRecursiveType} from './internal';
 import type {UnknownArray} from './unknown-array';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to delimiter case recursively.
@@ -40,6 +41,14 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 		},
 	],
 };
+
+const splitOnNumbers: DelimiterCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, '-', {splitOnNumbers: true}> = {
+	'line-1': {
+		'line-2': [{
+			'line-3': 'string',
+		}],
+	},
+};
 ```
 
 @category Change case
@@ -49,36 +58,41 @@ const result: DelimiterCasedPropertiesDeep<UserWithFriends, '-'> = {
 export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = Value extends NonRecursiveType
 	? Value
 	: Value extends UnknownArray
-		? DelimiterCasedPropertiesArrayDeep<Value, Delimiter>
+		? DelimiterCasedPropertiesArrayDeep<Value, Delimiter, Options>
 		: Value extends Set<infer U>
-			? Set<DelimiterCasedPropertiesDeep<U, Delimiter>> : {
+			? Set<DelimiterCasedPropertiesDeep<U, Delimiter, Options>> : {
 				[K in keyof Value as DelimiterCase<
 				K,
-				Delimiter
-				>]: DelimiterCasedPropertiesDeep<Value[K], Delimiter>;
+				Delimiter,
+				Options
+				>]: DelimiterCasedPropertiesDeep<Value[K], Delimiter, Options>;
 			};
 
 // This is a copy of CamelCasedPropertiesArrayDeep (see: camel-cased-properties-deep.d.ts).
 // These types should be kept in sync.
-type DelimiterCasedPropertiesArrayDeep<Value extends UnknownArray, Delimiter extends string> =
-	Value extends []
-		? []
-		// Tailing spread array
-		:	Value extends [infer U, ...infer V]
-			? [DelimiterCasedPropertiesDeep<U, Delimiter>, ...DelimiterCasedPropertiesDeep<V, Delimiter>]
-			: Value extends readonly [infer U, ...infer V]
-				? readonly [DelimiterCasedPropertiesDeep<U, Delimiter>, ...DelimiterCasedPropertiesDeep<V, Delimiter>]
-				// Leading spread array
+type DelimiterCasedPropertiesArrayDeep<
+	Value extends UnknownArray,
+	Delimiter extends string,
+	Options extends WordsOptions = {splitOnNumbers: false},
+> = Value extends []
+	? []
+	// Tailing spread array
+	:	Value extends [infer U, ...infer V]
+		? [DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ...DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+		: Value extends readonly [infer U, ...infer V]
+			? readonly [DelimiterCasedPropertiesDeep<U, Delimiter, Options>, ...DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+			// Leading spread array
+			: Value extends readonly [...infer U, infer V]
+				? [...DelimiterCasedPropertiesDeep<U, Delimiter, Options>, DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
 				: Value extends readonly [...infer U, infer V]
-					? [...DelimiterCasedPropertiesDeep<U, Delimiter>, DelimiterCasedPropertiesDeep<V, Delimiter>]
-					: Value extends readonly [...infer U, infer V]
-						? readonly [...DelimiterCasedPropertiesDeep<U, Delimiter>, DelimiterCasedPropertiesDeep<V, Delimiter>]
-						// Array
-						: Value extends Array<infer U>
-							? Array<DelimiterCasedPropertiesDeep<U, Delimiter>>
-							: Value extends ReadonlyArray<infer U>
-								? ReadonlyArray<DelimiterCasedPropertiesDeep<U, Delimiter>>
-								: never;
+					? readonly [...DelimiterCasedPropertiesDeep<U, Delimiter, Options>, DelimiterCasedPropertiesDeep<V, Delimiter, Options>]
+					// Array
+					: Value extends Array<infer U>
+						? Array<DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
+						: Value extends ReadonlyArray<infer U>
+							? ReadonlyArray<DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
+							: never;

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -24,7 +24,7 @@ const result: DelimiterCasedProperties<User, '-'> = {
 	'user-name': 'Tom',
 };
 
-const splitOnNumbers: DelimiterCasedProperties<{ line1: string }, '-', {splitOnNumbers: true}> = {
+const splitOnNumbers: DelimiterCasedProperties<{line1: string}, '-', {splitOnNumbers: true}> = {
 	'line-1': 'string',
 };
 ```

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -1,4 +1,5 @@
-import type {DelimiterCase} from './delimiter-case';
+import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -35,9 +36,11 @@ const splitOnNumbers: DelimiterCasedProperties<{ line1: string }, '-', {splitOnN
 export type DelimiterCasedProperties<
 	Value,
 	Delimiter extends string,
-	Options extends WordsOptions = {splitOnNumbers: false},
+	Options extends WordsOptions = {},
 > = Value extends Function
 	? Value
 	: Value extends Array<infer U>
 		? Value
-		: {[K in keyof Value as DelimiterCase<K, Delimiter, Options>]: Value[K]};
+		: {[K in keyof Value as
+			DelimiterCase<K, Delimiter, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>
+			]: Value[K]};

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCase} from './delimiter-case';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to delimiter case but not recursively.
@@ -21,6 +22,10 @@ const result: DelimiterCasedProperties<User, '-'> = {
 	'user-id': 1,
 	'user-name': 'Tom',
 };
+
+const splitOnNumbers: DelimiterCasedProperties<{ line1: string }, '-', {splitOnNumbers: true}> = {
+	'line-1': 'string',
+};
 ```
 
 @category Change case
@@ -30,8 +35,9 @@ const result: DelimiterCasedProperties<User, '-'> = {
 export type DelimiterCasedProperties<
 	Value,
 	Delimiter extends string,
+	Options extends WordsOptions = {splitOnNumbers: false},
 > = Value extends Function
 	? Value
 	: Value extends Array<infer U>
 		? Value
-		: {[K in keyof Value as DelimiterCase<K, Delimiter>]: Value[K]};
+		: {[K in keyof Value as DelimiterCase<K, Delimiter, Options>]: Value[K]};

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -1,4 +1,6 @@
+import type {DefaultDelimiterCaseOptions} from './delimiter-case';
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -55,5 +57,5 @@ const splitOnNumbers: KebabCasedPropertiesDeep<{ line1: { line2: [{ line3: strin
 */
 export type KebabCasedPropertiesDeep<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCasedPropertiesDeep<Value, '-', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCasedPropertiesDeep<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -42,11 +42,13 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 
-const splitOnNumbers: KebabCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
+const splitOnNumbers: KebabCasedPropertiesDeep<{line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
 	'line-1': {
-		'line-2': [{
-			'line-3': 'string',
-		}],
+		'line-2': [
+			{
+				'line-3': 'string',
+			},
+		],
 	},
 };
 ```

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to kebab case recursively.
@@ -38,10 +39,21 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
+const splitOnNumbers: KebabCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
+	'line-1': {
+		'line-2': [{
+			'line-3': 'string',
+		}],
+	},
+};
 ```
 
 @category Change case
 @category Template literal
 @category Object
 */
-export type KebabCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '-'>;
+export type KebabCasedPropertiesDeep<
+	Value,
+	Options extends WordsOptions = {splitOnNumbers: false},
+> = DelimiterCasedPropertiesDeep<Value, '-', Options>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCasedProperties} from './delimiter-cased-properties';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to kebab case but not recursively.
@@ -21,10 +22,17 @@ const result: KebabCasedProperties<User> = {
 	'user-id': 1,
 	'user-name': 'Tom',
 };
+
+const splitOnNumbers: KebabCasedProperties<{ line1: string }, {splitOnNumbers: true}> = {
+	'line-1': 'string',
+};
 ```
 
 @category Change case
 @category Template literal
 @category Object
 */
-export type KebabCasedProperties<Value> = DelimiterCasedProperties<Value, '-'>;
+export type KebabCasedProperties<
+	Value,
+	Options extends WordsOptions = {splitOnNumbers: false},
+> = DelimiterCasedProperties<Value, '-', Options>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -1,4 +1,6 @@
+import type {DefaultDelimiterCaseOptions} from './delimiter-case';
 import type {DelimiterCasedProperties} from './delimiter-cased-properties';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -34,5 +36,5 @@ const splitOnNumbers: KebabCasedProperties<{ line1: string }, {splitOnNumbers: t
 */
 export type KebabCasedProperties<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCasedProperties<Value, '-', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCasedProperties<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -25,7 +25,7 @@ const result: KebabCasedProperties<User> = {
 	'user-name': 'Tom',
 };
 
-const splitOnNumbers: KebabCasedProperties<{ line1: string }, {splitOnNumbers: true}> = {
+const splitOnNumbers: KebabCasedProperties<{line1: string}, {splitOnNumbers: true}> = {
 	'line-1': 'string',
 };
 ```

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -13,7 +13,8 @@ import type {SnakeCase} from 'type-fest';
 // Simple
 
 const someVariable: SnakeCase<'fooBar'> = 'foo_bar';
-const someVariableNoSplitOnNumbers: SnakeCase<'p2pNetwork', {splitOnNumbers: false}> = 'p2p_network';
+const noSplitOnNumbers: SnakeCase<'p2pNetwork'> = 'p2p_network';
+const splitOnNumbers: SnakeCase<'p2pNetwork', {splitOnNumbers: true}> = 'p_2_p_network';
 
 // Advanced
 

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to snake case recursively.
@@ -38,10 +39,21 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
+const splitOnNumbers: SnakeCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
+	line_1: {
+		line_2: [{
+			line_3: 'string',
+		}],
+	},
+};
 ```
 
 @category Change case
 @category Template literal
 @category Object
 */
-export type SnakeCasedPropertiesDeep<Value> = DelimiterCasedPropertiesDeep<Value, '_'>;
+export type SnakeCasedPropertiesDeep<
+	Value,
+	Options extends WordsOptions = {splitOnNumbers: false},
+> = DelimiterCasedPropertiesDeep<Value, '_', Options>;

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -42,11 +42,13 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 
-const splitOnNumbers: SnakeCasedPropertiesDeep<{ line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
+const splitOnNumbers: SnakeCasedPropertiesDeep<{line1: { line2: [{ line3: string }] }}, {splitOnNumbers: true}> = {
 	line_1: {
-		line_2: [{
-			line_3: 'string',
-		}],
+		line_2: [
+			{
+				line_3: 'string',
+			},
+		],
 	},
 };
 ```

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -1,4 +1,6 @@
+import type {DefaultDelimiterCaseOptions} from './delimiter-case';
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -55,5 +57,5 @@ const splitOnNumbers: SnakeCasedPropertiesDeep<{ line1: { line2: [{ line3: strin
 */
 export type SnakeCasedPropertiesDeep<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCasedPropertiesDeep<Value, '_', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCasedPropertiesDeep<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -25,7 +25,7 @@ const result: SnakeCasedProperties<User> = {
 	user_name: 'Tom',
 };
 
-const splitOnNumbers: SnakeCasedProperties<{ line1: string }, {splitOnNumbers: true}> = {
+const splitOnNumbers: SnakeCasedProperties<{line1: string}, {splitOnNumbers: true}> = {
 	'line_1': 'string',
 };
 ```

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -1,4 +1,6 @@
+import type {DefaultDelimiterCaseOptions} from './delimiter-case';
 import type {DelimiterCasedProperties} from './delimiter-cased-properties';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -34,5 +36,5 @@ const splitOnNumbers: SnakeCasedProperties<{ line1: string }, {splitOnNumbers: t
 */
 export type SnakeCasedProperties<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCasedProperties<Value, '_', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCasedProperties<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -1,4 +1,5 @@
 import type {DelimiterCasedProperties} from './delimiter-cased-properties';
+import type {WordsOptions} from './words';
 
 /**
 Convert object properties to snake case but not recursively.
@@ -21,10 +22,17 @@ const result: SnakeCasedProperties<User> = {
 	user_id: 1,
 	user_name: 'Tom',
 };
+
+const splitOnNumbers: SnakeCasedProperties<{ line1: string }, {splitOnNumbers: true}> = {
+	'line_1': 'string',
+};
 ```
 
 @category Change case
 @category Template literal
 @category Object
 */
-export type SnakeCasedProperties<Value> = DelimiterCasedProperties<Value, '_'>;
+export type SnakeCasedProperties<
+	Value,
+	Options extends WordsOptions = {splitOnNumbers: false},
+> = DelimiterCasedProperties<Value, '_', Options>;

--- a/test-d/delimiter-cased-properties-deep.ts
+++ b/test-d/delimiter-cased-properties-deep.ts
@@ -10,6 +10,9 @@ expectType<() => {a: string}>(fooBar);
 declare const bar: DelimiterCasedPropertiesDeep<Set<{fooBar: string}>, '-'>;
 expectType<Set<{'foo-bar': string}>>(bar);
 
+declare const withOptions: DelimiterCasedPropertiesDeep<Set<{helloWorld: {p2p: Array<{addressLine1: string}>}}>, '.', {splitOnNumbers: true}>;
+expectType<Set<{'hello.world': {'p.2.p': Array<{'address.line.1': string}>}}>>(withOptions);
+
 // Verify example
 type User = {
 	userId: number;

--- a/test-d/delimiter-cased-properties.ts
+++ b/test-d/delimiter-cased-properties.ts
@@ -10,6 +10,9 @@ expectType<Array<{helloWorld: string}>>(bar);
 declare const fooBar: DelimiterCasedProperties<() => {a: string}, '-'>;
 expectType<() => {a: string}>(fooBar);
 
+declare const withOptions: DelimiterCasedProperties<{helloWorld1: {fooBar: string}}, '.', {splitOnNumbers: true}>;
+expectType<{'hello.world.1': {fooBar: string}}>(withOptions);
+
 // Verify example
 type User = {
 	userId: number;

--- a/test-d/kebab-cased-properties-deep.ts
+++ b/test-d/kebab-cased-properties-deep.ts
@@ -1,11 +1,13 @@
 import {expectType} from 'tsd';
 import type {KebabCasedPropertiesDeep} from '../index';
 
-declare const foo: KebabCasedPropertiesDeep<{helloWorld: {fooBar: string}}>;
-expectType<{'hello-world': {'foo-bar': string}}>(foo);
+type FooBar = {helloWorld: {p2p: Array<{addressLine1: string}>}};
 
-declare const bar: KebabCasedPropertiesDeep<Set<{fooBar: string}>>;
-expectType<Set<{'foo-bar': string}>>(bar);
+declare const foo: KebabCasedPropertiesDeep<FooBar>;
+expectType<{'hello-world': {p2p: Array<{'address-line1': string}>}}>(foo);
+
+declare const bar: KebabCasedPropertiesDeep<FooBar, {splitOnNumbers: true}>;
+expectType<{'hello-world': {'p-2-p': Array<{'address-line-1': string}>}}>(bar);
 
 // Verify example
 type User = {

--- a/test-d/kebab-cased-properties.ts
+++ b/test-d/kebab-cased-properties.ts
@@ -1,8 +1,13 @@
 import {expectType} from 'tsd';
 import type {KebabCasedProperties} from '../index';
 
-declare const foo: KebabCasedProperties<{helloWorld: {fooBar: string}}>;
-expectType<{'hello-world': {fooBar: string}}>(foo);
+type Foobar = {helloWorld1: {fooBar: string}};
+
+declare const foo: KebabCasedProperties<Foobar>;
+expectType<{'hello-world1': {fooBar: string}}>(foo);
+
+declare const bar: KebabCasedProperties<Foobar, {splitOnNumbers: true}>;
+expectType<{'hello-world-1': {fooBar: string}}>(bar);
 
 // Verify example
 type User = {

--- a/test-d/snake-cased-properties-deep.ts
+++ b/test-d/snake-cased-properties-deep.ts
@@ -1,11 +1,13 @@
 import {expectType} from 'tsd';
 import type {SnakeCasedPropertiesDeep} from '../index';
 
-declare const foo: SnakeCasedPropertiesDeep<{helloWorld: {fooBar: string}}>;
-expectType<{hello_world: {foo_bar: string}}>(foo);
+type FooBar = {helloWorld: {p2p: Array<{addressLine1: string}>}};
 
-declare const bar: SnakeCasedPropertiesDeep<Set<{fooBar: string}>>;
-expectType<Set<{foo_bar: string}>>(bar);
+declare const foo: SnakeCasedPropertiesDeep<FooBar>;
+expectType<{hello_world: {p2p: Array<{address_line1: string}>}}>(foo);
+
+declare const bar: SnakeCasedPropertiesDeep<FooBar, {splitOnNumbers: true}>;
+expectType<{hello_world: {p_2_p: Array<{address_line_1: string}>}}>(bar);
 
 // Verify example
 type User = {

--- a/test-d/snake-cased-properties.ts
+++ b/test-d/snake-cased-properties.ts
@@ -1,8 +1,13 @@
 import {expectType} from 'tsd';
 import type {SnakeCasedProperties} from '../index';
 
-declare const foo: SnakeCasedProperties<{helloWorld: {fooBar: string}}>;
-expectType<{hello_world: {fooBar: string}}>(foo);
+type Foobar = {helloWorld1: {fooBar: string}};
+
+declare const foo: SnakeCasedProperties<Foobar>;
+expectType<{hello_world1: {fooBar: string}}>(foo);
+
+declare const bar: SnakeCasedProperties<Foobar, {splitOnNumbers: true}>;
+expectType<{hello_world_1: {fooBar: string}}>(bar);
 
 // Verify example
 type User = {


### PR DESCRIPTION
Closes https://github.com/sindresorhus/type-fest/issues/1072

Enable all types derived from or extending `DelimiterCase` to accept the `Options` generic.
- `DelimiterCasedProperties`
- `DelimiterCasedPropertiesDeep`
- `KebabCasedProperties`
- `KebabCasedPropertiesDeep`
- `SnakeCasedProperties`
- `SnakeCasedPropertiesDeep`