### PR TITLE
`OptionalKeysOf` / `WritableKeysOf`: Fix generic assignability with `keyof T`

### DIFF
--- a/source/optional-keys-of.d.ts
+++ b/source/optional-keys-of.d.ts
@@ -1,5 +1,3 @@
-import type {KeysOfUnion} from './keys-of-union';
-
 /**
 Extract all optional keys from the given type.
 
@@ -33,6 +31,9 @@ const update2: UpdateOperation<User> = {
 
 @category Utilities
 */
-export type OptionalKeysOf<BaseType extends object> = KeysOfUnion<{
-	[Key in keyof BaseType as BaseType extends Record<Key, BaseType[Key]> ? never : Key]: never
-}>;
+export type OptionalKeysOf<BaseType extends object> =
+	BaseType extends unknown // For distributing `BaseType`
+		? (keyof {
+			[Key in keyof BaseType as BaseType extends Record<Key, BaseType[Key]> ? never : Key]: never
+		}) & (keyof BaseType) // Intersect with `keyof BaseType` to ensure result of `OptionalKeysOf<BaseType>` is always assignable to `keyof BaseType`
+		: never; // Should never happen

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -1,5 +1,4 @@
 import type {IsEqual} from './is-equal';
-import type {KeysOfUnion} from './keys-of-union';
 
 /**
 Extract all writable keys from the given type.
@@ -26,6 +25,9 @@ const update1: UpdateRequest<User> = {
 
 @category Utilities
 */
