### PR TITLE
Refactor how options are handled for types

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -1,3 +1,4 @@
+import type {ApplyDefaultOptions} from './internal';
 import type {Words} from './words';
 
 /**
@@ -14,12 +15,16 @@ export type CamelCaseOptions = {
 	preserveConsecutiveUppercase?: boolean;
 };
 
+export type DefaultCamelCaseOptions = {
+	preserveConsecutiveUppercase: true;
+};
+
 /**
 Convert an array of words to camel-case.
 */
 type CamelCaseFromArray<
 	Words extends string[],
-	Options extends CamelCaseOptions,
+	Options extends Required<CamelCaseOptions>,
 	OutputString extends string = '',
 > = Words extends [
 	infer FirstWord extends string,
@@ -73,8 +78,11 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 @category Change case
 @category Template literal
 */
-export type CamelCase<Type, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Type extends string
+export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extends string
 	? string extends Type
 		? Type
-		: Uncapitalize<CamelCaseFromArray<Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type>, Options>>
+		: Uncapitalize<CamelCaseFromArray<
+		Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type>,
+		ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>
+		>>
 	: Type;

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -1,5 +1,5 @@
-import type {CamelCase, CamelCaseOptions} from './camel-case';
-import type {NonRecursiveType} from './internal';
+import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case';
+import type {ApplyDefaultOptions, NonRecursiveType} from './internal';
 import type {UnknownArray} from './unknown-array';
 
 /**
@@ -48,15 +48,20 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 */
 export type CamelCasedPropertiesDeep<
 	Value,
-	Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true},
+	Options extends CamelCaseOptions = {},
+> = _CamelCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+
+type _CamelCasedPropertiesDeep<
+	Value,
+	Options extends Required<CamelCaseOptions>,
 > = Value extends NonRecursiveType
 	? Value
 	: Value extends UnknownArray
 		? CamelCasedPropertiesArrayDeep<Value>
 		: Value extends Set<infer U>
-			? Set<CamelCasedPropertiesDeep<U, Options>>
+			? Set<_CamelCasedPropertiesDeep<U, Options>>
 			: {
-				[K in keyof Value as CamelCase<K, Options>]: CamelCasedPropertiesDeep<
+				[K in keyof Value as CamelCase<K, Options>]: _CamelCasedPropertiesDeep<
 				Value[K],
 				Options
 				>;

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -1,4 +1,5 @@
-import type {CamelCase, CamelCaseOptions} from './camel-case';
+import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case';
+import type {ApplyDefaultOptions} from './internal';
 
 /**
 Convert object properties to camel case but not recursively.
@@ -27,10 +28,12 @@ const result: CamelCasedProperties<User> = {
 @category Template literal
 @category Object
 */
-export type CamelCasedProperties<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Value extends Function
+export type CamelCasedProperties<Value, Options extends CamelCaseOptions = {}> = Value extends Function
 	? Value
 	: Value extends Array<infer U>
 		? Value
 		: {
-			[K in keyof Value as CamelCase<K, Options>]: Value[K];
+			[K in keyof Value as
+			CamelCase<K, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>
+			]: Value[K];
 		};

--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -3,7 +3,7 @@ import type {ConditionalExcept} from './conditional-except';
 import type {ConditionalSimplifyDeep} from './conditional-simplify';
 import type {UnknownRecord} from './unknown-record';
 import type {EmptyObject} from './empty-object';
-import type {IsPlainObject} from './internal';
+import type {ApplyDefaultOptions, IsPlainObject} from './internal';
 
 /**
 Used to mark properties that should be excluded.
@@ -31,6 +31,10 @@ export type ConditionalPickDeepOptions = {
 	@default 'extends'
 	*/
 	condition?: 'extends' | 'equality';
+};
+
+type DefaultConditionalPickDeepOptions = {
+	condition: 'extends';
 };
 
 /**
@@ -95,10 +99,20 @@ export type ConditionalPickDeep<
 	Type,
 	Condition,
 	Options extends ConditionalPickDeepOptions = {},
+> = _ConditionalPickDeep<
+Type,
+Condition,
+ApplyDefaultOptions<ConditionalPickDeepOptions, DefaultConditionalPickDeepOptions, Options>
+>;
+
+type _ConditionalPickDeep<
+	Type,
+	Condition,
+	Options extends Required<ConditionalPickDeepOptions>,
 > = ConditionalSimplifyDeep<ConditionalExcept<{
 	[Key in keyof Type]: AssertCondition<Type[Key], Condition, Options> extends true
 		? Type[Key]
 		: IsPlainObject<Type[Key]> extends true
-			? ConditionalPickDeep<Type[Key], Condition, Options>
+			? _ConditionalPickDeep<Type[Key], Condition, Options>
 			: typeof conditionalPickDeepSymbol;
 }, (typeof conditionalPickDeepSymbol | undefined) | EmptyObject>, never, UnknownRecord>;

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,5 +1,9 @@
+import type {ApplyDefaultOptions} from './internal';
 import type {IsStringLiteral} from './is-literal';
-import type {Words, WordsOptions} from './words';
+import type {Merge} from './merge';
+import type {DefaultWordsOptions, Words, WordsOptions} from './words';
+
+export type DefaultDelimiterCaseOptions = Merge<DefaultWordsOptions, {splitOnNumbers: false}>;
 
 /**
 Convert an array of words to delimiter case starting with a delimiter with input capitalization.
@@ -61,13 +65,12 @@ const rawCliOptions: OddlyCasedProperties<SomeOptions> = {
 export type DelimiterCase<
 	Value,
 	Delimiter extends string,
-	Options extends WordsOptions = {splitOnNumbers: false},
+	Options extends WordsOptions = {},
 > = Value extends string
 	? IsStringLiteral<Value> extends false
 		? Value
-		: Lowercase<
-		RemoveFirstLetter<
-		DelimiterCaseFromArray<Words<Value, Options>, Delimiter>
-		>
-		>
+		: Lowercase<RemoveFirstLetter<DelimiterCaseFromArray<
+		Words<Value, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>,
+		Delimiter
+		>>>
 	: Value;

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -1,3 +1,4 @@
+import type {ApplyDefaultOptions} from './internal';
 import type {IsEqual} from './is-equal';
 
 /**
@@ -38,6 +39,10 @@ type ExceptOptions = {
 	@default false
 	*/
 	requireExactProps?: boolean;
