### PR TITLE
`ArrayTail`: Add `preserveReadonly` option

### DIFF
--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -1,4 +1,38 @@
-import type {UnknownArrayOrTuple} from './internal';
+import type {ApplyDefaultOptions, IfArrayReadonly} from './internal';
+import type {UnknownArray} from './unknown-array';
+
+/**
+@see {@link ArrayTail}
+*/
+type ArrayTailOptions = {
+	/**
+	Return a readonly array if the input array is readonly.
+
+	@default false
+
+	@example
+	```
+	import type {ArrayTail} from 'type-fest';
+
+	type Example1 = ArrayTail<readonly [string, number, boolean], {preserveReadonly: true}>;
+	//=> readonly [number, boolean]
+
+	type Example2 = ArrayTail<[string, number, boolean], {preserveReadonly: true}>;
+	//=> [number, boolean]
+
+	type Example3 = ArrayTail<readonly [string, number, boolean], {preserveReadonly: false}>;
+	//=> [number, boolean]
+
+	type Example4 = ArrayTail<[string, number, boolean], {preserveReadonly: false}>;
+	//=> [number, boolean]
+	```
+	*/
+	preserveReadonly?: boolean;
+};
+
+type DefaultArrayTailOptions = {
+	preserveReadonly: false;
+};
 
 /**
 Extracts the type of an array or tuple minus the first element.
@@ -20,9 +54,22 @@ add3(4);
 //=> 7
 ```
 
+@see {@link ArrayTailOptions}
+
 @category Array
 */
-export type ArrayTail<TArray extends UnknownArrayOrTuple> = TArray extends readonly [unknown?, ...infer Tail]
+export type ArrayTail<TArray extends UnknownArray, Options extends ArrayTailOptions = {}> =
+	ApplyDefaultOptions<ArrayTailOptions, DefaultArrayTailOptions, Options> extends infer ResolvedOptions extends Required<ArrayTailOptions>
+		? TArray extends UnknownArray // For distributing `TArray`
+			? _ArrayTail<TArray> extends infer Result
+				? ResolvedOptions['preserveReadonly'] extends true
+					? IfArrayReadonly<TArray, Readonly<Result>, Result>
+					: Result
+				: never // Should never happen
+			: never // Should never happen
+		: never; // Should never happen
+
+type _ArrayTail<TArray extends UnknownArray> = TArray extends readonly [unknown?, ...infer Tail]
 	? keyof TArray & `${number}` extends never
 		? []
 		: Tail

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {ArrayTail} from '../index';
+import type {ArrayTail, UnknownArray} from '../index';
 
 declare const getArrayTail: <T extends readonly unknown[]>(array: T) => ArrayTail<T>;
 
@@ -30,3 +30,19 @@ expectType<['b'?]>([] as ArrayTail<['a'?, 'b'?]>);
 
 // Union of tuples
 expectType<[] | ['b']>([] as ArrayTail<[] | ['a', 'b']>);
+expectType<['y'?] | ['b', ...string[]] | []>([] as ArrayTail<readonly ['x'?, 'y'?] | ['a', 'b', ...string[]] | readonly string[]>);
+
+// `preserveReadonly` option
+type ReadonlyPreservingArrayTail<Type extends UnknownArray> = ArrayTail<Type, {preserveReadonly: true}>;
+
+expectType<[]>({} as ReadonlyPreservingArrayTail<[]>);
+expectType<readonly []>({} as ReadonlyPreservingArrayTail<readonly []>);
+expectType<[number?, ...string[]]>({} as ReadonlyPreservingArrayTail<[string?, number?, ...string[]]>);
+expectType<readonly [number?, ...string[]]>({} as ReadonlyPreservingArrayTail<readonly [string?, number?, ...string[]]>);
+
+expectType<[number] | readonly [boolean, string?]>({} as ReadonlyPreservingArrayTail<[string, number] | readonly [number, boolean, string?]>);
+expectType<readonly [number] | readonly []>({} as ReadonlyPreservingArrayTail<readonly [string, number] | readonly string[]>);
+expectType<[number?] | [boolean, string?] | []>({} as ReadonlyPreservingArrayTail<[string?, number?] | [number, boolean, string?] | [...string[], number]>);
+
+expectType<[]>({} as ReadonlyPreservingArrayTail<string[]>);
+expectType<readonly []>({} as ReadonlyPreservingArrayTail<readonly string[]>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Adds `preserveReadonly` option to `ArrayTail` type.