### PR TITLE
`RequireAllOrNone` / `RequireAtLeastOne` / `RequireExactlyOne` / `RequireOneOrNone`: Fix behaviour with `any` and `never`

### DIFF
--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -1,3 +1,4 @@
+import type {IsAny} from '../is-any';
 import type {IsNever} from '../is-never';
 import type {Primitive} from '../primitive';
 
@@ -111,3 +112,28 @@ type InternalIsUnion<T, U = T> =
 	? boolean extends Result ? true
 		: Result
 	: never; // Should never happen
+
+/**
+An if-else-like type that resolves depending on whether the given type is `any` or `never`.
+
+@example
+```
+// When `T` is a NOT `any` or `never` (like `string`) => Returns `IfNotAnyOrNever` branch
+type A = IfNotAnyOrNever<string, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+//=> 'VALID'
+
+// When `T` is `any` => Returns `IfAny` branch
+type B = IfNotAnyOrNever<any, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+//=> 'IS_ANY'
+
+// When `T` is `never` => Returns `IfNever` branch
+type C = IfNotAnyOrNever<never, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+//=> 'IS_NEVER'
+```
+*/
+export type IfNotAnyOrNever<T, IfNotAnyOrNever, IfAny = any, IfNever = never> =
+	IsAny<T> extends true
+		? IfAny
+		: IsNever<T> extends true
+			? IfNever
+			: IfNotAnyOrNever;

--- a/source/require-all-or-none.d.ts
+++ b/source/require-all-or-none.d.ts
@@ -1,4 +1,6 @@
-import type {RequireNone} from './internal';
+import type {IfAny} from './if-any';
+import type {IfNever} from './if-never';
+import type {IfNotAnyOrNever, RequireNone} from './internal';
 
 /**
 Requires all of the keys in the given object.
@@ -36,7 +38,14 @@ const responder2: RequireAllOrNone<Responder, 'text' | 'json'> = {
 
 @category Object
 */
