### PR TITLE
Add support for PromiseLike in AsyncReturnType

### DIFF
--- a/source/async-return-type.d.ts
+++ b/source/async-return-type.d.ts
@@ -1,4 +1,4 @@
-type AsyncFunction = (...arguments_: any[]) => Promise<unknown>;
+type AsyncFunction = (...arguments_: any[]) => PromiseLike<unknown>;
 
 /**
 Unwrap the return type of a function that returns a `Promise`.

--- a/test-d/async-return-type.ts
+++ b/test-d/async-return-type.ts
@@ -11,3 +11,20 @@ asyncFunction().then(value => { // eslint-disable-line unicorn/prefer-top-level-
 	expectType<Value>(value);
 	expectNotAssignable<string>(value);
 });
+
+
+
+function asyncPromiseLike(): PromiseLike<number> {
+	return {
+		then(onfulfilled) {
+			return Promise.resolve(2).then(onfulfilled);
+		}
+	};
+}
+
+type ValuePromiseLike = AsyncReturnType<typeof asyncPromiseLike>;
+
+asyncPromiseLike().then(value => { // eslint-disable-line unicorn/prefer-top-level-await, @typescript-eslint/no-floating-promises
+	expectType<ValuePromiseLike>(value);
+	expectNotAssignable<string>(value);
+});

--- a/test-d/async-return-type.ts
+++ b/test-d/async-return-type.ts
@@ -12,14 +12,8 @@ asyncFunction().then(value => { // eslint-disable-line unicorn/prefer-top-level-
 	expectNotAssignable<string>(value);
 });
 
-
-
 function asyncPromiseLike(): PromiseLike<number> {
-	return {
-		then(onfulfilled) {
-			return Promise.resolve(2).then(onfulfilled);
-		}
-	};
+	return Promise.resolve(2);
 }
 
 type ValuePromiseLike = AsyncReturnType<typeof asyncPromiseLike>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Add support for PromiseLike:

```ts
function asyncPromiseLike(): PromiseLike<number> {
	return Promise.resolve(2);
}

type ValuePromiseLike = AsyncReturnType<typeof asyncPromiseLike>;
```
