### PR TITLE
Make `IsFloat<T>` handle numbers represented using exponential notation

### DIFF
--- a/source/is-float.d.ts
+++ b/source/is-float.d.ts
@@ -3,31 +3,41 @@ import type {Zero} from './numeric';
 /**
 Returns a boolean for whether the given number is a float, like `1.5` or `-1.5`.
 
-It returns `false` for `Infinity`.
-
 Use-case:
 - If you want to make a conditional branch based on the result of whether a number is a float or not.
 
 @example
 ```
-type Float = IsFloat<1.5>;
+type A = IsFloat<1.5>;
 //=> true
 
-type IntegerWithDecimal = IsInteger<1.0>;
+type B = IsFloat<-1.5>;
+//=> true
+
+type C = IsFloat<1e-7;
+//=> true
+
+type D = IsFloat<1.0>;
 //=> false
 
-type NegativeFloat = IsInteger<-1.5>;
-//=> true
+type E = IsFloat<PositiveInfinity>;
+//=> false
 
-type Infinity_ = IsInteger<Infinity>;
+type F = IsFloat<1.23+21>;
 //=> false
 ```
+
+@category Type Guard
+@category Numeric
 */
-export type IsFloat<T> =
-T extends number
-	? `${T}` extends `${infer _Sign extends '' | '-'}${number}.${infer Decimal extends number}`
-		? Decimal extends Zero
-			? false
-			: true
-		: false
+export type IsFloat<T> = T extends number
+	? `${T}` extends `${'' | '-'}${number}e${infer E extends '-' | '+'}${number}`
+		? E extends '-'
+			? true
+			: false
+		: `${T}` extends `${'' | '-'}${number}.${infer Decimal extends number}`
+			? Decimal extends Zero
+				? false
+				: true
+			: false
 	: false;

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -3,38 +3,37 @@ import type {IsFloat} from './is-float';
 import type {PositiveInfinity, NegativeInfinity} from './numeric';
 
 /**
-Returns a boolean for whether the given number is a integer, like `-5`, `1.0` or `100`.
-
-Like [`Number#IsInteger()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/IsInteger) but for types.
+Returns a boolean for whether the given number is an integer, like `-5`, `1.0` or `100`.
 
 Use-case:
-- If you want to make a conditional branch based on the result of whether a number is a intrger or not.
+- If you want to make a conditional branch based on the result of whether a number is an integer or not.
 
 @example
 ```
-type Integer = IsInteger<1>;
+type A = IsInteger<1>;
 //=> true
 
-type IntegerWithDecimal = IsInteger<1.0>;
+type B = IsInteger<1.0>;
 //=> true
 
-type NegativeInteger = IsInteger<-1>;
+type C = IsInteger<-1>;
 //=> true
 
-type Float = IsInteger<1.5>;
+type D = IsInteger<1.23+21>;
+//=> true
+
+type E = IsInteger<1.5>;
 //=> false
 
-// Supports non-decimal numbers
+type F = IsInteger<PositiveInfinity>
+//=> false
 
-type OctalInteger: IsInteger<0o10>;
-//=> true
-
-type BinaryInteger: IsInteger<0b10>;
-//=> true
-
-type HexadecimalInteger: IsInteger<0x10>;
-//=> true
+type G = IsInteger<1e-7>
+//=> false
 ```
+
+@category Type Guard
+@category Numeric
 */
 export type IsInteger<T> =
 T extends bigint

--- a/test-d/is-float.ts
+++ b/test-d/is-float.ts
@@ -1,17 +1,25 @@
 import {expectType} from 'tsd';
 import type {IsFloat, PositiveInfinity} from '../index';
 