-export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> = (
+export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
+	IfNotAnyOrNever<ObjectType,
+	IfNever<KeysType,
+	ObjectType,
+	_RequireAllOrNone<ObjectType, IfAny<KeysType, keyof ObjectType, KeysType>>
+	>>;
+
+type _RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType> = (
 	| RequireAll<ObjectType, KeysType>
 	| RequireNone<KeysType>
 ) & Omit<ObjectType, KeysType>; // The rest of the keys.

--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -1,4 +1,7 @@
 import type {Except} from './except';
+import type {IfAny} from './if-any';
+import type {IfNever} from './if-never';
+import type {IfNotAnyOrNever} from './internal';
 
 /**
 Create a type that requires at least one of the given keys. The remaining keys are kept as is.
@@ -24,6 +27,16 @@ const responder: RequireAtLeastOne<Responder, 'text' | 'json'> = {
 export type RequireAtLeastOne<
 	ObjectType,
 	KeysType extends keyof ObjectType = keyof ObjectType,
+> =
+	IfNotAnyOrNever<ObjectType,
+	IfNever<KeysType,
+	never,
+	_RequireAtLeastOne<ObjectType, IfAny<KeysType, keyof ObjectType, KeysType>>
+	>>;
+
+type _RequireAtLeastOne<
+	ObjectType,
+	KeysType extends keyof ObjectType,
 > = {
 	// For each `Key` in `KeysType` make a mapped type:
 	[Key in KeysType]-?: Required<Pick<ObjectType, Key>> & // 1. Make `Key`'s type required

--- a/source/require-exactly-one.d.ts
+++ b/source/require-exactly-one.d.ts
@@ -1,3 +1,7 @@
+import type {IfAny} from './if-any';
+import type {IfNever} from './if-never';
+import type {IfNotAnyOrNever} from './internal';
+
 /**
 Create a type that requires exactly one of the given keys and disallows more. The remaining keys are kept as is.
 
@@ -28,6 +32,13 @@ const responder: RequireExactlyOne<Responder, 'text' | 'json'> = {
 @category Object
 */
 export type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
+	IfNotAnyOrNever<ObjectType,
+	IfNever<KeysType,
+	never,
+	_RequireExactlyOne<ObjectType, IfAny<KeysType, keyof ObjectType, KeysType>>
+	>>;
+
+type _RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType> =
 	{[Key in KeysType]: (
 		Required<Pick<ObjectType, Key>> &
 		Partial<Record<Exclude<KeysType, Key>, never>>

--- a/source/require-one-or-none.d.ts
+++ b/source/require-one-or-none.d.ts
@@ -1,5 +1,7 @@
 import type {RequireExactlyOne} from './require-exactly-one';
-import type {RequireNone} from './internal';
+import type {IfNotAnyOrNever, RequireNone} from './internal';
+import type {IfNever} from './if-never';
+import type {IfAny} from './if-any';
 
 /**
 Create a type that requires exactly one of the given keys and disallows more, or none of the given keys. The remaining keys are kept as is.
@@ -31,7 +33,14 @@ const responder3: Responder = {
 
 @category Object
 */
-export type RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> = (
+export type RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
+	IfNotAnyOrNever<ObjectType,
+	IfNever<KeysType,
+	ObjectType,
+	_RequireOneOrNone<ObjectType, IfAny<KeysType, keyof ObjectType, KeysType>>
+	>>;
+
+type _RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType> = (
 	| RequireExactlyOne<ObjectType, KeysType>
 	| RequireNone<KeysType>
 ) & Omit<ObjectType, KeysType>; // Ignore unspecified keys.

--- a/test-d/internal/if-not-any-or-never.ts
+++ b/test-d/internal/if-not-any-or-never.ts
@@ -1,0 +1,12 @@
+import {expectType} from 'tsd';
+import type {IfNotAnyOrNever} from '../../source/internal';
+
+expectType<any>({} as IfNotAnyOrNever<any, string>);
+expectType<never>({} as IfNotAnyOrNever<never, string>);
+expectType<number>({} as IfNotAnyOrNever<any, string, number>);
+expectType<number>({} as IfNotAnyOrNever<any, string, number, boolean>);
+expectType<never>({} as IfNotAnyOrNever<never, string, number>);
+expectType<boolean>({} as IfNotAnyOrNever<never, string, number, boolean>);
+expectType<number>({} as IfNotAnyOrNever<string, number>);
+expectType<number>({} as IfNotAnyOrNever<string | number, number, boolean>);
+expectType<number>({} as IfNotAnyOrNever<object, number, boolean, string>);

--- a/test-d/require-all-or-none.ts
+++ b/test-d/require-all-or-none.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {RequireAllOrNone, Simplify} from '../index';
 
 type SystemMessages = {
@@ -80,3 +80,25 @@ function narrowingTest3(foo: Simplify<RequireAllOrNone<{a: string; b: string; c:
 
 	return '';
 }
+
+expectType<{a: number; b: string} | {a?: never; b?: never}>({} as Simplify<RequireAllOrNone<{a: number; b: string}>>); // `Simplify` is required for the assertion to pass
+expectType<{a: number; b: string} | {a?: never; b?: never}>({} as Simplify<RequireAllOrNone<{a: number; b: string}, any>>); // `Simplify` is required for the assertion to pass
+expectType<{a: number; b: string; c: boolean} | {a?: never; b?: never; c?: never}>(
+	{} as Simplify<RequireAllOrNone<{a: number; b: string; c: boolean}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b: string; c: boolean} | {a?: never; b?: never; c?: never}>(
+	{} as Simplify<RequireAllOrNone<{a: number; b: string; c: boolean}, any>>, // `Simplify` is required for the assertion to pass
+);
+
+expectType<{}>({} as RequireAllOrNone<{}>);
+expectType<{a: string; b: number}>({} as RequireAllOrNone<{a: string; b: number}, never>);
+
+expectType<any>({} as RequireAllOrNone<any>);
+expectType<any>({} as RequireAllOrNone<any, 'foo'>);
+expectType<any>({} as RequireAllOrNone<any, any>);
+expectType<any>({} as RequireAllOrNone<any, never>);
+
+expectType<never>({} as RequireAllOrNone<never>);
+expectType<never>({} as RequireAllOrNone<never, 'foo'>);
+expectType<never>({} as RequireAllOrNone<never, any>);
+expectType<never>({} as RequireAllOrNone<never, never>);

--- a/test-d/require-at-least-one.ts
+++ b/test-d/require-at-least-one.ts
@@ -1,5 +1,5 @@
-import {expectAssignable} from 'tsd';
-import type {RequireAtLeastOne} from '../index';
+import {expectAssignable, expectType} from 'tsd';
+import type {RequireAtLeastOne, Simplify} from '../index';
 
 type SystemMessages = {
 	default: string;
@@ -40,3 +40,29 @@ expectAssignable<MessageBoard<ValidMessages>>(
 	({macos = '', linux = '🐧', windows = '⊞'}) =>
 		`${linux} + ${windows} = ${macos}`,
 );
+
+expectType<{a: number; b?: string} | {a?: number; b: string}>(
+	{} as Simplify<RequireAtLeastOne<{a: number; b: string}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: string} | {a?: number; b: string}>(
+	{} as Simplify<RequireAtLeastOne<{a: number; b: string}, any>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: string; c?: boolean} | {a?: number; b: string; c?: boolean} | {a?: number; b?: string; c: boolean}>(
+	{} as Simplify<RequireAtLeastOne<{a: number; b: string; c: boolean}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: string; c?: boolean} | {a?: number; b: string; c?: boolean} | {a?: number; b?: string; c: boolean}>(
+	{} as Simplify<RequireAtLeastOne<{a: number; b: string; c: boolean}, any>>, // `Simplify` is required for the assertion to pass
+);
+
+expectType<never>({} as RequireAtLeastOne<{}>);
+expectType<never>({} as RequireAtLeastOne<{a: string; b: number}, never>);
+
+expectType<any>({} as RequireAtLeastOne<any>);
+expectType<any>({} as RequireAtLeastOne<any, 'foo'>);
+expectType<any>({} as RequireAtLeastOne<any, any>);
+expectType<any>({} as RequireAtLeastOne<any, never>);
+
+expectType<never>({} as RequireAtLeastOne<never>);
+expectType<never>({} as RequireAtLeastOne<never, 'foo'>);
+expectType<never>({} as RequireAtLeastOne<never, any>);
+expectType<never>({} as RequireAtLeastOne<never, never>);

--- a/test-d/require-exactly-one.ts
+++ b/test-d/require-exactly-one.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {RequireExactlyOne, Simplify} from '../index';
 
 type SystemMessages = {
@@ -86,3 +86,25 @@ function narrowingTest3(foo: Simplify<RequireExactlyOne<{a: string; b: string; c
 
 	return foo.b;
 }
+
+expectType<{a: number; b?: never} | {a?: never; b: string}>({} as Simplify<RequireExactlyOne<{a: number; b: string}>>); // `Simplify` is required for the assertion to pass
+expectType<{a: number; b?: never} | {a?: never; b: string}>({} as Simplify<RequireExactlyOne<{a: number; b: string}, any>>); // `Simplify` is required for the assertion to pass
+expectType<{a: number; b?: never; c?: never} | {a?: never; b: string; c?: never} | {a?: never; b?: never; c: boolean}>(
+	{} as Simplify<RequireExactlyOne<{a: number; b: string; c: boolean}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: never; c?: never} | {a?: never; b: string; c?: never} | {a?: never; b?: never; c: boolean}>(
+	{} as Simplify<RequireExactlyOne<{a: number; b: string; c: boolean}, any>>, // `Simplify` is required for the assertion to pass
+);
+
+expectType<never>({} as RequireExactlyOne<{}>);
+expectType<never>({} as RequireExactlyOne<{a: string; b: number}, never>);
+
+expectType<any>({} as RequireExactlyOne<any>);
+expectType<any>({} as RequireExactlyOne<any, 'foo'>);
+expectType<any>({} as RequireExactlyOne<any, any>);
+expectType<any>({} as RequireExactlyOne<any, never>);
+
+expectType<never>({} as RequireExactlyOne<never>);
+expectType<never>({} as RequireExactlyOne<never, 'foo'>);
+expectType<never>({} as RequireExactlyOne<never, any>);
+expectType<never>({} as RequireExactlyOne<never, never>);

--- a/test-d/require-one-or-none.ts
+++ b/test-d/require-one-or-none.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectNotAssignable} from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import type {RequireOneOrNone, Simplify} from '../index';
 
 type OneAtMost = RequireOneOrNone<Record<'foo' | 'bar' | 'baz', true>>;
@@ -104,3 +104,29 @@ function narrowingTest3(foo: Simplify<RequireOneOrNone<{a: string; b: string; c:
 
 	return '';
 }
+
+expectType<{a: number; b?: never} | {a?: never; b: string} | {a?: never; b?: never}>(
+	{} as Simplify<RequireOneOrNone<{a: number; b: string}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: never} | {a?: never; b: string} | {a?: never; b?: never}>(
+	{} as Simplify<RequireOneOrNone<{a: number; b: string}, any>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: never; c?: never} | {a?: never; b: string; c?: never} | {a?: never; b?: never; c: boolean} | {a?: never; b?: never; c?: never}>(
+	{} as Simplify<RequireOneOrNone<{a: number; b: string; c: boolean}>>, // `Simplify` is required for the assertion to pass
+);
+expectType<{a: number; b?: never; c?: never} | {a?: never; b: string; c?: never} | {a?: never; b?: never; c: boolean} | {a?: never; b?: never; c?: never}>(
+	{} as Simplify<RequireOneOrNone<{a: number; b: string; c: boolean}, any>>, // `Simplify` is required for the assertion to pass
+);
+
+expectType<{}>({} as RequireOneOrNone<{}>);
+expectType<{a: string; b: number}>({} as RequireOneOrNone<{a: string; b: number}, never>);
+
+expectType<any>({} as RequireOneOrNone<any>);
+expectType<any>({} as RequireOneOrNone<any, 'foo'>);
+expectType<any>({} as RequireOneOrNone<any, any>);
+expectType<any>({} as RequireOneOrNone<any, never>);
+
+expectType<never>({} as RequireOneOrNone<never>);
+expectType<never>({} as RequireOneOrNone<never, 'foo'>);
+expectType<never>({} as RequireOneOrNone<never, any>);
+expectType<never>({} as RequireOneOrNone<never, never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes behaviour of `RequireAllOrNone`, `RequireAtLeastOne`, `RequireExactlyOne` & `RequireOneOrNone` with `any` and `never`.

1. All four types now return `any` when the first type argument is `any`.

    ```ts
    type Current = Simplify<RequireAllOrNone<any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //          [x: number]: any;
    //          [x: symbol]: any;
    //      } | {
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      }
    
    type Updated = RequireAllOrNone<any>;
    //   ^? type Updated = any
    ```

    <details><summary>Behaviour for the other three types</summary>
    
    ```ts
    type Current = Simplify<RequireAtLeastOne<any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //          [x: number]: any;
    //          [x: symbol]: any;
    //      } | {
    //          [x: number]: any;
    //          [x: string]: any;
    //          [x: symbol]: any;
    //      } | {
    //          [x: symbol]: any;
    //          [x: string]: any;
    //          [x: number]: any;
    //      }
    
    type Updated = RequireAtLeastOne<any>;
    //   ^? type Updated = any
    ```
    
    ```ts
    type Current = Simplify<RequireExactlyOne<any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: number]: any;
    //          [x: string]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: symbol]: any;
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //      }
    
    type Updated = RequireExactlyOne<any>;
    //   ^? type Updated = any
    ```
    
    ```ts
    type Current = Simplify<RequireOneOrNone<any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: number]: any;
    //          [x: string]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: symbol]: any;
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //      } | {
    //          ...;
    //      }
    
    type Updated = RequireOneOrNone<any>;
    //   ^? type Updated = any
    ```
    </details> 

2. All four types now return `never` when the first type argument is `never`.

    ```ts
    type Current = Simplify<RequireAllOrNone<never>>;
    //   ^? type Current = {
    //          [x: string]: never;
    //          [x: number]: never;
    //          [x: symbol]: never;
    //      } | {
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      }
    
    type Updated = RequireAllOrNone<never>;
    //   ^? type Updated = never
    ```
    
    <details><summary>Behaviour for the other three types</summary>
    
    ```ts
    // No change in behaviour for `RequireAtLeastOne`, it was already correct
    type Current = RequireAtLeastOne<never>;
    //   ^? type Current = never
    
    type Updated = RequireAtLeastOne<never>;
    //   ^? type Updated = never
    ```
    
    ```ts
    type Current = Simplify<RequireExactlyOne<never>>;
    //   ^? type Current = {
    //          [x: string]: never;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: number]: never;
    //          [x: string]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: symbol]: never;
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //      }

    type Updated = RequireExactlyOne<never>;
    //   ^? type Updated = never
    ```
    
    ```ts
    type Current = Simplify<RequireOneOrNone<never>>;
    //   ^? type Current = {
    //          [x: string]: never;
    //          [x: number]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: number]: never;
    //          [x: string]: undefined;
    //          [x: symbol]: undefined;
    //      } | {
    //          [x: symbol]: never;
    //          [x: string]: undefined;
    //          [x: number]: undefined;
    //      } | {
    //          ...;
    //      }

    type Updated = RequireOneOrNone<never>;
    //   ^? type Updated = never
    ```
    </details>

3. When the second type argument is `any`, all four types now behave as if no second type argument was provided.

    ```ts
    type Current = Simplify<RequireAllOrNone<{a: number; b: string}, any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //      } | {
    //          [x: string]: undefined;
    //      }
    
    type Updated = Simplify<RequireAllOrNone<{a: number; b: string}, any>>;
    //   ^? type Updated = {
    //          a: number;
    //          b: string;
    //      } | {
    //          a?: never;
    //          b?: never;
    //      }
    ```
    
    <details><summary>Behaviour for the other three types</summary>
    
    ```ts
    type Current = Simplify<RequireAtLeastOne<{a: number; b: string}, any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //      }
    
    type Updated = Simplify<RequireAtLeastOne<{a: number; b: string}, any>>;
    //   ^? type Updated = {
    //          a: number;
    //          b?: string;
    //      } | {
    //          b: string;
    //          a?: number;
    //      }
    ```
    
    ```ts
    type Current = Simplify<RequireExactlyOne<{a: number; b: string}, any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //      }
    
    type Updated = Simplify<RequireExactlyOne<{a: number; b: string}, any>>;
    //   ^? type Updated = {
    //          a: number;
    //          b?: never;
    //      } | {
    //          b: string;
    //          a?: never;
    //      }
    ```
    
    ```ts
    type Current = Simplify<RequireOneOrNone<{a: number; b: string}, any>>;
    //   ^? type Current = {
    //          [x: string]: any;
    //      } | {
    //          [x: string]: undefined;
    //      }
    
    type Updated = Simplify<RequireOneOrNone<{a: number; b: string}, any>>;
    //   ^? type Updated = {
    //          a: number;
    //          b?: never;
    //      } | {
    //          b: string;
    //          a?: never;
    //      } | {
    //          a?: never;
    //          b?: never;
    //      }
    ```
    
    </details>

4. When the second type argument is `never`.

    Ideally, all four types should return back the input type in this case. For example, `RequireAllOrNone<{a: string; b: number}, never>` should return `{a: string; b: number}`. This makes sense because these types are designed to leave unspecified keys unchanged—and if the specified keys are `never`, then nothing should change.
    
    Currently, only `RequireAllOrNone` and `RequireOneOrNone` behave this way. The other two types return `never`, which I believe is incorrect.
    
    **This PR doesn't address this issue, because `NonEmptyObject` currently depends on `RequireAtLeastOne` returning `never` in this case. I'll create a separate PR to fix it.**
    
    ```ts
    type Current1 = Simplify<RequireAllOrNone<{a: number}, never>>;
    //   ^? type Current1 = {
    //          a: number;
    //      } | {
    //          a: number;
    //      }
    
    type Current2 = Simplify<RequireOneOrNone<{a: number}, never>>;
    //   ^? type Current2 = {
    //          a: number;
    //      }
    
    type Current3 = Simplify<RequireAtLeastOne<{a: number}, never>>;
    //   ^? type Current3 = never
    
    type Current4 = Simplify<RequireExactlyOne<{a: number}, never>>;
    //   ^? type Current4 = never
    ```
