### PR TITLE
`PartialDeep`: Fix JSDoc examples

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -76,13 +76,15 @@ By default, this does not affect elements in array and tuple types. You can chan
 ```
 import type {PartialDeep} from 'type-fest';
 
-type Settings = {
-	languages: string[];
-}
-
-const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true}> = {
-	languages: [undefined]
+type Shape = {
+	dimensions: [number, number];
 };
+
+const partialShape: PartialDeep<Shape, {recurseIntoArrays: true}> = {
+	dimensions: [], // Ok
+};
+
+partialShape.dimensions = [15]; // Ok
 ```
 
 @see {@link PartialDeepOptions}

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -54,19 +54,19 @@ Use-cases:
 ```
 import type {PartialDeep} from 'type-fest';
 
-const settings: Settings = {
+let settings = {
 	textEditor: {
 		fontSize: 14,
 		fontColor: '#000000',
-		fontWeight: 400
+		fontWeight: 400,
 	},
 	autocomplete: false,
-	autosave: true
+	autosave: true,
 };
 
-const applySavedSettings = (savedSettings: PartialDeep<Settings>) => {
-	return {...settings, ...savedSettings};
-}
+const applySavedSettings = (savedSettings: PartialDeep<typeof settings>) => (
+	{...settings, ...savedSettings, textEditor: {...settings.textEditor, ...savedSettings.textEditor}}
+);
 
 settings = applySavedSettings({textEditor: {fontWeight: 500}});
 ```

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -32,7 +32,7 @@ export type PartialDeepOptions = {
 
 	declare const partialSettings: PartialDeep<Settings, {recurseIntoArrays: true; allowUndefinedInNonTupleArrays: true}>;
 
-	partialSettings.languages = [undefined]; // Ok
+	partialSettings.languages = [undefined]; // OK
 	```
 	*/
 	readonly allowUndefinedInNonTupleArrays?: boolean;
@@ -81,10 +81,10 @@ type Shape = {
 };
 
 const partialShape: PartialDeep<Shape, {recurseIntoArrays: true}> = {
-	dimensions: [], // Ok
+	dimensions: [], // OK
 };
 
-partialShape.dimensions = [15]; // Ok
+partialShape.dimensions = [15]; // OK
 ```
 
 @see {@link PartialDeepOptions}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

- The second example became incorrect after `allowUndefinedInNonTupleArrays` was disabled (#1126).
- The first example also has several issues, although they are unrelated to the option change.