### PR TITLE
`OptionalKeysOf` / `RequiredKeysOf`: Fix instantiations with unions and arrays

### DIFF
--- a/source/optional-keys-of.d.ts
+++ b/source/optional-keys-of.d.ts
@@ -1,3 +1,5 @@
+import type {KeysOfUnion} from './keys-of-union';
+
 /**
 Extract all optional keys from the given type.
 
@@ -31,8 +33,6 @@ const update2: UpdateOperation<User> = {
 
 @category Utilities
 */
-export type OptionalKeysOf<BaseType extends object> = Exclude<{
-	[Key in keyof BaseType]: BaseType extends Record<Key, BaseType[Key]>
-		? never
-		: Key
-}[keyof BaseType], undefined>;
+export type OptionalKeysOf<BaseType extends object> = KeysOfUnion<{
+	[Key in keyof BaseType as BaseType extends Record<Key, BaseType[Key]> ? never : Key]: never
+}>;

--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,4 +1,3 @@
-import type {KeysOfUnion} from './keys-of-union';
 import type {WritableKeysOf} from './writable-keys-of';
 
 /**
@@ -25,4 +24,7 @@ const update1: UpdateResponse<User> = {
 
 @category Utilities
 */
-export type ReadonlyKeysOf<T> = Exclude<KeysOfUnion<T>, WritableKeysOf<T>>;
+export type ReadonlyKeysOf<T> =
+	T extends unknown // For distributing `T`
+		? Exclude<keyof T, WritableKeysOf<T>>
+		: never; // Should never happen

--- a/source/required-keys-of.d.ts
+++ b/source/required-keys-of.d.ts
@@ -1,3 +1,5 @@
+import type {OptionalKeysOf} from './optional-keys-of';
+
 /**
 Extract all required keys from the given type.
 
@@ -22,8 +24,7 @@ const validator2 = createValidation<User>('surname', value => value.length < 25)
 
 @category Utilities
 */
-export type RequiredKeysOf<BaseType extends object> = Exclude<{
-	[Key in keyof BaseType]: BaseType extends Record<Key, BaseType[Key]>
-		? Key
-		: never
-}[keyof BaseType], undefined>;
+export type RequiredKeysOf<BaseType extends object> =
+	BaseType extends unknown // For distributing `BaseType`
+		? Exclude<keyof BaseType, OptionalKeysOf<BaseType>>
+		: never; // Should never happen

--- a/test-d/optional-keys-of.ts
+++ b/test-d/optional-keys-of.ts
@@ -27,3 +27,15 @@ declare const test3: OptionalKeysOf3;
 expectType<'b'>(test1);
 expectType<'a' | 'b'>(test2);
 expectType<never>(test3);
+
+expectType<'a' | 'c'>({} as OptionalKeysOf<{readonly a?: string; readonly b: number; c?: boolean; d: string}>);
+
+// Unions
+expectType<'b' | 'c'>({} as OptionalKeysOf<{a: string; b?: number} | {readonly c?: string; readonly d: number}>);
+expectType<'a' | 'b'>({} as OptionalKeysOf<{a: string; b: number} | {a?: string; b?: number}>);
+
+// Arrays
+expectType<never>({} as OptionalKeysOf<[]>);
+expectType<never>({} as OptionalKeysOf<readonly [string, number, boolean]>);
+expectType<'1' | '2'>({} as OptionalKeysOf<[string, number?, boolean?]>);
+expectType<'0' | '1' | '2'>({} as OptionalKeysOf<[string?] | readonly [string, number?] | [string, number, boolean?]>);

--- a/test-d/readonly-keys-of.ts
+++ b/test-d/readonly-keys-of.ts
@@ -33,6 +33,7 @@ expectType<'c'>({} as ReadonlyKeysOf<{a?: string; b: number; readonly c: boolean
 
 // Unions
 expectType<'b' | 'c'>({} as ReadonlyKeysOf<{a: string; readonly b: number} | {readonly c?: string; d?: number}>);
+expectType<'a' | 'b'>({} as ReadonlyKeysOf<{a: string; b: number} | {readonly a: string; readonly b: number}>);
 
 // TODO: Uncomment when targeting TypeScript 5.3 or later.
 // Arrays

--- a/test-d/required-keys-of.ts
+++ b/test-d/required-keys-of.ts
@@ -27,3 +27,15 @@ declare const test3: RequiredKeysOf3;
 expectType<'a'>(test1);
 expectType<never>(test2);
 expectType<'a' | 'b'>(test3);
+
+expectType<'a' | 'c'>({} as RequiredKeysOf<{readonly a: string; readonly b?: number; c: boolean; d?: string}>);
+
+// Unions
+expectType<'b' | 'c'>({} as RequiredKeysOf<{a?: string; b: number} | {readonly c: string; readonly d?: number}>);
+expectType<'a' | 'b'>({} as RequiredKeysOf<{a?: string; b?: number} | {a: string; b: number}>);
+
+// Arrays
+expectType<keyof []>({} as RequiredKeysOf<[]>);
+expectType<keyof readonly [string, number, boolean]>({} as RequiredKeysOf<readonly [string, number, boolean]>);
+expectType<Exclude<keyof [string, number?, boolean?], '1' | '2'>>({} as RequiredKeysOf<[string, number?, boolean?]>);
+expectType<Exclude<keyof [string, number, boolean?], '2'>>({} as RequiredKeysOf<[string?] | readonly [string, number?] | [string, number, boolean?]>);

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -33,6 +33,7 @@ expectType<'c'>({} as WritableKeysOf<{readonly a?: string; readonly b: number; c
 
 // Unions
 expectType<'b' | 'c'>({} as WritableKeysOf<{readonly a: string; b: number} | {c?: string; readonly d?: number}>);
+expectType<'a' | 'b'>({} as WritableKeysOf<{readonly a: string; readonly b: number} | {a: string; b: number}>);
 
 // TODO: Uncomment when targeting TypeScript 5.3 or later.
 // Arrays


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes behaviour `OptionalKeysOf` / `RequiredKeysOf` with unions and also improves the behaviour with arrays.