### PR TITLE
`PartialDeep`: Disable `allowUndefinedInNonTupleArrays` option by default

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -18,10 +18,10 @@ export type PartialDeepOptions = {
 	- When set to `true`, elements of non-tuple arrays can be `undefined`.
 	- When set to `false`, only explicitly defined elements are allowed in non-tuple arrays, ensuring stricter type checking.
 
-	@default true
+	@default false
 
 	@example
-	You can prevent `undefined` values in non-tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}` as the second type argument:
+	You can allow `undefined` values in non-tuple arrays by passing `{recurseIntoArrays: true; allowUndefinedInNonTupleArrays: true}` as the second type argument:
 
 	```
 	import type {PartialDeep} from 'type-fest';
@@ -30,10 +30,9 @@ export type PartialDeepOptions = {
 		languages: string[];
 	};
 
-	declare const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}>;
+	declare const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: true}>;
 
-	partialSettings.languages = [undefined]; // Error
-	partialSettings.languages = []; // Ok
+	partialSettings.languages = [undefined]; // Ok
 	```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;
@@ -41,7 +40,7 @@ export type PartialDeepOptions = {
 
 type DefaultPartialDeepOptions = {
 	recurseIntoArrays: false;
-	allowUndefinedInNonTupleArrays: true;
+	allowUndefinedInNonTupleArrays: false;
 };
 
 /**

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -53,11 +53,11 @@ expectType<null | undefined>(partialDeepFoo.bar!.null);
 expectType<undefined>(partialDeepFoo.bar!.undefined);
 expectAssignable<Map<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.map);
 expectAssignable<Set<string | undefined> | undefined>(partialDeepFoo.bar!.set);
-expectType<Array<string | undefined> | undefined>(partialDeepFoo.bar!.array);
+expectType<string[] | undefined>(partialDeepFoo.bar!.array);
 expectType<['foo'?] | undefined>(partialDeepFoo.bar!.tuple);
 expectAssignable<ReadonlyMap<string | undefined, string | undefined> | undefined>(partialDeepFoo.bar!.readonlyMap);
 expectAssignable<ReadonlySet<string | undefined> | undefined>(partialDeepFoo.bar!.readonlySet);
-expectType<ReadonlyArray<string | undefined> | undefined>(partialDeepFoo.bar!.readonlyArray);
+expectType<readonly string[] | undefined>(partialDeepFoo.bar!.readonlyArray);
 expectType<readonly ['foo'?] | undefined>(partialDeepFoo.bar!.readonlyTuple);
 // Check for compiling with omitting partial keys
 partialDeepFoo = {baz: 'fred'};
@@ -80,12 +80,12 @@ const partialDeepNoRecurseIntoArraysFoo: PartialDeep<typeof foo> = foo;
 // Check that `{recurseIntoArrays: true}` behaves as intended
 expectType<PartialDeep<typeof foo, {recurseIntoArrays: true}>>(partialDeepFoo);
 
-// Check that `{allowUndefinedInNonTupleArrays: true}` is the default
+// Check that `{allowUndefinedInNonTupleArrays: false}` is the default
 const partialDeepAllowUndefinedInNonTupleArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true}> = foo;
-expectType<Array<string | undefined> | undefined>(partialDeepAllowUndefinedInNonTupleArraysFoo.bar!.array);
-// Check that `{allowUndefinedInNonTupleArrays: false}` behaves as intended
-const partialDeepDoNotAllowUndefinedInNonTupleArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: false}> = foo;
-expectType<string[] | undefined>(partialDeepDoNotAllowUndefinedInNonTupleArraysFoo.bar!.array);
+expectType<string[] | undefined>(partialDeepAllowUndefinedInNonTupleArraysFoo.bar!.array);
+// Check that `{allowUndefinedInNonTupleArrays: true}` behaves as intended
+const partialDeepDoNotAllowUndefinedInNonTupleArraysFoo: PartialDeep<typeof foo, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: true}> = foo;
+expectType<Array<string | undefined> | undefined>(partialDeepDoNotAllowUndefinedInNonTupleArraysFoo.bar!.array);
 
 // These are mostly the same checks as before, but the array/tuple types are different.
 // @ts-expect-error
@@ -127,3 +127,4 @@ expectType<void>(functionWithProperties3());
 expectType<{p1?: {p2?: string; p3?: [{p4?: number}?, string?]}}>({} as Simplify<typeof functionWithProperties3>);
 
 expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]}, {allowUndefinedInNonTupleArrays: false}>>);
+expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]}, {allowUndefinedInNonTupleArrays: true}>>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 6 of #450 