+};
+
+type DefaultExceptOptions = {
+	requireExactProps: false;
 };
 
 /**
@@ -93,7 +98,10 @@ type PostPayload = Except<UserData, 'email'>;
 
 @category Object
 */
-export type Except<ObjectType, KeysType extends keyof ObjectType, Options extends ExceptOptions = {requireExactProps: false}> = {
+export type Except<ObjectType, KeysType extends keyof ObjectType, Options extends ExceptOptions = {}> =
+	_Except<ObjectType, KeysType, ApplyDefaultOptions<ExceptOptions, DefaultExceptOptions, Options>>;
+
+type _Except<ObjectType, KeysType extends keyof ObjectType, Options extends Required<ExceptOptions>> = {
 	[KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];
 } & (Options['requireExactProps'] extends true
 	? Partial<Record<KeysType, never>>

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -1,4 +1,4 @@
-import type {StringDigit, ToString} from './internal';
+import type {ApplyDefaultOptions, StringDigit, ToString} from './internal';
 import type {LiteralStringUnion} from './literal-union';
 import type {Paths} from './paths';
 import type {Split} from './split';
@@ -15,10 +15,14 @@ type GetOptions = {
 	strict?: boolean;
 };
 
+type DefaultGetOptions = {
+	strict: true;
+};
+
 /**
 Like the `Get` type but receives an array of strings as a path parameter.
 */
-type GetWithPath<BaseType, Keys, Options extends GetOptions = {}> =
+type GetWithPath<BaseType, Keys, Options extends Required<GetOptions>> =
 	Keys extends readonly []
 		? BaseType
 		: Keys extends readonly [infer Head, ...infer Tail]
@@ -32,7 +36,7 @@ type GetWithPath<BaseType, Keys, Options extends GetOptions = {}> =
 /**
 Adds `undefined` to `Type` if `strict` is enabled.
 */
-type Strictify<Type, Options extends GetOptions> =
+type Strictify<Type, Options extends Required<GetOptions>> =
 	Options['strict'] extends false ? Type : (Type | undefined);
 
 /**
@@ -41,7 +45,7 @@ If `Options['strict']` is `true`, includes `undefined` in the returned type when
 Known limitations:
 - Does not include `undefined` in the type on object types with an index signature (for example, `{a: string; [key: string]: string}`).
 */
-type StrictPropertyOf<BaseType, Key extends keyof BaseType, Options extends GetOptions> =
+type StrictPropertyOf<BaseType, Key extends keyof BaseType, Options extends Required<GetOptions>> =
 	Record<string, any> extends BaseType
 		? string extends keyof BaseType
 			? Strictify<BaseType[Key], Options> // Record<string, any>
@@ -122,7 +126,7 @@ Note:
 - Returns `unknown` if `Key` is not a property of `BaseType`, since TypeScript uses structural typing, and it cannot be guaranteed that extra properties unknown to the type system will exist at runtime.
 - Returns `undefined` from nullish values, to match the behaviour of most deep-key libraries like `lodash`, `dot-prop`, etc.
 */
-type PropertyOf<BaseType, Key extends string, Options extends GetOptions = {}> =
+type PropertyOf<BaseType, Key extends string, Options extends Required<GetOptions>> =
 	BaseType extends null | undefined
 		? undefined
 		: Key extends keyof BaseType
@@ -206,5 +210,10 @@ export type Get<
 	Path extends
 	| readonly string[]
 	| LiteralStringUnion<ToString<Paths<BaseType, {bracketNotation: false; maxRecursionDepth: 2}> | Paths<BaseType, {bracketNotation: true; maxRecursionDepth: 2}>>>,
-	Options extends GetOptions = {}> =
-		GetWithPath<BaseType, Path extends string ? ToPath<Path> : Path, Options>;
+	Options extends GetOptions = {},
+> =
+	GetWithPath<
+	BaseType,
+	Path extends string ? ToPath<Path> : Path,
+	ApplyDefaultOptions<GetOptions, DefaultGetOptions, Options>
+	>;

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -228,5 +228,5 @@ export type ApplyDefaultOptions<
 		[Key in keyof SpecifiedOptions
 		as Key extends OptionalKeysOf<Options> ? undefined extends SpecifiedOptions[Key] ? never : Key : Key
 		]: SpecifiedOptions[Key]
-	}> & Required<Options>>
+	}> & Required<Options>> // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
 	>>;

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -165,7 +165,56 @@ export type ReadonlyKeysOfUnion<Union> = Union extends unknown ? keyof {
 } : never;
 
 /**
-Merge user specified options with default options.
+Merges user specified options with default options.
+
+@example
+```
+type PathsOptions = {maxRecursionDepth?: number; leavesOnly?: boolean};
+type DefaultPathsOptions = {maxRecursionDepth: 10; leavesOnly: false};
+type SpecifiedOptions = {leavesOnly: true};
+
+type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOptions>;
+//=> {maxRecursionDepth: 10; leavesOnly: true}
+```
+
+@example
+```
+// Complains if default values are not provided for optional options
+
+type PathsOptions = {maxRecursionDepth?: number; leavesOnly?: boolean};
+type DefaultPathsOptions = {maxRecursionDepth: 10};
+type SpecifiedOptions = {};
+
+type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOptions>;
+//                                              ~~~~~~~~~~~~~~~~~~~
+// Property 'leavesOnly' is missing in type 'DefaultPathsOptions' but required in type '{ maxRecursionDepth: number; leavesOnly: boolean; }'.
+```
+
+@example
+```
+// Complains if an option's default type does not conform to the expected type
+
+type PathsOptions = {maxRecursionDepth?: number; leavesOnly?: boolean};
+type DefaultPathsOptions = {maxRecursionDepth: 10; leavesOnly: 'no'};
+type SpecifiedOptions = {};
+
+type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOptions>;
+//                                              ~~~~~~~~~~~~~~~~~~~
+// Types of property 'leavesOnly' are incompatible. Type 'string' is not assignable to type 'boolean'.
+```
+
+@example
+```
+// Complains if an option's specified type does not conform to the expected type
+
+type PathsOptions = {maxRecursionDepth?: number; leavesOnly?: boolean};
+type DefaultPathsOptions = {maxRecursionDepth: 10; leavesOnly: false};
+type SpecifiedOptions = {leavesOnly: 'yes'};
+
+type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOptions>;
+//                                                                   ~~~~~~~~~~~~~~~~
+// Types of property 'leavesOnly' are incompatible. Type 'string' is not assignable to type 'boolean'.
+```
 */
 export type ApplyDefaultOptions<
 	Options extends object,

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -4,6 +4,8 @@ import type {IsEqual} from '../is-equal';
 import type {KeysOfUnion} from '../keys-of-union';
 import type {RequiredKeysOf} from '../required-keys-of';
 import type {Merge} from '../merge';
