### PR TITLE
`LessThan` / `GreaterThan` / `GreaterThanOrEqual`: Fix behaviour with unions

### DIFF
--- a/source/greater-than.d.ts
+++ b/source/greater-than.d.ts
@@ -21,31 +21,36 @@ GreaterThan<1, 5>;
 //=> false
 ```
 */
-export type GreaterThan<A extends number, B extends number> = number extends A | B
-	? never
-	: [
-		IsEqual<A, PositiveInfinity>, IsEqual<A, NegativeInfinity>,
-		IsEqual<B, PositiveInfinity>, IsEqual<B, NegativeInfinity>,
-	] extends infer R extends [boolean, boolean, boolean, boolean]
-		? Or<
-		And<IsEqual<R[0], true>, IsEqual<R[2], false>>,
-		And<IsEqual<R[3], true>, IsEqual<R[1], false>>
-		> extends true
-			? true
-			: Or<
-			And<IsEqual<R[1], true>, IsEqual<R[3], false>>,
-			And<IsEqual<R[2], true>, IsEqual<R[0], false>>
-			> extends true
-				? false
-				: true extends R[number]
-					? false
-					: [IsNegative<A>, IsNegative<B>] extends infer R extends [boolean, boolean]
-						? [true, false] extends R
+export type GreaterThan<A extends number, B extends number> =
+	A extends number // For distributing `A`
+		? B extends number // For distributing `B`
+			? number extends A | B
+				? never
+				: [
+					IsEqual<A, PositiveInfinity>, IsEqual<A, NegativeInfinity>,
+					IsEqual<B, PositiveInfinity>, IsEqual<B, NegativeInfinity>,
+				] extends infer R extends [boolean, boolean, boolean, boolean]
+					? Or<
+					And<IsEqual<R[0], true>, IsEqual<R[2], false>>,
+					And<IsEqual<R[3], true>, IsEqual<R[1], false>>
+					> extends true
+						? true
+						: Or<
+						And<IsEqual<R[1], true>, IsEqual<R[3], false>>,
+						And<IsEqual<R[2], true>, IsEqual<R[0], false>>
+						> extends true
 							? false
-							: [false, true] extends R
-								? true
-								: [false, false] extends R
-									? PositiveNumericStringGt<`${A}`, `${B}`>
-									: PositiveNumericStringGt<`${NumberAbsolute<B>}`, `${NumberAbsolute<A>}`>
-						: never
-		: never;
+							: true extends R[number]
+								? false
+								: [IsNegative<A>, IsNegative<B>] extends infer R extends [boolean, boolean]
+									? [true, false] extends R
+										? false
+										: [false, true] extends R
+											? true
+											: [false, false] extends R
+												? PositiveNumericStringGt<`${A}`, `${B}`>
+												: PositiveNumericStringGt<`${NumberAbsolute<B>}`, `${NumberAbsolute<A>}`>
+									: never
+					: never
+			: never // Should never happen
+		: never; // Should never happen

--- a/source/less-than.d.ts
+++ b/source/less-than.d.ts
@@ -19,4 +19,8 @@ LessThan<1, 5>;
 */
 export type LessThan<A extends number, B extends number> = number extends A | B
 	? never
-	: GreaterThanOrEqual<A, B> extends true ? false : true;
+	: GreaterThanOrEqual<A, B> extends infer Result
+		? Result extends true
+			? false
+			: true
+		: never; // Should never happen

--- a/test-d/greater-than-or-equal.ts
+++ b/test-d/greater-than-or-equal.ts
@@ -13,6 +13,21 @@ expectType<GreaterThanOrEqual<-2, -2>>(true);
 expectType<GreaterThanOrEqual<-2, -3>>(true);
 expectType<GreaterThanOrEqual<-2, number>>(never);
 
+// === unions ===
+expectType<GreaterThanOrEqual<100 | 200, 50>>(true);
+expectType<GreaterThanOrEqual<25, -100 | -15 | 2 | 21>>(true);
+expectType<GreaterThanOrEqual<10 | 15, -5 | 10>>(true);
+
+expectType<GreaterThanOrEqual<10, 50 | 100>>(false);
+expectType<GreaterThanOrEqual<50 | 25 | 0 | -16, 100>>(false);
+expectType<GreaterThanOrEqual<1 | 2, 3 | 4>>(false);
+
+expectType<GreaterThanOrEqual<-10, -90 | 90>>({} as boolean);
+expectType<GreaterThanOrEqual<-16 | 16, 0>>({} as boolean);
+expectType<GreaterThanOrEqual<-4 | 45, 20 | 30>>({} as boolean);
+expectType<GreaterThanOrEqual<1 | -1 | 3, 0 | 2>>({} as boolean);
+expectType<GreaterThanOrEqual<1 | 2 | 3, 3 | 4>>({} as boolean);
+
 expectType<GreaterThanOrEqual<PositiveInfinity, -999>>(true);
 expectType<GreaterThanOrEqual<PositiveInfinity, 999>>(true);
 expectType<GreaterThanOrEqual<999, PositiveInfinity>>(false);

--- a/test-d/greater-than.ts
+++ b/test-d/greater-than.ts
@@ -13,6 +13,20 @@ expectType<GreaterThan<-2, -2>>(false);
 expectType<GreaterThan<-2, -3>>(true);
 expectType<GreaterThan<-2, number>>(never);
 
+// === unions ===
+expectType<GreaterThan<100 | 200, 50>>(true);
+expectType<GreaterThan<25, -100 | -15 | 2 | 21>>(true);
+expectType<GreaterThan<10 | 15, -5 | 5>>(true);
+
+expectType<GreaterThan<10, 50 | 100>>(false);
+expectType<GreaterThan<50 | 25 | 0 | -16, 100>>(false);
+expectType<GreaterThan<1 | 2 | 3, 3 | 4>>(false);
+
+expectType<GreaterThan<-10, -90 | 90>>({} as boolean);
+expectType<GreaterThan<-16 | 16, 0>>({} as boolean);
+expectType<GreaterThan<-4 | 45, 20 | 30>>({} as boolean);
+expectType<GreaterThan<1 | -1 | 3, 0 | 2>>({} as boolean);
+
 expectType<GreaterThan<PositiveInfinity, -999>>(true);
 expectType<GreaterThan<PositiveInfinity, 999>>(true);
 expectType<GreaterThan<999, PositiveInfinity>>(false);

--- a/test-d/less-than.ts
+++ b/test-d/less-than.ts
@@ -12,6 +12,21 @@ expectType<LessThan<2, 2>>(false);
 expectType<LessThan<-2, -2>>(false);
 expectType<LessThan<-2, -3>>(false);
 expectType<LessThan<-2, number>>(never);
+
+// === unions ===
+expectType<LessThan<10, 50 | 100>>(true);
+expectType<LessThan<50 | 25 | 0 | -16, 100>>(true);
+expectType<LessThan<1 | 2, 3 | 4>>(true);
+
+expectType<LessThan<100 | 200, 50>>(false);
+expectType<LessThan<25, -100 | -15 | 2 | 21>>(false);
+expectType<LessThan<10 | 15, -5 | 10>>(false);
+
+expectType<LessThan<-10, -90 | 90>>({} as boolean);
+expectType<LessThan<-16 | 16, 0>>({} as boolean);
+expectType<LessThan<-4 | 45, 20 | 30>>({} as boolean);
+expectType<LessThan<1 | -1 | 3, 0 | 2>>({} as boolean);
+
 expectType<LessThan<PositiveInfinity, -999>>(false);
 expectType<LessThan<PositiveInfinity, 999>>(false);
 expectType<LessThan<999, PositiveInfinity>>(true);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixed behaviour of `LessThan`, `GreaterThan` and `GreaterThanOrEqual` when instantiated with unions. Discovered this while replying to #1115.

```ts
type Current = LessThan<0, -1 | 1>;
//   ^? type Current = false

type Updated = LessThan<0, -1 | 1>;
//   ^? type Updated = boolean
```

```ts
type Current = GreaterThan<0, -1 | 1>
//   ^? type Current = true

type Updated = GreaterThan<0, -1 | 1>
//   ^? type Updated = boolean
```

```ts
type Current = GreaterThanOrEqual<0, -1 | 1>
//   ^? type Current = true

type Updated = GreaterThanOrEqual<0, -1 | 1>
//   ^? type Updated = boolean
```