### PR TITLE
`CamelCasedPropertiesDeep` / `DelimiterCasedPropertiesDeep` / `KebabCasedPropertiesDeep` / `PascalCasedPropertiesDeep` / `SnakeCasedPropertiesDeep`: Fix behaviour when property value is `unknown`

### DIFF
--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -68,12 +68,11 @@ type _CamelCasedPropertiesDeep<
 		? CamelCasedPropertiesArrayDeep<Value, Options>
 		: Value extends Set<infer U>
 			? Set<_CamelCasedPropertiesDeep<U, Options>>
-			: {
-				[K in keyof Value as CamelCase<K, Options>]: _CamelCasedPropertiesDeep<
-				Value[K],
-				Options
-				>;
-			};
+			: Value extends object
+				? {
+					[K in keyof Value as CamelCase<K, Options>]: _CamelCasedPropertiesDeep<Value[K], Options>;
+				}
+				: Value;
 
 // This is a copy of DelimiterCasedPropertiesArrayDeep (see: delimiter-cased-properties-deep.d.ts).
 // These types should be kept in sync.

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -72,13 +72,13 @@ type _DelimiterCasedPropertiesDeep<
 	: Value extends UnknownArray
 		? DelimiterCasedPropertiesArrayDeep<Value, Delimiter, Options>
 		: Value extends Set<infer U>
-			? Set<_DelimiterCasedPropertiesDeep<U, Delimiter, Options>> : {
-				[K in keyof Value as DelimiterCase<
-				K,
-				Delimiter,
-				Options
-				>]: _DelimiterCasedPropertiesDeep<Value[K], Delimiter, Options>;
-			};
+			? Set<_DelimiterCasedPropertiesDeep<U, Delimiter, Options>>
+			: Value extends object
+				? {
+					[K in keyof Value as DelimiterCase<K, Delimiter, Options>]:
+					_DelimiterCasedPropertiesDeep<Value[K], Delimiter, Options>
+				}
+				: Value;
 
 // This is a copy of CamelCasedPropertiesArrayDeep (see: camel-cased-properties-deep.d.ts).
 // These types should be kept in sync.

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -54,6 +54,9 @@ type _PascalCasedPropertiesDeep<Value, Options extends Required<CamelCaseOptions
 	: Value extends Array<infer U>
 		? Array<_PascalCasedPropertiesDeep<U, Options>>
 		: Value extends Set<infer U>
-			? Set<_PascalCasedPropertiesDeep<U, Options>> : {
-				[K in keyof Value as PascalCase<K, Options>]: _PascalCasedPropertiesDeep<Value[K], Options>;
-			};
+			? Set<_PascalCasedPropertiesDeep<U, Options>>
+			: Value extends object
+				? {
+					[K in keyof Value as PascalCase<K, Options>]: _PascalCasedPropertiesDeep<Value[K], Options>;
+				}
+				: Value;

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -66,3 +66,9 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<CamelCasedPropertiesDeep<UserWithFriends>>(result);
+
+expectType<{fooBar: unknown}>({} as CamelCasedPropertiesDeep<{foo_bar: unknown}>);
+expectType<{fooBar: {barBaz: unknown}; biz: unknown}>({} as CamelCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);
+
+expectType<{fooBar: any}>({} as CamelCasedPropertiesDeep<{foo_bar: any}>);
+expectType<{fooBar: {barBaz: any}; biz: any}>({} as CamelCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);

--- a/test-d/delimiter-cased-properties-deep.ts
+++ b/test-d/delimiter-cased-properties-deep.ts
@@ -83,3 +83,9 @@ enum UserType {
 declare const enumTest: DelimiterCasedPropertiesDeep<{userType: UserType}, '-'>;
 expectType<{['user-type']: UserType}>(enumTest);
 enumTest['user-type'] = UserType.AdminUser;
+
+expectType<{'foo-bar': unknown}>({} as DelimiterCasedPropertiesDeep<{fooBar: unknown}, '-'>);
+expectType<{'foo_bar': {'bar_baz': unknown}; biz: unknown}>({} as DelimiterCasedPropertiesDeep<{fooBar: {barBaz: unknown}; biz: unknown}, '_'>);
+
+expectType<{'foo-bar': any}>({} as DelimiterCasedPropertiesDeep<{fooBar: any}, '-'>);
+expectType<{'foo_bar': {'bar_baz': any}; biz: any}>({} as DelimiterCasedPropertiesDeep<{fooBar: {barBaz: any}; biz: any}, '_'>);

--- a/test-d/kebab-cased-properties-deep.ts
+++ b/test-d/kebab-cased-properties-deep.ts
@@ -45,3 +45,9 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<KebabCasedPropertiesDeep<UserWithFriends>>(result);
+
+expectType<{'foo-bar': unknown}>({} as KebabCasedPropertiesDeep<{foo_bar: unknown}>);
+expectType<{'foo-bar': {'bar-baz': unknown}; biz: unknown}>({} as KebabCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);
+
+expectType<{'foo-bar': any}>({} as KebabCasedPropertiesDeep<{foo_bar: any}>);
+expectType<{'foo-bar': {'bar-baz': any}; biz: any}>({} as KebabCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);

--- a/test-d/pascal-cased-properties-deep.ts
+++ b/test-d/pascal-cased-properties-deep.ts
@@ -46,3 +46,9 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<PascalCasedPropertiesDeep<UserWithFriends>>(result);
+
+expectType<{'FooBar': unknown}>({} as PascalCasedPropertiesDeep<{foo_bar: unknown}>);
+expectType<{'FooBar': {'BarBaz': unknown}; Biz: unknown}>({} as PascalCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);
+
+expectType<{'FooBar': any}>({} as PascalCasedPropertiesDeep<{foo_bar: any}>);
+expectType<{'FooBar': {'BarBaz': any}; Biz: any}>({} as PascalCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);

--- a/test-d/snake-cased-properties-deep.ts
+++ b/test-d/snake-cased-properties-deep.ts
@@ -45,3 +45,9 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<SnakeCasedPropertiesDeep<UserWithFriends>>(result);
+
+expectType<{foo_bar: unknown}>({} as SnakeCasedPropertiesDeep<{fooBar: unknown}>);
+expectType<{foo_bar: {bar_baz: unknown}; biz: unknown}>({} as SnakeCasedPropertiesDeep<{fooBar: {barBaz: unknown}; biz: unknown}>);
+
+expectType<{foo_bar: any}>({} as SnakeCasedPropertiesDeep<{fooBar: any}>);
+expectType<{foo_bar: {bar_baz: any}; biz: any}>({} as SnakeCasedPropertiesDeep<{fooBar: {barBaz: any}; biz: any}>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes #1111 and similar issue in other types.