-expectType<false>({} as IsFloat<0>);
-expectType<false>({} as IsFloat<1>);
-expectType<false>({} as IsFloat<1.0>); // eslint-disable-line unicorn/no-zero-fractions
-expectType<true>({} as IsFloat<1.5>);
-expectType<false>({} as IsFloat<-1>);
-expectType<false>({} as IsFloat<number>);
-expectType<false>({} as IsFloat<0o10>);
-expectType<false>({} as IsFloat<1n>);
-expectType<false>({} as IsFloat<0n>);
-expectType<false>({} as IsFloat<0b10>);
-expectType<false>({} as IsFloat<0x10>);
-expectType<false>({} as IsFloat<1e+100>);
-expectType<false>({} as IsFloat<PositiveInfinity>);
-expectType<false>({} as IsFloat<typeof Number.POSITIVE_INFINITY>);
+declare const x: unknown;
+
+expectType<false>(x as IsFloat<0>);
+expectType<false>(x as IsFloat<1>);
+expectType<false>(x as IsFloat<1.0>); // eslint-disable-line unicorn/no-zero-fractions
+expectType<false>(x as IsFloat<-1>);
+expectType<false>(x as IsFloat<number>);
+expectType<false>(x as IsFloat<0o10>);
+expectType<false>(x as IsFloat<1n>);
+expectType<false>(x as IsFloat<0n>);
+expectType<false>(x as IsFloat<0b10>);
+expectType<false>(x as IsFloat<0x10>);
+expectType<false>(x as IsFloat<1e+100>);
+expectType<false>(x as IsFloat<1.23e+21>);
+expectType<false>(x as IsFloat<-1.23e+21>);
+expectType<false>(x as IsFloat<'1.23'>);
+expectType<false>(x as IsFloat<PositiveInfinity>);
+
+expectType<true>(x as IsFloat<1.5>);
+expectType<true>(x as IsFloat<999_999_999_999_999.9>);
+expectType<true>(x as IsFloat<0.000_000_1>);
+expectType<true>(x as IsFloat<-1e-7>);

--- a/test-d/is-integer.ts
+++ b/test-d/is-integer.ts
@@ -1,17 +1,24 @@
 import {expectType} from 'tsd';
 import type {IsInteger, PositiveInfinity} from '../index';
 
-expectType<true>({} as IsInteger<0>);
-expectType<true>({} as IsInteger<1>);
-expectType<true>({} as IsInteger<1.0>); // eslint-disable-line unicorn/no-zero-fractions
-expectType<false>({} as IsInteger<1.5>);
-expectType<true>({} as IsInteger<-1>);
-expectType<false>({} as IsInteger<number>);
-expectType<true>({} as IsInteger<0o10>);
-expectType<true>({} as IsInteger<1n>);
-expectType<true>({} as IsInteger<0n>);
-expectType<true>({} as IsInteger<0b10>);
-expectType<true>({} as IsInteger<0x10>);
-expectType<true>({} as IsInteger<1e+100>);
-expectType<false>({} as IsInteger<PositiveInfinity>);
-expectType<false>({} as IsInteger<typeof Number.POSITIVE_INFINITY>);
+declare const x: unknown;
+
+expectType<false>(x as IsInteger<1.5>);
+expectType<false>(x as IsInteger<-1.5>);
+expectType<false>(x as IsInteger<number>);
+expectType<false>(x as IsInteger<PositiveInfinity>);
+expectType<false>(x as IsInteger<0.000_000_1>);
+expectType<false>(x as IsInteger<-1e-7>);
+
+expectType<true>(x as IsInteger<0>);
+expectType<true>(x as IsInteger<1>);
+expectType<true>(x as IsInteger<1.0>); // eslint-disable-line unicorn/no-zero-fractions
+expectType<true>(x as IsInteger<-1>);
+expectType<true>(x as IsInteger<0o10>);
+expectType<true>(x as IsInteger<1n>);
+expectType<true>(x as IsInteger<0n>);
+expectType<true>(x as IsInteger<0b10>);
+expectType<true>(x as IsInteger<0x10>);
+expectType<true>(x as IsInteger<1e+100>);
+expectType<true>(x as IsInteger<1.23e+21>);
+expectType<true>(x as IsInteger<-1.23e+21>);


### PR DESCRIPTION
NB. This also fixes `IsInteger<T>`, `Float<T>` and `Integer<T>` as well since they rely on `isFloat<T>`.