+import type {IfAny} from '../if-any';
+import type {IfNever} from '../if-never';
 import type {FilterDefinedKeys, FilterOptionalKeys} from './keys';
 import type {NonRecursiveType} from './type';
 import type {ToString} from './string';
@@ -170,6 +172,9 @@ export type ApplyDefaultOptions<
 	Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
 	SpecifiedOptions extends Options,
 > =
+	IfAny<SpecifiedOptions, Defaults,
+	IfNever<SpecifiedOptions, Defaults,
 	Simplify<Merge<Defaults, {
 		[Key in keyof SpecifiedOptions as undefined extends SpecifiedOptions[Key] ? never : Key]: SpecifiedOptions[Key]
-	}> & Required<Options>>;
+	}> & Required<Options>>
+	>>;

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -6,6 +6,7 @@ import type {RequiredKeysOf} from '../required-keys-of';
 import type {Merge} from '../merge';
 import type {IfAny} from '../if-any';
 import type {IfNever} from '../if-never';
+import type {OptionalKeysOf} from '../optional-keys-of';
 import type {FilterDefinedKeys, FilterOptionalKeys} from './keys';
 import type {NonRecursiveType} from './type';
 import type {ToString} from './string';
@@ -224,6 +225,8 @@ export type ApplyDefaultOptions<
 	IfAny<SpecifiedOptions, Defaults,
 	IfNever<SpecifiedOptions, Defaults,
 	Simplify<Merge<Defaults, {
-		[Key in keyof SpecifiedOptions as undefined extends SpecifiedOptions[Key] ? never : Key]: SpecifiedOptions[Key]
+		[Key in keyof SpecifiedOptions
+		as Key extends OptionalKeysOf<Options> ? undefined extends SpecifiedOptions[Key] ? never : Key : Key
+		]: SpecifiedOptions[Key]
 	}> & Required<Options>>
 	>>;

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -2,6 +2,8 @@ import type {Simplify} from '../simplify';
 import type {UnknownArray} from '../unknown-array';
 import type {IsEqual} from '../is-equal';
 import type {KeysOfUnion} from '../keys-of-union';
+import type {RequiredKeysOf} from '../required-keys-of';
+import type {Merge} from '../merge';
 import type {FilterDefinedKeys, FilterOptionalKeys} from './keys';
 import type {NonRecursiveType} from './type';
 import type {ToString} from './string';
@@ -159,3 +161,15 @@ type ReadonlyKeys = ReadonlyKeysOfUnion<User | Post>;
 export type ReadonlyKeysOfUnion<Union> = Union extends unknown ? keyof {
 	[Key in keyof Union as IsEqual<{[K in Key]: Union[Key]}, {readonly [K in Key]: Union[Key]}> extends true ? Key : never]: never
 } : never;
