### PR TITLE
Remove unused imports

### DIFF
--- a/source/is-float.d.ts
+++ b/source/is-float.d.ts
@@ -1,5 +1,3 @@
-import type {Zero} from './numeric';
-
 /**
 Returns a boolean for whether the given number is a float, like `1.5` or `-1.5`.
 

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -1,6 +1,5 @@
 import type {Except} from './except';
 import type {HomomorphicPick} from './internal';
-import type {KeysOfUnion} from './keys-of-union';
 import type {Simplify} from './simplify';
 
 /**

--- a/source/set-readonly.d.ts
+++ b/source/set-readonly.d.ts
@@ -1,6 +1,5 @@
 import type {Except} from './except';
 import type {HomomorphicPick} from './internal';
-import type {KeysOfUnion} from './keys-of-union';
 import type {Simplify} from './simplify';
 
 /**

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -1,6 +1,5 @@
 import type {Except} from './except';
 import type {HomomorphicPick, IfArrayReadonly} from './internal';
-import type {KeysOfUnion} from './keys-of-union';
 import type {OptionalKeysOf} from './optional-keys-of';
 import type {Simplify} from './simplify';
 import type {UnknownArray} from './unknown-array';

--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -1,4 +1,4 @@
-import type {NonRecursiveType, UnionMin, UnionMax, TupleLength, StaticPartOfArray, VariablePartOfArray, IsUnion, IsArrayReadonly, SetArrayAccess, ApplyDefaultOptions} from './internal';
+import type {NonRecursiveType, UnionMin, UnionMax, TupleLength, StaticPartOfArray, VariablePartOfArray, IsArrayReadonly, SetArrayAccess, ApplyDefaultOptions} from './internal';
 import type {IsNever} from './is-never';
 import type {UnknownArray} from './unknown-array';
 

--- a/test-d/find-global-type.ts
+++ b/test-d/find-global-type.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-var, unicorn/prevent-abbreviations */
-import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
+import {expectType} from 'tsd';
 import type {FindGlobalInstanceType, FindGlobalType} from '..';
 
 declare class NonGlobalES6Class {}

--- a/test-d/union-to-tuple.ts
+++ b/test-d/union-to-tuple.ts
@@ -1,4 +1,4 @@
-import {expectAssignable, expectError, expectType} from 'tsd';
+import {expectAssignable, expectType} from 'tsd';
 import type {UnionToTuple} from '../index';
 
 type Options = UnionToTuple<'a' | 'b' | 'c'>;


### PR DESCRIPTION
This PR removes a few unused imports. I believe these orphaned imports result from this commit: https://github.com/sindresorhus/type-fest/commit/4789c7cd5532538b8e572a04a639ab2af034cc87.
