### PR TITLE
`WritableKeysOf` / `ReadonlyKeysOf`: Fix behaviour with unions and optional properties

### DIFF
--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,4 +1,4 @@
-import type {IsEqual} from './is-equal';
+import type {WritableKeysOf} from './writable-keys-of';
 
 /**
 Extract all readonly keys from the given type.
@@ -24,6 +24,4 @@ const update1: UpdateResponse<User> = {
 
 @category Utilities
 */
-export type ReadonlyKeysOf<T> = NonNullable<{
-	[P in keyof T]: IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends true ? P : never
-}[keyof T]>;
+export type ReadonlyKeysOf<T> = T extends unknown ? Exclude<keyof T, WritableKeysOf<T>> : never;

--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,3 +1,4 @@
+import type {KeysOfUnion} from './keys-of-union';
 import type {WritableKeysOf} from './writable-keys-of';
 
 /**
@@ -24,4 +25,4 @@ const update1: UpdateResponse<User> = {
 
 @category Utilities
 */
-export type ReadonlyKeysOf<T> = T extends unknown ? Exclude<keyof T, WritableKeysOf<T>> : never;
+export type ReadonlyKeysOf<T> = Exclude<KeysOfUnion<T>, WritableKeysOf<T>>;

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -25,6 +25,6 @@ const update1: UpdateRequest<User> = {
 
 @category Utilities
 */
-export type WritableKeysOf<T> = NonNullable<{
-	[P in keyof T]: IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never
-}[keyof T]>;
+export type WritableKeysOf<T> = keyof {
+	[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never
+};

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -1,4 +1,5 @@
 import type {IsEqual} from './is-equal';
+import type {KeysOfUnion} from './keys-of-union';
 
 /**
 Extract all writable keys from the given type.
@@ -25,6 +26,6 @@ const update1: UpdateRequest<User> = {
 
 @category Utilities
 */
-export type WritableKeysOf<T> = keyof {
+export type WritableKeysOf<T> = KeysOfUnion<{
 	[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never
-};
+}>;

--- a/test-d/readonly-keys-of.ts
+++ b/test-d/readonly-keys-of.ts
@@ -34,6 +34,7 @@ expectType<'c'>({} as ReadonlyKeysOf<{a?: string; b: number; readonly c: boolean
 // Unions
 expectType<'b' | 'c'>({} as ReadonlyKeysOf<{a: string; readonly b: number} | {readonly c?: string; d?: number}>);
 
+// TODO: Uncomment when targeting TypeScript 5.3 or later.
 // Arrays
 // expectType<never>({} as Extract<ReadonlyKeysOf<[string, number, boolean]>, number | `${number}`>);
 // expectType<number | '0' | '1' | '2'>({} as Extract<ReadonlyKeysOf<readonly [string, number, boolean]>, number | `${number}`>);

--- a/test-d/readonly-keys-of.ts
+++ b/test-d/readonly-keys-of.ts
@@ -27,3 +27,15 @@ declare const test3: ReadonlyKeysOf3;
 expectType<'b'>(test1);
 expectType<'a' | 'b'>(test2);
 expectType<never>(test3);
+
+expectType<'a' | 'c'>({} as ReadonlyKeysOf<{readonly a?: string; b: number; readonly c: boolean}>);
+expectType<'c'>({} as ReadonlyKeysOf<{a?: string; b: number; readonly c: boolean}>);
+
+// Unions
+expectType<'b' | 'c'>({} as ReadonlyKeysOf<{a: string; readonly b: number} | {readonly c?: string; d?: number}>);
+
+// Arrays
+// expectType<never>({} as Extract<ReadonlyKeysOf<[string, number, boolean]>, number | `${number}`>);
+// expectType<number | '0' | '1' | '2'>({} as Extract<ReadonlyKeysOf<readonly [string, number, boolean]>, number | `${number}`>);
+// expectType<never>({} as Extract<ReadonlyKeysOf<string[]>, number | `${number}`>);
+// expectType<number>({} as Extract<ReadonlyKeysOf<readonly string[]>, number | `${number}`>);

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -27,3 +27,6 @@ declare const test3: WritableKeysOf3;
 expectType<'b'>(test1);
 expectType<'a' | 'b'>(test2);
 expectType<never>(test3);
+
+expectType<'a' | 'c'>({} as WritableKeysOf<{a?: string; readonly b: number; c: boolean}>);
+expectType<'c'>({} as WritableKeysOf<{readonly a?: string; readonly b: number; c: boolean}>);

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -31,6 +31,9 @@ expectType<never>(test3);
 expectType<'a' | 'c'>({} as WritableKeysOf<{a?: string; readonly b: number; c: boolean}>);
 expectType<'c'>({} as WritableKeysOf<{readonly a?: string; readonly b: number; c: boolean}>);
 
+// Unions
+expectType<'b' | 'c'>({} as WritableKeysOf<{readonly a: string; b: number} | {c?: string; readonly d?: number}>);
+
 // Arrays
 // expectType<number | '0' | '1' | '2'>({} as Extract<WritableKeysOf<[string, number, boolean]>, number | `${number}`>);
 // expectType<never>({} as Extract<WritableKeysOf<readonly [string, number, boolean]>, number | `${number}`>);

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -34,6 +34,7 @@ expectType<'c'>({} as WritableKeysOf<{readonly a?: string; readonly b: number; c
 // Unions
 expectType<'b' | 'c'>({} as WritableKeysOf<{readonly a: string; b: number} | {c?: string; readonly d?: number}>);
 
+// TODO: Uncomment when targeting TypeScript 5.3 or later.
 // Arrays
 // expectType<number | '0' | '1' | '2'>({} as Extract<WritableKeysOf<[string, number, boolean]>, number | `${number}`>);
 // expectType<never>({} as Extract<WritableKeysOf<readonly [string, number, boolean]>, number | `${number}`>);

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -30,3 +30,9 @@ expectType<never>(test3);
 
 expectType<'a' | 'c'>({} as WritableKeysOf<{a?: string; readonly b: number; c: boolean}>);
 expectType<'c'>({} as WritableKeysOf<{readonly a?: string; readonly b: number; c: boolean}>);
+
+// Arrays
+// expectType<number | '0' | '1' | '2'>({} as Extract<WritableKeysOf<[string, number, boolean]>, number | `${number}`>);
+// expectType<never>({} as Extract<WritableKeysOf<readonly [string, number, boolean]>, number | `${number}`>);
+// expectType<number>({} as Extract<WritableKeysOf<string[]>, number | `${number}`>);
+// expectType<never>({} as Extract<WritableKeysOf<readonly string[]>, number | `${number}`>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1087

Looks like there's some issue in TS `v5.4` and later, because it works fine in `v5.3` and below ([playground link](https://tsplay.dev/w1vnKN)). Regardless, the updated implementation should work fine across all versions.

Also, fixes behaviour with unions.

<br />

The updated implementation also improves behaviour with arrays:
```ts
type CurrentBehaviour = WritableKeysOf<[string, number]>;
//   ^? type CurrentBehaviour = 2 | "0" | "1" | (() => ArrayIterator<"0" | "1">) | {
//          [x: number]: boolean | undefined;
//          length?: boolean | undefined;
//          toString?: boolean | undefined;
//          toLocaleString?: boolean | undefined;
//          ... 28 more ...;
//          readonly [Symbol.unscopables]?: boolean | undefined;
//      } | ... 28 more ... | ((searchElement: "0" | "1", fromIndex?: number) => boolean)

type UpdatedBehaviour = WritableKeysOf<[string, number]>;
//   ^? type T = number | typeof Symbol.iterator | "0" | "1" | "length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | ... 26 more ... | "with"
```

However, I had to comment out the array cases because looks like there's some issue with `readonly` arrays in `v5.1` and `v5.2`.

In `v5.1` and `v5.2`, the `number` key loses it's `readonly` modifier while mapping, causing `WritableKeys<readonly [string]>` to incorrectly include `number` in its result.

```ts
type Test<T> = {
	[P in keyof T as number extends P ? P : never]: {[Q in P]: T[P]}
};

type T1 = Test<readonly [string]>;
//   ^? type T1 = {
//          [x: number]: {
//              [x: number]: string;
//          };
//      }
```

In `v5.3` and higher, the `number` key correctly preserves it's `readonly` modifier while mapping, so `WritableKeys<readonly [string]>` no longer has `number` in it's result.
```ts
type Test<T> = {
	[P in keyof T as number extends P ? P : never]: {[Q in P]: T[P]}
};

type T1 = Test<readonly [string]>;
//   ^? type T1 = {
//          readonly [x: number]: {
//              readonly [x: number]: string;
//          };
//      }
```

We'll probably have to figure out a way in which we can run certain test cases only for certain specific versions.