+
+/**
+Merge user specified options with default options.
+*/
+export type ApplyDefaultOptions<
+	Options extends object,
+	Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
+	SpecifiedOptions extends Options,
+> =
+	Simplify<Merge<Defaults, {
+		[Key in keyof SpecifiedOptions as undefined extends SpecifiedOptions[Key] ? never : Key]: SpecifiedOptions[Key]
+	}> & Required<Options>>;

--- a/source/is-tuple.d.ts
+++ b/source/is-tuple.d.ts
@@ -1,5 +1,6 @@
 import type {IfAny} from './if-any';
 import type {IfNever} from './if-never';
+import type {ApplyDefaultOptions} from './internal';
 import type {UnknownArray} from './unknown-array';
 
 /**
@@ -26,6 +27,10 @@ export type IsTupleOptions = {
 	```
 	*/
 	fixedLengthOnly?: boolean;
+};
+
+type DefaultIsTupleOptions = {
+	fixedLengthOnly: true;
 };
 
 /**
@@ -63,7 +68,13 @@ type RestItemsAllowed = IsTuple<[1, 2, ...number[]], {fixedLengthOnly: false}>;
 */
 export type IsTuple<
 	TArray extends UnknownArray,
-	Options extends IsTupleOptions = {fixedLengthOnly: true},
+	Options extends IsTupleOptions = {},
+> =
+	_IsTuple<TArray, ApplyDefaultOptions<IsTupleOptions, DefaultIsTupleOptions, Options>>;
+
+type _IsTuple<
+	TArray extends UnknownArray,
+	Options extends Required<IsTupleOptions>,
 > =
 	IfAny<TArray, boolean, IfNever<TArray, false,
 	TArray extends unknown // For distributing `TArray`

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -1,4 +1,5 @@
-import type {DelimiterCase} from './delimiter-case';
+import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -39,5 +40,5 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 */
 export type KebabCase<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCase<Value, '-', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCase<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,4 +1,4 @@
-import type {BuiltIns} from './internal';
+import type {ApplyDefaultOptions, BuiltIns} from './internal';
 
 /**
 @see {@link PartialDeep}
@@ -36,6 +36,11 @@ export type PartialDeepOptions = {
 	```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;
+};
+
+type DefaultPartialDeepOptions = {
+	recurseIntoArrays: false;
+	allowUndefinedInNonTupleArrays: true;
 };
 
 /**
@@ -87,7 +92,10 @@ const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 @category Set
 @category Map
 */
-export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends BuiltIns | (((...arguments_: any[]) => unknown)) | (new (...arguments_: any[]) => unknown)
+export type PartialDeep<T, Options extends PartialDeepOptions = {}> =
+	_PartialDeep<T, ApplyDefaultOptions<PartialDeepOptions, DefaultPartialDeepOptions, Options>>;
+
+type _PartialDeep<T, Options extends Required<PartialDeepOptions>> = T extends BuiltIns | (((...arguments_: any[]) => unknown)) | (new (...arguments_: any[]) => unknown)
 	? T
 	: T extends Map<infer KeyType, infer ValueType>
 		? PartialMapDeep<KeyType, ValueType, Options>
@@ -102,8 +110,8 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 							? Options['recurseIntoArrays'] extends true
 								? ItemType[] extends T // Test for arrays (non-tuples) specifically
 									? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
-										? ReadonlyArray<PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
-										: Array<PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										? ReadonlyArray<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										: Array<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
 									: PartialObjectDeep<T, Options> // Tuples behave properly
 								: T // If they don't opt into array testing, just use the original type
 							: PartialObjectDeep<T, Options>
@@ -112,26 +120,26 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 /**
 Same as `PartialDeep`, but accepts only `Map`s and as inputs. Internal helper for `PartialDeep`.
 */
-type PartialMapDeep<KeyType, ValueType, Options extends PartialDeepOptions> = {} & Map<PartialDeep<KeyType, Options>, PartialDeep<ValueType, Options>>;
+type PartialMapDeep<KeyType, ValueType, Options extends Required<PartialDeepOptions>> = {} & Map<_PartialDeep<KeyType, Options>, _PartialDeep<ValueType, Options>>;
 
 /**
 Same as `PartialDeep`, but accepts only `Set`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialSetDeep<T, Options extends PartialDeepOptions> = {} & Set<PartialDeep<T, Options>>;
+type PartialSetDeep<T, Options extends Required<PartialDeepOptions>> = {} & Set<_PartialDeep<T, Options>>;
 
 /**
 Same as `PartialDeep`, but accepts only `ReadonlyMap`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialReadonlyMapDeep<KeyType, ValueType, Options extends PartialDeepOptions> = {} & ReadonlyMap<PartialDeep<KeyType, Options>, PartialDeep<ValueType, Options>>;
+type PartialReadonlyMapDeep<KeyType, ValueType, Options extends Required<PartialDeepOptions>> = {} & ReadonlyMap<_PartialDeep<KeyType, Options>, _PartialDeep<ValueType, Options>>;
 
 /**
 Same as `PartialDeep`, but accepts only `ReadonlySet`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialReadonlySetDeep<T, Options extends PartialDeepOptions> = {} & ReadonlySet<PartialDeep<T, Options>>;
+type PartialReadonlySetDeep<T, Options extends Required<PartialDeepOptions>> = {} & ReadonlySet<_PartialDeep<T, Options>>;
 
 /**
 Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialObjectDeep<ObjectType extends object, Options extends PartialDeepOptions> = {
-	[KeyType in keyof ObjectType]?: PartialDeep<ObjectType[KeyType], Options>
+type PartialObjectDeep<ObjectType extends object, Options extends Required<PartialDeepOptions>> = {
+	[KeyType in keyof ObjectType]?: _PartialDeep<ObjectType[KeyType], Options>
 };

--- a/source/partial-on-undefined-deep.d.ts
+++ b/source/partial-on-undefined-deep.d.ts
@@ -1,5 +1,5 @@
 import type {IfUnknown} from './if-unknown';
-import type {BuiltIns, LiteralKeyOf} from './internal';
+import type {ApplyDefaultOptions, BuiltIns, LiteralKeyOf} from './internal';
 import type {Merge} from './merge';
 
 /**
@@ -12,6 +12,10 @@ export type PartialOnUndefinedDeepOptions = {
 	@default false
 	*/
 	readonly recurseIntoArrays?: boolean;
