### PR TITLE
`CamelCase` / `CamelCasedProperties` / `CamelCasedPropertiesDeep` / `PascalCase` / `PascalCasedProperties` / `PascalCasedPropertiesDeep`: Disable `preserveConsecutiveUppercase` option by default

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -10,13 +10,13 @@ export type CamelCaseOptions = {
 	/**
 	Whether to preserved consecutive uppercase letter.
 
-	@default true
+	@default false
 	*/
 	preserveConsecutiveUppercase?: boolean;
 };
 
 export type DefaultCamelCaseOptions = {
-	preserveConsecutiveUppercase: true;
+	preserveConsecutiveUppercase: false;
 };
 
 /**

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -41,10 +41,10 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 
-const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{fooBAR: { fooBARBiz: [{ fooBARBaz: string }] }}, {preserveConsecutiveUppercase: false}> = {
-	fooBar: {
-		fooBarBiz: [{
-			fooBarBaz: 'string',
+const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{fooBAR: {fooBARBiz: [{fooBARBaz: string}]}}, {preserveConsecutiveUppercase: true}> = {
+	fooBAR: {
+		fooBARBiz: [{
+			fooBARBaz: 'string',
 		}],
 	},
 };

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -23,8 +23,8 @@ const result: CamelCasedProperties<User> = {
 	userName: 'Tom',
 };
 
-const preserveConsecutiveUppercase: CamelCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: false}> = {
-	fooBar: 'string',
+const preserveConsecutiveUppercase: CamelCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: true}> = {
+	fooBAR: 'string',
 };
 ```
 

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -11,10 +11,11 @@ import type {PascalCase} from 'type-fest';
 // Simple
 
 const someVariable: PascalCase<'foo-bar'> = 'FooBar';
+const preserveConsecutiveUppercase: PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'FooBARBaz';
 
 // Advanced
 
-type PascalCaseProps<T> = {
+type PascalCasedProperties<T> = {
 	[K in keyof T as PascalCase<K>]: T[K]
 };
 
@@ -22,12 +23,18 @@ interface RawOptions {
 	'dry-run': boolean;
 	'full_family_name': string;
 	foo: number;
-}
+	BAR: string;
+	QUZ_QUX: number;
+	'OTHER-FIELD': boolean;
+};
 
-const dbResult: CamelCasedProperties<ModelProps> = {
+const dbResult: PascalCasedProperties<RawOptions> = {
 	DryRun: true,
 	FullFamilyName: 'bar.js',
-	Foo: 123
+	Foo: 123,
+	Bar: 'foo',
+	QuzQux: 6,
+	OtherField: false,
 };
 ```
 

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -40,6 +40,14 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
+const preserveConsecutiveUppercase: PascalCasedPropertiesDeep<{fooBAR: {fooBARBiz: [{fooBARBaz: string}]}}, {preserveConsecutiveUppercase: true}> = {
+	FooBAR: {
+		FooBARBiz: [{
+			FooBARBaz: 'string',
+		}],
+	},
+};
 ```
 
 @category Change case

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -23,6 +23,10 @@ const result: PascalCasedProperties<User> = {
 	UserId: 1,
 	UserName: 'Tom',
 };
+
+const preserveConsecutiveUppercase: PascalCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: true}> = {
+	FooBAR: 'string',
+};
 ```
 
 @category Change case

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -67,15 +67,15 @@ expectAssignable<CamelCasedProperties<RawOptions>>({
 	otherField: false,
 });
 
-expectType<CamelCase<'fooBAR'>>('fooBAR');
-expectType<CamelCase<'fooBAR', {preserveConsecutiveUppercase: false}>>('fooBar');
+expectType<CamelCase<'fooBAR'>>('fooBar');
+expectType<CamelCase<'fooBAR', {preserveConsecutiveUppercase: true}>>('fooBAR');
 
-expectType<CamelCase<'fooBARBiz'>>('fooBARBiz');
-expectType<CamelCase<'fooBARBiz', {preserveConsecutiveUppercase: false}>>('fooBarBiz');
+expectType<CamelCase<'fooBARBiz'>>('fooBarBiz');
+expectType<CamelCase<'fooBARBiz', {preserveConsecutiveUppercase: true}>>('fooBARBiz');
 
-expectType<CamelCase<'foo BAR-Biz_BUZZ'>>('fooBARBizBUZZ');
+expectType<CamelCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: true}>>('fooBARBizBUZZ');
 expectType<CamelCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('fooBarBizBuzz');
-expectType<CamelCase<'foo\tBAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('fooBarBizBuzz');
+expectType<CamelCase<'foo\tBAR-Biz_BUZZ'>>('fooBarBizBuzz');
 
+expectType<CamelCase<string, {preserveConsecutiveUppercase: true}>>('string' as string);
 expectType<CamelCase<string>>('string' as string);
-expectType<CamelCase<string, {preserveConsecutiveUppercase: false}>>('string' as string);

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -13,10 +13,10 @@ expectType<Set<{fooBar: string}>>(bar);
 
 type bazBizDeep = {fooBAR: number; baz: {fooBAR: Array<{BARFoo: string}>}};
 
-declare const baz: CamelCasedPropertiesDeep<bazBizDeep>;
+declare const baz: CamelCasedPropertiesDeep<bazBizDeep, {preserveConsecutiveUppercase: true}>;
 expectType<{fooBAR: number; baz: {fooBAR: Array<{bARFoo: string}>}}>(baz);
 
-declare const biz: CamelCasedPropertiesDeep<bazBizDeep, {preserveConsecutiveUppercase: false}>;
+declare const biz: CamelCasedPropertiesDeep<bazBizDeep>;
 expectType<{fooBar: number; baz: {fooBar: Array<{barFoo: string}>}}>(biz);
 
 declare const tuple: CamelCasedPropertiesDeep<{tuple: [number, string, {D: string}]}>;

--- a/test-d/camel-cased-properties.ts
+++ b/test-d/camel-cased-properties.ts
@@ -10,10 +10,10 @@ expectType<Array<{helloWorld: string}>>(bar);
 declare const fooBar: CamelCasedProperties<() => {a: string}>;
 expectType<() => {a: string}>(fooBar);
 
-declare const baz: CamelCasedProperties<{fooBAR: number; BARFoo: string}>;
+declare const baz: CamelCasedProperties<{fooBAR: number; BARFoo: string}, {preserveConsecutiveUppercase: true}>;
 expectType<{fooBAR: number; bARFoo: string}>(baz);
 
-declare const biz: CamelCasedProperties<{fooBAR: number; BARFoo: string}, {preserveConsecutiveUppercase: false}>;
+declare const biz: CamelCasedProperties<{fooBAR: number; BARFoo: string}>;
 expectType<{fooBar: number; barFoo: string}>(biz);
 
 // Verify example

--- a/test-d/pascal-case.ts
+++ b/test-d/pascal-case.ts
@@ -9,3 +9,16 @@ expectType<'FooBar'>(pascalFromKebab);
 
 const pascalFromComplexKebab: PascalCase<'foo-bar-abc-123'> = 'FooBarAbc123';
 expectType<'FooBarAbc123'>(pascalFromComplexKebab);
+
+expectType<PascalCase<'fooBAR'>>('FooBar');
+expectType<PascalCase<'fooBAR', {preserveConsecutiveUppercase: true}>>('FooBAR');
+
+expectType<PascalCase<'fooBARBiz'>>('FooBarBiz');
+expectType<PascalCase<'fooBARBiz', {preserveConsecutiveUppercase: true}>>('FooBARBiz');
+
+expectType<PascalCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: true}>>('FooBARBizBUZZ');
+expectType<PascalCase<'foo BAR-Biz_BUZZ', {preserveConsecutiveUppercase: false}>>('FooBarBizBuzz');
+expectType<PascalCase<'foo\tBAR-Biz_BUZZ'>>('FooBarBizBuzz');
+
+expectType<PascalCase<string, {preserveConsecutiveUppercase: true}>>({} as Capitalize<string>);
+expectType<PascalCase<string>>({} as Capitalize<string>);

--- a/test-d/pascal-cased-properties-deep.ts
+++ b/test-d/pascal-cased-properties-deep.ts
@@ -52,3 +52,11 @@ expectType<{'FooBar': {'BarBaz': unknown}; Biz: unknown}>({} as PascalCasedPrope
 
 expectType<{'FooBar': any}>({} as PascalCasedPropertiesDeep<{foo_bar: any}>);
 expectType<{'FooBar': {'BarBaz': any}; Biz: any}>({} as PascalCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);
+
+type bazBizDeep = {fooBAR: number; baz: {fooBAR: Array<{BARFoo: string}>}};
+
+declare const baz: PascalCasedPropertiesDeep<bazBizDeep, {preserveConsecutiveUppercase: true}>;
+expectType<{FooBAR: number; Baz: {FooBAR: Array<{BARFoo: string}>}}>(baz);
+
+declare const biz: PascalCasedPropertiesDeep<bazBizDeep>;
+expectType<{FooBar: number; Baz: {FooBar: Array<{BarFoo: string}>}}>(biz);

--- a/test-d/pascal-cased-properties.ts
+++ b/test-d/pascal-cased-properties.ts
@@ -20,3 +20,9 @@ const result: PascalCasedProperties<User> = {
 	UserName: 'Tom',
 };
 expectType<PascalCasedProperties<User>>(result);
+
+declare const baz: PascalCasedProperties<{fooBAR: number; BARFoo: string}, {preserveConsecutiveUppercase: true}>;
+expectType<{FooBAR: number; BARFoo: string}>(baz);
+
+declare const biz: PascalCasedProperties<{fooBAR: number; BARFoo: string}>;
+expectType<{FooBar: number; BarFoo: string}>(biz);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 4 in #450.