-export type WritableKeysOf<T> = KeysOfUnion<{
-	[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never
-}>;
+export type WritableKeysOf<T> =
+	T extends unknown // For distributing `T`
+		? (keyof {
+			[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never
+		}) & keyof T // Intersect with `keyof T` to ensure result of `WritableKeysOf<T>` is always assignable to `keyof T`
+		: never; // Should never happen

--- a/test-d/optional-keys-of.ts
+++ b/test-d/optional-keys-of.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {OptionalKeysOf} from '../index';
+import type {OptionalKeysOf, UnknownRecord} from '../index';
 
 type TestType1 = {
 	a: string;
@@ -39,3 +39,48 @@ expectType<never>({} as OptionalKeysOf<[]>);
 expectType<never>({} as OptionalKeysOf<readonly [string, number, boolean]>);
 expectType<'1' | '2'>({} as OptionalKeysOf<[string, number?, boolean?]>);
 expectType<'0' | '1' | '2'>({} as OptionalKeysOf<[string?] | readonly [string, number?] | [string, number, boolean?]>);
+
+// `OptionalKeysOf<T>` should be assignable to `keyof T`
+type Assignability1<T, _K extends keyof T> = unknown;
+type Test1<T extends object> = Assignability1<T, OptionalKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `OptionalKeysOf<T>`
+type Assignability2<T extends object, _K extends OptionalKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test2<T extends object> = Assignability2<T, keyof T>;
+
+// `OptionalKeysOf<T>` should be assignable to `PropertyKey`
+type Assignability3<_T, _K extends PropertyKey> = unknown;
+type Test3<T extends object> = Assignability3<T, OptionalKeysOf<T>>;
+
+// `PropertyKey` should NOT be assignable to `OptionalKeysOf<T>`
+type Assignability4<T extends object, _K extends OptionalKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test4<T extends object> = Assignability4<T, PropertyKey>;
+
+// `OptionalKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `Record<string, unknown>`
+type Assignability5<T extends Record<string, unknown>, _K extends keyof T> = unknown;
+type Test5<T extends Record<string, unknown>> = Assignability5<T, OptionalKeysOf<T>>;
+
+// `OptionalKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `object`
+type Assignability6<T extends object, _K extends keyof T> = unknown;
+type Test6<T extends object> = Assignability6<T, OptionalKeysOf<T>>;
+
+// `OptionalKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `UnknownRecord`
+type Assignability7<T extends UnknownRecord, _K extends keyof T> = unknown;
+type Test7<T extends UnknownRecord> = Assignability7<T, OptionalKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `OptionalKeysOf<T>` even when `T` is constrained to `Record<string, unknown>`
+type Assignability8<T extends Record<string, unknown>, _K extends OptionalKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test8<T extends Record<string, unknown>> = Assignability8<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `OptionalKeysOf<T>` even when `T` is constrained to `object`
+type Assignability9<T extends object, _K extends OptionalKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test9<T extends object> = Assignability9<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `OptionalKeysOf<T>` even when `T` is constrained to `UnknownRecord`
+type Assignability10<T extends UnknownRecord, _K extends OptionalKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;

--- a/test-d/readonly-keys-of.ts
+++ b/test-d/readonly-keys-of.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {ReadonlyKeysOf} from '../index';
+import type {ReadonlyKeysOf, UnknownRecord} from '../index';
 
 type TestType1 = {
 	a: string;
@@ -41,3 +41,48 @@ expectType<'a' | 'b'>({} as ReadonlyKeysOf<{a: string; b: number} | {readonly a:
 // expectType<number | '0' | '1' | '2'>({} as Extract<ReadonlyKeysOf<readonly [string, number, boolean]>, number | `${number}`>);
 // expectType<never>({} as Extract<ReadonlyKeysOf<string[]>, number | `${number}`>);
 // expectType<number>({} as Extract<ReadonlyKeysOf<readonly string[]>, number | `${number}`>);
+
+// `ReadonlyKeysOf<T>` should be assignable to `keyof T`
+type Assignability1<T, _K extends keyof T> = unknown;
+type Test1<T extends object> = Assignability1<T, ReadonlyKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `ReadonlyKeysOf<T>`
+type Assignability2<T extends object, _K extends ReadonlyKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test2<T extends object> = Assignability2<T, keyof T>;
+
+// `ReadonlyKeysOf<T>` should be assignable to `PropertyKey`
+type Assignability3<_T, _K extends PropertyKey> = unknown;
+type Test3<T extends object> = Assignability3<T, ReadonlyKeysOf<T>>;
+
+// `PropertyKey` should NOT be assignable to `ReadonlyKeysOf<T>`
+type Assignability4<T extends object, _K extends ReadonlyKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test4<T extends object> = Assignability4<T, PropertyKey>;
+
+// `ReadonlyKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `Record<string, unknown>`
+type Assignability5<T extends Record<string, unknown>, _K extends keyof T> = unknown;
+type Test5<T extends Record<string, unknown>> = Assignability5<T, ReadonlyKeysOf<T>>;
+
+// `ReadonlyKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `object`
+type Assignability6<T extends object, _K extends keyof T> = unknown;
+type Test6<T extends object> = Assignability6<T, ReadonlyKeysOf<T>>;
+
+// `ReadonlyKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `UnknownRecord`
+type Assignability7<T extends UnknownRecord, _K extends keyof T> = unknown;
+type Test7<T extends UnknownRecord> = Assignability7<T, ReadonlyKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `ReadonlyKeysOf<T>` even when `T` is constrained to `Record<string, unknown>`
+type Assignability8<T extends Record<string, unknown>, _K extends ReadonlyKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test8<T extends Record<string, unknown>> = Assignability8<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `ReadonlyKeysOf<T>` even when `T` is constrained to `object`
+type Assignability9<T extends object, _K extends ReadonlyKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test9<T extends object> = Assignability9<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `ReadonlyKeysOf<T>` even when `T` is constrained to `UnknownRecord`
+type Assignability10<T extends UnknownRecord, _K extends ReadonlyKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;

--- a/test-d/required-keys-of.ts
+++ b/test-d/required-keys-of.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {RequiredKeysOf} from '../index';
+import type {RequiredKeysOf, UnknownRecord} from '../index';
 
 type TestType1 = {
 	a: string;
@@ -39,3 +39,48 @@ expectType<keyof []>({} as RequiredKeysOf<[]>);
 expectType<keyof readonly [string, number, boolean]>({} as RequiredKeysOf<readonly [string, number, boolean]>);
 expectType<Exclude<keyof [string, number?, boolean?], '1' | '2'>>({} as RequiredKeysOf<[string, number?, boolean?]>);
 expectType<Exclude<keyof [string, number, boolean?], '2'>>({} as RequiredKeysOf<[string?] | readonly [string, number?] | [string, number, boolean?]>);
+
+// `RequiredKeysOf<T>` should be assignable to `keyof T`
+type Assignability1<T, _K extends keyof T> = unknown;
+type Test1<T extends object> = Assignability1<T, RequiredKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `RequiredKeysOf<T>`
+type Assignability2<T extends object, _K extends RequiredKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test2<T extends object> = Assignability2<T, keyof T>;
+
+// `RequiredKeysOf<T>` should be assignable to `PropertyKey`
+type Assignability3<_T, _K extends PropertyKey> = unknown;
+type Test3<T extends object> = Assignability3<T, RequiredKeysOf<T>>;
+
+// `PropertyKey` should NOT be assignable to `RequiredKeysOf<T>`
+type Assignability4<T extends object, _K extends RequiredKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test4<T extends object> = Assignability4<T, PropertyKey>;
+
+// `RequiredKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `Record<string, unknown>`
+type Assignability5<T extends Record<string, unknown>, _K extends keyof T> = unknown;
+type Test5<T extends Record<string, unknown>> = Assignability5<T, RequiredKeysOf<T>>;
+
+// `RequiredKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `object`
+type Assignability6<T extends object, _K extends keyof T> = unknown;
+type Test6<T extends object> = Assignability6<T, RequiredKeysOf<T>>;
+
+// `RequiredKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `UnknownRecord`
+type Assignability7<T extends UnknownRecord, _K extends keyof T> = unknown;
+type Test7<T extends UnknownRecord> = Assignability7<T, RequiredKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `RequiredKeysOf<T>` even when `T` is constrained to `Record<string, unknown>`
+type Assignability8<T extends Record<string, unknown>, _K extends RequiredKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test8<T extends Record<string, unknown>> = Assignability8<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `RequiredKeysOf<T>` even when `T` is constrained to `object`
+type Assignability9<T extends object, _K extends RequiredKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test9<T extends object> = Assignability9<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `RequiredKeysOf<T>` even when `T` is constrained to `UnknownRecord`
+type Assignability10<T extends UnknownRecord, _K extends RequiredKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {WritableKeysOf} from '../index';
+import type {UnknownRecord, WritableKeysOf} from '../index';
 
 type TestType1 = {
 	readonly a: string;
@@ -41,3 +41,48 @@ expectType<'a' | 'b'>({} as WritableKeysOf<{readonly a: string; readonly b: numb
 // expectType<never>({} as Extract<WritableKeysOf<readonly [string, number, boolean]>, number | `${number}`>);
 // expectType<number>({} as Extract<WritableKeysOf<string[]>, number | `${number}`>);
 // expectType<never>({} as Extract<WritableKeysOf<readonly string[]>, number | `${number}`>);
+
+// `WritableKeysOf<T>` should be assignable to `keyof T`
+type Assignability1<T, _K extends keyof T> = unknown;
+type Test1<T extends object> = Assignability1<T, WritableKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `WritableKeysOf<T>`
+type Assignability2<T extends object, _K extends WritableKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test2<T extends object> = Assignability2<T, keyof T>;
+
+// `WritableKeysOf<T>` should be assignable to `PropertyKey`
+type Assignability3<_T, _K extends PropertyKey> = unknown;
+type Test3<T extends object> = Assignability3<T, WritableKeysOf<T>>;
+
+// `PropertyKey` should NOT be assignable to `WritableKeysOf<T>`
+type Assignability4<T extends object, _K extends WritableKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test4<T extends object> = Assignability4<T, PropertyKey>;
+
+// `WritableKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `Record<string, unknown>`
+type Assignability5<T extends Record<string, unknown>, _K extends keyof T> = unknown;
+type Test5<T extends Record<string, unknown>> = Assignability5<T, WritableKeysOf<T>>;
+
+// `WritableKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `object`
+type Assignability6<T extends object, _K extends keyof T> = unknown;
+type Test6<T extends object> = Assignability6<T, WritableKeysOf<T>>;
+
+// `WritableKeysOf<T>` should be assignable to `keyof T` even when `T` is constrained to `UnknownRecord`
+type Assignability7<T extends UnknownRecord, _K extends keyof T> = unknown;
+type Test7<T extends UnknownRecord> = Assignability7<T, WritableKeysOf<T>>;
+
+// `keyof T` should NOT be assignable to `WritableKeysOf<T>` even when `T` is constrained to `Record<string, unknown>`
+type Assignability8<T extends Record<string, unknown>, _K extends WritableKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test8<T extends Record<string, unknown>> = Assignability8<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `WritableKeysOf<T>` even when `T` is constrained to `object`
+type Assignability9<T extends object, _K extends WritableKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test9<T extends object> = Assignability9<T, keyof T>;
+
+// `keyof T` should NOT be assignable to `WritableKeysOf<T>` even when `T` is constrained to `UnknownRecord`
+type Assignability10<T extends UnknownRecord, _K extends WritableKeysOf<T>> = unknown;
+// @ts-expect-error
+type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1097 