+};
+
+type DefaultPartialOnUndefinedDeepOptions = {
+	recurseIntoArrays: false;
 };
 
 /**
@@ -47,7 +51,10 @@ const testSettings: PartialOnUndefinedDeep<Settings> = {
 
 @category Object
 */
-export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOptions = {}> = T extends Record<any, any> | undefined
+export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOptions = {}> =
+	_PartialOnUndefinedDeep<T, ApplyDefaultOptions<PartialOnUndefinedDeepOptions, DefaultPartialOnUndefinedDeepOptions, Options>>;
+
+type _PartialOnUndefinedDeep<T, Options extends Required<PartialOnUndefinedDeepOptions>> = T extends Record<any, any> | undefined
 	? {[KeyType in keyof T as undefined extends T[KeyType] ? IfUnknown<T[KeyType], never, KeyType> : never]?: PartialOnUndefinedDeepValue<T[KeyType], Options>} extends infer U // Make a partial type with all value types accepting undefined (and set them optional)
 		? Merge<{[KeyType in keyof T as KeyType extends LiteralKeyOf<U> ? never : KeyType]: PartialOnUndefinedDeepValue<T[KeyType], Options>}, U> // Join all remaining keys not treated in U
 		: never // Should not happen
@@ -56,16 +63,16 @@ export type PartialOnUndefinedDeep<T, Options extends PartialOnUndefinedDeepOpti
 /**
 Utility type to get the value type by key and recursively call `PartialOnUndefinedDeep` to transform sub-objects.
 */
-type PartialOnUndefinedDeepValue<T, Options extends PartialOnUndefinedDeepOptions> = T extends BuiltIns | ((...arguments_: any[]) => unknown)
+type PartialOnUndefinedDeepValue<T, Options extends Required<PartialOnUndefinedDeepOptions>> = T extends BuiltIns | ((...arguments_: any[]) => unknown)
 	? T
 	: T extends ReadonlyArray<infer U> // Test if type is array or tuple
 		? Options['recurseIntoArrays'] extends true // Check if option is activated
 			? U[] extends T // Check if array not tuple
 				? readonly U[] extends T
-					? ReadonlyArray<PartialOnUndefinedDeep<U, Options>> // Readonly array treatment
-					: Array<PartialOnUndefinedDeep<U, Options>> // Mutable array treatment
-				: PartialOnUndefinedDeep<{[Key in keyof T]: PartialOnUndefinedDeep<T[Key], Options>}, Options> // Tuple treatment
+					? ReadonlyArray<_PartialOnUndefinedDeep<U, Options>> // Readonly array treatment
+					: Array<_PartialOnUndefinedDeep<U, Options>> // Mutable array treatment
+				: _PartialOnUndefinedDeep<{[Key in keyof T]: _PartialOnUndefinedDeep<T[Key], Options>}, Options> // Tuple treatment
 			: T
 		: T extends Record<any, any> | undefined
-			? PartialOnUndefinedDeep<T, Options>
+			? _PartialOnUndefinedDeep<T, Options>
 			: unknown;

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -1,4 +1,5 @@
-import type {CamelCase, CamelCaseOptions} from './camel-case';
+import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case';
+import type {ApplyDefaultOptions} from './internal';
 
 /**
 Converts a string literal to pascal-case.
@@ -33,6 +34,9 @@ const dbResult: CamelCasedProperties<ModelProps> = {
 @category Change case
 @category Template literal
 */
