### PR TITLE
SetRequiredDeep: fix incorrect docs

### DIFF
--- a/source/set-required-deep.d.ts
+++ b/source/set-required-deep.d.ts
@@ -28,7 +28,7 @@ type SomeRequiredDeep = SetRequiredDeep<Foo, 'a' | `c.${number}.d`>;
 // type SomeRequiredDeep = {
 // 	a: number; // Is now required
 // 	b?: string;
-// 	c: {
+// 	c?: {
 // 		d: number // Is now required
 // 	}[]
 // }


### PR DESCRIPTION
The docblock for `SetRequiredDeep` insinuates that it changes the requiredness of the entire path given to it, while in reality it just changes the leaf.