### PR TITLE
`PartialDeep`: Fix behaviour with functions containing properties

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -1,4 +1,5 @@
 import type {ApplyDefaultOptions, BuiltIns} from './internal';
+import type {IsNever} from './is-never';
 
 /**
 @see {@link PartialDeep}
@@ -95,27 +96,29 @@ const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
 export type PartialDeep<T, Options extends PartialDeepOptions = {}> =
 	_PartialDeep<T, ApplyDefaultOptions<PartialDeepOptions, DefaultPartialDeepOptions, Options>>;
 
-type _PartialDeep<T, Options extends Required<PartialDeepOptions>> = T extends BuiltIns | (((...arguments_: any[]) => unknown)) | (new (...arguments_: any[]) => unknown)
+type _PartialDeep<T, Options extends Required<PartialDeepOptions>> = T extends BuiltIns | ((new (...arguments_: any[]) => unknown))
 	? T
-	: T extends Map<infer KeyType, infer ValueType>
-		? PartialMapDeep<KeyType, ValueType, Options>
-		: T extends Set<infer ItemType>
-			? PartialSetDeep<ItemType, Options>
-			: T extends ReadonlyMap<infer KeyType, infer ValueType>
-				? PartialReadonlyMapDeep<KeyType, ValueType, Options>
-				: T extends ReadonlySet<infer ItemType>
-					? PartialReadonlySetDeep<ItemType, Options>
-					: T extends object
-						? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
-							? Options['recurseIntoArrays'] extends true
-								? ItemType[] extends T // Test for arrays (non-tuples) specifically
-									? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
-										? ReadonlyArray<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
-										: Array<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
-									: PartialObjectDeep<T, Options> // Tuples behave properly
-								: T // If they don't opt into array testing, just use the original type
-							: PartialObjectDeep<T, Options>
-						: unknown;
+	: IsNever<keyof T> extends true // For functions with no properties
+		? T
+		: T extends Map<infer KeyType, infer ValueType>
+			? PartialMapDeep<KeyType, ValueType, Options>
+			: T extends Set<infer ItemType>
+				? PartialSetDeep<ItemType, Options>
+				: T extends ReadonlyMap<infer KeyType, infer ValueType>
+					? PartialReadonlyMapDeep<KeyType, ValueType, Options>
+					: T extends ReadonlySet<infer ItemType>
+						? PartialReadonlySetDeep<ItemType, Options>
+						: T extends object
+							? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
+								? Options['recurseIntoArrays'] extends true
+									? ItemType[] extends T // Test for arrays (non-tuples) specifically
+										? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
+											? ReadonlyArray<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+											: Array<_PartialDeep<Options['allowUndefinedInNonTupleArrays'] extends false ? ItemType : ItemType | undefined, Options>>
+										: PartialObjectDeep<T, Options> // Tuples behave properly
+									: T // If they don't opt into array testing, just use the original type
+								: PartialObjectDeep<T, Options>
+							: unknown;
 
 /**
 Same as `PartialDeep`, but accepts only `Map`s and as inputs. Internal helper for `PartialDeep`.
@@ -140,6 +143,9 @@ type PartialReadonlySetDeep<T, Options extends Required<PartialDeepOptions>> = {
 /**
 Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`.
 */
-type PartialObjectDeep<ObjectType extends object, Options extends Required<PartialDeepOptions>> = {
-	[KeyType in keyof ObjectType]?: _PartialDeep<ObjectType[KeyType], Options>
-};
+type PartialObjectDeep<ObjectType extends object, Options extends Required<PartialDeepOptions>> =
+	(ObjectType extends (...arguments_: any) => unknown
+		? (...arguments_: Parameters<ObjectType>) => ReturnType<ObjectType>
+		: {}) & ({
+		[KeyType in keyof ObjectType]?: _PartialDeep<ObjectType[KeyType], Options>
+	});

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,5 +1,5 @@
 import {expectType, expectAssignable} from 'tsd';
-import type {PartialDeep} from '../index';
+import type {PartialDeep, Simplify} from '../index';
 
 class ClassA {
 	foo = 1;
@@ -110,3 +110,20 @@ expectAssignable<ReadonlyMap<string | undefined, string | undefined> | undefined
 expectAssignable<ReadonlySet<string | undefined> | undefined>(partialDeepNoRecurseIntoArraysBar.readonlySet);
 expectType<readonly string[] | undefined>(partialDeepNoRecurseIntoArraysBar.readonlyArray);
 expectType<readonly ['foo'] | undefined>(partialDeepNoRecurseIntoArraysBar.readonlyTuple);
+
+type FunctionWithProperties = {(a1: string, a2: number): boolean; p1: string; readonly p2: number};
+declare const functionWithProperties: PartialDeep<FunctionWithProperties>;
+expectType<boolean>(functionWithProperties('foo', 1));
+expectType<{p1?: string; readonly p2?: number}>({} as Simplify<typeof functionWithProperties>); // `Simplify` removes the call signature from `typeof functionWithProperties`
+
+type FunctionWithProperties2 = {(a1: boolean, ...a2: string[]): number; p1: {p2?: string; p3: {readonly p4?: boolean}}};
+declare const functionWithProperties2: PartialDeep<FunctionWithProperties2>;
+expectType<number>(functionWithProperties2(true, 'foo', 'bar'));
+expectType<{p1?: {p2?: string; p3?: {readonly p4?: boolean}}}>({} as Simplify<typeof functionWithProperties2>);
+
+type FunctionWithProperties3 = {(): void; p1: {p2?: string; p3: [{p4: number}, string]}};
+declare const functionWithProperties3: PartialDeep<FunctionWithProperties3, {recurseIntoArrays: true}>;
+expectType<void>(functionWithProperties3());
+expectType<{p1?: {p2?: string; p3?: [{p4?: number}?, string?]}}>({} as Simplify<typeof functionWithProperties3>);
+
+expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]}, {allowUndefinedInNonTupleArrays: false}>>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1107 