### PR TITLE
`ApplyDefaultOptions`: Improve behaviour when `strictNullChecks` is disabled

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -226,7 +226,11 @@ export type ApplyDefaultOptions<
 	IfNever<SpecifiedOptions, Defaults,
 	Simplify<Merge<Defaults, {
 		[Key in keyof SpecifiedOptions
-		as Key extends OptionalKeysOf<Options> ? undefined extends SpecifiedOptions[Key] ? never : Key : Key
+		as Key extends OptionalKeysOf<Options>
+			? Extract<SpecifiedOptions[Key], undefined> extends never
+				? Key
+				: never
+			: Key
 		]: SpecifiedOptions[Key]
 	}> & Required<Options>> // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
 	>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1095 

This PR ensures that the happy path for `ApplyDefaultOptions` works as expected even when `strictNullChecks` is disabled.

**Note**: Edge cases will still behave differently depending on whether `strictNullChecks` is enabled or not.