### PR TITLE
`ObservableLike`: Move to sub-export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@
 export type * from './source/primitive.d.ts';
 export type * from './source/typed-array.d.ts';
 export type * from './source/basic.d.ts';
-export type * from './source/observable-like.d.ts';
 
 // Utilities
 export type {KeysOfUnion} from './source/keys-of-union.d.ts';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
 	},
 	"type": "module",
 	"exports": {
-		"types": "./index.d.ts"
+		".": {
+			"types": "./index.d.ts"
+		},
+		"./globals": {
+			"types": "./source/globals/index.d.ts"
+		}
 	},
 	"types": "./index.d.ts",
 	"sideEffects": false,

--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ Click the type names for complete docs.
 - [`AbstractClass`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/classes.html#abstract-classes).
 - [`AbstractConstructor`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures) constructor.
 - [`TypedArray`](source/typed-array.d.ts) - Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
-- [`ObservableLike`](source/observable-like.d.ts) - Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
+- [`ObservableLike`](source/globals/observable-like.d.ts) - Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
 
 ### Utilities
 

--- a/source/globals/index.d.ts
+++ b/source/globals/index.d.ts
@@ -1,0 +1,1 @@
+export type * from './observable-like.d.ts';

--- a/source/globals/observable-like.d.ts
+++ b/source/globals/observable-like.d.ts
@@ -9,6 +9,7 @@ declare global {
 @remarks
 The TC39 observable proposal defines a `closed` property, but some implementations (such as xstream) do not as of 10/08/2021.
 As well, some guidance on making an `Observable` to not include `closed` property.
+
 @see https://github.com/tc39/proposal-observable/blob/master/src/Observable.js#L129-L130
 @see https://github.com/staltz/xstream/blob/6c22580c1d84d69773ee4b0905df44ad464955b3/src/index.ts#L79-L85
 @see https://github.com/benlesh/symbol-observable#making-an-object-observable
@@ -23,10 +24,12 @@ export type Unsubscribable = {
 @category Observable
 */
 type OnNext<ValueType> = (value: ValueType) => void;
+
 /**
 @category Observable
 */
 type OnError = (error: unknown) => void;
+
 /**
 @category Observable
 */
@@ -43,6 +46,13 @@ export type Observer<ValueType> = {
 
 /**
 Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
+
+You must import it as a sub-import:
+
+@example
+```
+import type {ObservableLike} from 'type-fest/globals';
+```
 
 @remarks
 The TC39 Observable proposal defines 2 forms of `subscribe()`:

--- a/test-d/observable-like.ts
+++ b/test-d/observable-like.ts
@@ -1,5 +1,5 @@
 import {expectType, expectAssignable} from 'tsd';
-import type {ObservableLike} from '../index.d.ts';
+import type {ObservableLike} from '../source/globals/index.d.ts';
 
 // eslint-disable-next-line no-use-extend-native/no-use-extend-native
 expectAssignable<symbol>(Symbol.observable);


### PR DESCRIPTION
Fixes #1122
