### PR TITLE
docs: add `-D` flag to the install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ PR welcome for additional commonly needed types and docs improvements. Read the 
 ## Install
 
 ```sh
-npm install type-fest
+npm install -D type-fest
 ```
 
 *Requires TypeScript >=5.1 and [`{strict: true}`](https://www.typescriptlang.org/tsconfig#strict) in your tsconfig.*


### PR DESCRIPTION
`type-fest` is a typescript-only library, so [like typescript itself](https://www.npmjs.com/package/typescript#:~:text=latest%20stable%20version%3A-,npm%20install%20%2DD%20typescript,-For%20our%20nightly), it should be added to ``devDependencies`` and not to ``dependencies``.