-export type PascalCase<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = CamelCase<Value, Options> extends string
+export type PascalCase<Value, Options extends CamelCaseOptions = {}> =
+	_PascalCase<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+
+type _PascalCase<Value, Options extends Required<CamelCaseOptions>> = CamelCase<Value, Options> extends string
 	? Capitalize<CamelCase<Value, Options>>
 	: CamelCase<Value, Options>;

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -1,4 +1,5 @@
-import type {CamelCaseOptions} from './camel-case';
+import type {CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {PascalCase} from './pascal-case';
 
 /**
@@ -45,11 +46,14 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 @category Template literal
 @category Object
 */
-export type PascalCasedPropertiesDeep<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Value extends Function | Date | RegExp
+export type PascalCasedPropertiesDeep<Value, Options extends CamelCaseOptions = {}> =
+	_PascalCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+
+type _PascalCasedPropertiesDeep<Value, Options extends Required<CamelCaseOptions>> = Value extends Function | Date | RegExp
 	? Value
 	: Value extends Array<infer U>
-		? Array<PascalCasedPropertiesDeep<U, Options>>
+		? Array<_PascalCasedPropertiesDeep<U, Options>>
 		: Value extends Set<infer U>
-			? Set<PascalCasedPropertiesDeep<U, Options>> : {
-				[K in keyof Value as PascalCase<K, Options>]: PascalCasedPropertiesDeep<Value[K], Options>;
+			? Set<_PascalCasedPropertiesDeep<U, Options>> : {
+				[K in keyof Value as PascalCase<K, Options>]: _PascalCasedPropertiesDeep<Value[K], Options>;
 			};

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -1,4 +1,5 @@
-import type {CamelCaseOptions} from './camel-case';
+import type {CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {PascalCase} from './pascal-case';
 
 /**
@@ -28,8 +29,8 @@ const result: PascalCasedProperties<User> = {
 @category Template literal
 @category Object
 */
-export type PascalCasedProperties<Value, Options extends CamelCaseOptions = {preserveConsecutiveUppercase: true}> = Value extends Function
+export type PascalCasedProperties<Value, Options extends CamelCaseOptions = {}> = Value extends Function
 	? Value
 	: Value extends Array<infer U>
 		? Value
-		: {[K in keyof Value as PascalCase<K, Options>]: Value[K]};
+		: {[K in keyof Value as PascalCase<K, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>]: Value[K]};

--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -1,4 +1,4 @@
-import type {StaticPartOfArray, VariablePartOfArray, NonRecursiveType, ToString, IsNumberLike} from './internal';
+import type {StaticPartOfArray, VariablePartOfArray, NonRecursiveType, ToString, IsNumberLike, ApplyDefaultOptions} from './internal';
 import type {EmptyObject} from './empty-object';
 import type {IsAny} from './is-any';
 import type {UnknownArray} from './unknown-array';
@@ -176,16 +176,7 @@ open('listB.1'); // TypeError. Because listB only has one element.
 @category Object
 @category Array
 */
-export type Paths<T, Options extends PathsOptions = {}> = _Paths<T, {
-	// Set default maxRecursionDepth to 10
-	maxRecursionDepth: Options['maxRecursionDepth'] extends number ? Options['maxRecursionDepth'] : DefaultPathsOptions['maxRecursionDepth'];
-	// Set default bracketNotation to false
-	bracketNotation: Options['bracketNotation'] extends boolean ? Options['bracketNotation'] : DefaultPathsOptions['bracketNotation'];
-	// Set default leavesOnly to false
-	leavesOnly: Options['leavesOnly'] extends boolean ? Options['leavesOnly'] : DefaultPathsOptions['leavesOnly'];
-	// Set default depth to number
-	depth: Options['depth'] extends number ? Options['depth'] : DefaultPathsOptions['depth'];
-}>;
+export type Paths<T, Options extends PathsOptions = {}> = _Paths<T, ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, Options>>;
 
 type _Paths<T, Options extends Required<PathsOptions>> =
 	T extends NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -1,5 +1,11 @@
+import type {ApplyDefaultOptions} from './internal';
+
 type ReplaceOptions = {
 	all?: boolean;
+};
+
+type DefaultReplaceOptions = {
+	all: false;
 };
 
 /**
@@ -60,13 +66,13 @@ export type Replace<
 	Search extends string,
 	Replacement extends string,
 	Options extends ReplaceOptions = {},
-> = _Replace<Input, Search, Replacement, Options>;
+> = _Replace<Input, Search, Replacement, ApplyDefaultOptions<ReplaceOptions, DefaultReplaceOptions, Options>>;
 
 type _Replace<
 	Input extends string,
 	Search extends string,
 	Replacement extends string,
-	Options extends ReplaceOptions,
+	Options extends Required<ReplaceOptions>,
 	Accumulator extends string = '',
 > = Search extends string // For distributing `Search`
 	? Replacement extends string // For distributing `Replacement`

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -1,3 +1,5 @@
+import type {DefaultDelimiterCaseOptions} from './delimiter-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {SnakeCase} from './snake-case';
 import type {WordsOptions} from './words';
 
@@ -20,5 +22,7 @@ const someVariableNoSplitOnNumbers: ScreamingSnakeCase<'p2pNetwork', {splitOnNum
  */
 export type ScreamingSnakeCase<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = Value extends string ? Uppercase<SnakeCase<Value, Options>> : Value;
+	Options extends WordsOptions = {},
+> = Value extends string
+	? Uppercase<SnakeCase<Value, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>>
+	: Value;

--- a/source/set-field-type.d.ts
+++ b/source/set-field-type.d.ts
@@ -1,3 +1,4 @@
+import type {ApplyDefaultOptions} from './internal';
 import type {Simplify} from './simplify';
 
 type SetFieldTypeOptions = {
@@ -9,6 +10,10 @@ type SetFieldTypeOptions = {
 	@default true
 	*/
 	preservePropertyModifiers?: boolean;
+};
+
+type DefaultSetFieldTypeOptions = {
+	preservePropertyModifiers: true;
 };
 
 /**
@@ -48,7 +53,10 @@ type MyModelApi = SetFieldType<MyModel, 'createdAt' | 'updatedAt', string, {pres
 
 @category Object
 */
-export type SetFieldType<BaseType, Keys extends keyof BaseType, NewType, Options extends SetFieldTypeOptions = {preservePropertyModifiers: true}> =
+export type SetFieldType<BaseType, Keys extends keyof BaseType, NewType, Options extends SetFieldTypeOptions = {}> =
+	_SetFieldType<BaseType, Keys, NewType, ApplyDefaultOptions<SetFieldTypeOptions, DefaultSetFieldTypeOptions, Options>>;
+
+type _SetFieldType<BaseType, Keys extends keyof BaseType, NewType, Options extends Required<SetFieldTypeOptions>> =
 	Simplify<{
 		[P in keyof BaseType]: P extends Keys ? NewType : BaseType[P];
 	} & (

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -1,4 +1,5 @@
-import type {DelimiterCase} from './delimiter-case';
+import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case';
+import type {ApplyDefaultOptions} from './internal';
 import type {WordsOptions} from './words';
 
 /**
@@ -39,5 +40,5 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 */
 export type SnakeCase<
 	Value,
-	Options extends WordsOptions = {splitOnNumbers: false},
-> = DelimiterCase<Value, '_', Options>;
+	Options extends WordsOptions = {},
+> = DelimiterCase<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -1,5 +1,5 @@
 import type {And} from './and';
-import type {Not} from './internal';
+import type {ApplyDefaultOptions, Not} from './internal';
 import type {IsStringLiteral} from './is-literal';
 import type {Or} from './or';
 
@@ -65,9 +65,8 @@ export type Split<
 	S extends string,
 	Delimiter extends string,
 	Options extends SplitOptions = {},
-> = SplitHelper<S, Delimiter, {
-	strictLiteralChecks: Options['strictLiteralChecks'] extends boolean ? Options['strictLiteralChecks'] : DefaultSplitOptions['strictLiteralChecks'];
-}>;
+> =
+	SplitHelper<S, Delimiter, ApplyDefaultOptions<SplitOptions, DefaultSplitOptions, Options>>;
 
 type SplitHelper<
 	S extends string,

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -1,4 +1,5 @@
 import type {
+	ApplyDefaultOptions,
 	IsLowerCase,
 	IsNumeric,
 	IsUpperCase,
@@ -37,7 +38,7 @@ export type WordsOptions = {
 	splitOnNumbers?: boolean;
 };
 
-type DefaultOptions = {
+export type DefaultWordsOptions = {
 	splitOnNumbers: true;
 };
 
@@ -74,9 +75,8 @@ type Words5 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 @category Change case
 @category Template literal
 */
-export type Words<Sentence extends string, Options extends WordsOptions = {}> = WordsImplementation<Sentence, {
-	splitOnNumbers: Options['splitOnNumbers'] extends boolean ? Options['splitOnNumbers'] : DefaultOptions['splitOnNumbers'];
-}>;
+export type Words<Sentence extends string, Options extends WordsOptions = {}> =
+	WordsImplementation<Sentence, ApplyDefaultOptions<WordsOptions, DefaultWordsOptions, Options>>;
 
 type WordsImplementation<
 	Sentence extends string,

--- a/test-d/internal/apply-default-options.ts
+++ b/test-d/internal/apply-default-options.ts
@@ -36,6 +36,13 @@ expectType<{fixedLengthOnly: false; strict: true}>(requiredOptions);
 declare const undefinedsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth: undefined}>; // Possible when `exactOptionalPropertyTypes` is disabled
 expectType<DefaultPathsOptions>(undefinedsGetOverwritten);
 
+// Caveat: User specified `undefined` for optional properties with explicit undefined also gets overwritten
+declare const undefinedsGetOverwritten2: ApplyDefaultOptions<{recurseIntoArrays?: boolean | undefined}, {recurseIntoArrays: true}, {recurseIntoArrays: undefined}>;
+expectType<{recurseIntoArrays: true}>(undefinedsGetOverwritten2);
+
+declare const undefinedAsValidValue: ApplyDefaultOptions<{recurseIntoArrays: boolean | undefined}, {}, {recurseIntoArrays: undefined}>;
+expectType<{recurseIntoArrays: undefined}>(undefinedAsValidValue);
+
 declare const optionalOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth?: 5; bracketNotation?: true}>;
 expectType<DefaultPathsOptions>(optionalOptionsGetOverwritten);
 

--- a/test-d/internal/apply-default-options.ts
+++ b/test-d/internal/apply-default-options.ts
@@ -39,6 +39,12 @@ expectType<DefaultPathsOptions>(undefinedsGetOverwritten);
 declare const optionalOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth?: 5; bracketNotation?: true}>;
 expectType<DefaultPathsOptions>(optionalOptionsGetOverwritten);
 
+declare const neverAsOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, never>;
+expectType<DefaultPathsOptions>(neverAsOptionsGetOverwritten);
+
+declare const anyAsOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, any>;
+expectType<DefaultPathsOptions>(anyAsOptionsGetOverwritten);
+
 // @ts-expect-error - `Defaults` should be compatible with `Options`
 declare const defaultsShouldBeCompatible: ApplyDefaultOptions<{fixedLengthOnly?: boolean}, {fixedLengthOnly: 'no'}, {}>;
 

--- a/test-d/internal/apply-default-options.ts
+++ b/test-d/internal/apply-default-options.ts
@@ -1,0 +1,59 @@
+import {expectType} from 'tsd';
+import type {ApplyDefaultOptions} from '../../source/internal';
+
+type PathsOptions = {
+	maxRecursionDepth?: number;
+	bracketNotation?: boolean;
+	leavesOnly?: boolean;
+	depth?: number;
+};
+
+type DefaultPathsOptions = {
+	maxRecursionDepth: 10;
+	bracketNotation: false;
+	leavesOnly: false;
+	depth: number;
+};
+
+declare const noOptionsSpecified: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {}>;
+expectType<DefaultPathsOptions>(noOptionsSpecified);
+
+declare const someOptionsSpecified: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {leavesOnly: true; depth: 2}>;
+expectType<{maxRecursionDepth: 10; bracketNotation: false; leavesOnly: true; depth: 2}>(someOptionsSpecified);
+
+declare const someOptionsSpecified2: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth: 5}>;
+expectType<{maxRecursionDepth: 5; bracketNotation: false; leavesOnly: false; depth: number}>(someOptionsSpecified2);
+
+declare const allOptionsSpecified: ApplyDefaultOptions<
+PathsOptions, DefaultPathsOptions, {maxRecursionDepth: 5; bracketNotation: false; leavesOnly: false; depth: 1}
+>;
+expectType<{maxRecursionDepth: 5; bracketNotation: false; leavesOnly: false; depth: 1}>(allOptionsSpecified);
+
+declare const requiredOptions: ApplyDefaultOptions<{fixedLengthOnly?: boolean; strict: boolean}, {fixedLengthOnly: false}, {strict: true}>;
+expectType<{fixedLengthOnly: false; strict: true}>(requiredOptions);
+
+// @ts-ignore
+declare const undefinedsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth: undefined}>; // Possible when `exactOptionalPropertyTypes` is disabled
+expectType<DefaultPathsOptions>(undefinedsGetOverwritten);
+
+declare const optionalOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth?: 5; bracketNotation?: true}>;
+expectType<DefaultPathsOptions>(optionalOptionsGetOverwritten);
+
+// @ts-expect-error - `Defaults` should be compatible with `Options`
+declare const defaultsShouldBeCompatible: ApplyDefaultOptions<{fixedLengthOnly?: boolean}, {fixedLengthOnly: 'no'}, {}>;
+
+// @ts-expect-error - `SpecifiedOptions` should be compatible with `Options`
+declare const specifiedOptionsShouldBeCompatible: ApplyDefaultOptions<{fixedLengthOnly?: boolean}, {fixedLengthOnly: false}, {fixedLengthOnly: 'yes'}>;
+
+// @ts-expect-error - Optional options should have a default value
+declare const defaultForOptionalOptions: ApplyDefaultOptions<PathsOptions, Omit<DefaultPathsOptions, 'depth'>, {}>;
+
+// @ts-expect-error - Required options should be specified
+declare const requiredOptionsShouldBeSpecified: ApplyDefaultOptions<{fixedLengthOnly: boolean}, {}, {}>;
+
+// @ts-expect-error - Required options should not have a default value
+declare const noDefaultForRequiredOptions: ApplyDefaultOptions<{fixedLengthOnly: boolean}, {fixedLengthOnly: false}, {fixedLengthOnly: false}>;
+
+// The output of `ApplyDefaultOptions<SomeOption, ...>` should be assignable to `Required<SomeOption>`
+type SomeType<Options extends PathsOptions = {}> = _SomeType<ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, Options>>;
+type _SomeType<Options extends Required<PathsOptions>> = Options;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR streamlines how type options are handled. Currently, there’s no consistent approach—some types define default options inline as the default type argument, which only works well when there’s a single option. Others don’t specify any defaults at all, which isn’t ideal.

To address this, this PR introduces an internal type called `ApplyDefaultOptions`. It takes three parameters: the options schema, the default options, and the user-specified options and returns an object ensuring that **all options have defined values**, using defaults where necessary.

An example usage of this would be as follows:
https://github.com/sindresorhus/type-fest/blob/382eb878280afd4c4363a719e0f401ddc11e83ad/source/paths.d.ts#L179-L181
![github com_sindresorhus_type-fest_pull_1081_files (2)](https://github.com/user-attachments/assets/8336df56-75bd-4461-82d0-e42cee473151)




And the type also enforces the following checks:
https://github.com/sindresorhus/type-fest/blob/382eb878280afd4c4363a719e0f401ddc11e83ad/test-d/internal/apply-default-options.ts#L48-L65

<br>

**NOTE:**
1. I haven't updated `Get` to use `ApplyDefaultValue` because its option handling is a bit complex. It's better to address that in a separate PR.
2. `Schema` also couldn't be updated to use `ApplyDefaultValue` because `SchemaOptions` contains an optional property that explicitly allows `undefined` (`recurseIntoArrays?: boolean | undefined`). This becomes a problem because `ApplyDefaultValue` is designed to overwrite an _optional_ option if its user-specified type is `undefined`—which I believe is the ideal behaviour.
https://github.com/sindresorhus/type-fest/blob/f26ff0b766af8a7cd8bf55edb3ccf514fb38f97a/test-d/internal/apply-default-options.ts#L35-L37
However, this also means that explicitly defined `undefined` values also get overwritten, because I don't think there's a way to differentiate between something like `{ option?: string }` and `{ option?: string | undefined }`. Let me know your thoughts on this.
https://github.com/sindresorhus/type-fest/blob/f26ff0b766af8a7cd8bf55edb3ccf514fb38f97a/test-d/internal/apply-default-options.ts#L39-L41
IMO, we could just remove `undefined` from `recurseIntoArrays` option in `v5`.