### PR TITLE
`Split`: Enable `StrictLiteralChecks` option by default

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -64,7 +64,7 @@ ToPath<'foo[0].bar.baz'>
 //=> ['foo', '0', 'bar', 'baz']
 ```
 */
-type ToPath<S extends string> = Split<FixPathSquareBrackets<S>, '.'>;
+type ToPath<S extends string> = Split<FixPathSquareBrackets<S>, '.', {strictLiteralChecks: false}>;
 
 /**
 Replaces square-bracketed dot notation with dots, for example, `foo[0].bar` -> `foo.0.bar`.

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -12,9 +12,7 @@ type SplitOptions = {
 	/**
 	When enabled, instantiations with non-literal string types (e.g., `string`, `Uppercase<string>`, `on${string}`) simply return back `string[]` without performing any splitting, as the exact structure cannot be statically determined.
 
-	Note: In the future, this option might be enabled by default, so if you currently rely on this being disabled, you should consider explicitly enabling it.
-
-	@default false
+	@default true
 
 	@example
 	```ts
@@ -35,7 +33,7 @@ type SplitOptions = {
 };
 
 type DefaultSplitOptions = {
-	strictLiteralChecks: false;
+	strictLiteralChecks: true;
 };
 
 /**

--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -38,14 +38,14 @@ expectType<['a', 'b', 'c'] | ['a,b,c'] | ['x', 'y', 'z'] | ['x:y:z']>({} as Spli
 // -- strictLiteralChecks: false --
 // NOTE: The behaviour covered in the test below is not acurate because the `a.b.${string}` type might hold a value like `a.b.c.d`,
 // which, when split by `.`, would result in `['a', 'b', 'c', 'd']`, which wouldn't conform to the output type of `['a', 'b', string]`.
-expectType<['a', 'b', string]>(split('a.b.c.d' as `a.b.${string}`, '.'));
+expectType<['a', 'b', string]>({} as Split<`a.b.${string}`, '.', {strictLiteralChecks: false}>);
 
 // -- strictLiteralChecks: true --
-expectType<string[]>({} as Split<string, '', {strictLiteralChecks: true}>);
-expectType<string[]>({} as Split<Uppercase<string>, '-', {strictLiteralChecks: true}>);
-expectType<string[]>({} as Split<`on${string}`, 'n', {strictLiteralChecks: true}>);
-expectType<string[]>({} as Split<'a,b,c', string, {strictLiteralChecks: true}>);
-expectType<string[]>({} as Split<'a,b,c', Lowercase<string>, {strictLiteralChecks: true}>);
+expectType<string[]>({} as Split<string, ''>);
+expectType<string[]>({} as Split<Uppercase<string>, '-'>);
+expectType<string[]>({} as Split<`on${string}`, 'n'>);
+expectType<string[]>({} as Split<'a,b,c', string>);
+expectType<string[]>({} as Split<'a,b,c', Lowercase<string>>);
 expectType<string[]>({} as Split<'a,b,c', `,${string}`, {strictLiteralChecks: true}>);
 expectType<string[]>({} as Split<`on${string}`, Lowercase<string>, {strictLiteralChecks: true}>);
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 7 in #450.