### PR TITLE
Add SetNonNullable alternative names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ type ShouldBeNever = IfAny<'not any', 'not never', 'never'>;
 - `SetValues` - See [`IterableElement`](source/iterable-element.d.ts)
 - `PickByTypes` - See [`ConditionalPick`](source/conditional-pick.d.ts)
 - `HomomorphicOmit` - See [`Except`](source/except.d.ts)
+- `DeepNonNullable`/`NonNullableDeep` - See [`SetNonNullable`](set-non-nullable.d.ts)
 
 ## Tips
 


### PR DESCRIPTION
I was migrating from other library and was looking for recursive `NonNullable`, which was called `DeepNonNullable`. Only through search in issues I found `SetNonNullable`.

Related #795