### PR TITLE
`ReadonlyKeysOf` / `WritableKeysOf`: Add `object` constraint to type argument

### DIFF
--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -24,7 +24,7 @@ const update1: UpdateResponse<User> = {
 
 @category Utilities
 */
-export type ReadonlyKeysOf<T> =
+export type ReadonlyKeysOf<T extends object> =
 	T extends unknown // For distributing `T`
 		? Exclude<keyof T, WritableKeysOf<T>>
 		: never; // Should never happen

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -25,7 +25,7 @@ const update1: UpdateRequest<User> = {
 
 @category Utilities
 */
-export type WritableKeysOf<T> =
+export type WritableKeysOf<T extends object> =
 	T extends unknown // For distributing `T`
 		? (keyof {
 			[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never

--- a/test-d/readonly-keys-of.ts
+++ b/test-d/readonly-keys-of.ts
@@ -85,3 +85,6 @@ type Test9<T extends object> = Assignability9<T, keyof T>;
 type Assignability10<T extends UnknownRecord, _K extends ReadonlyKeysOf<T>> = unknown;
 // @ts-expect-error
 type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;
+
+// @ts-expect-error
+type AllowsOnlyObjects = ReadonlyKeysOf<string>;

--- a/test-d/writable-keys-of.ts
+++ b/test-d/writable-keys-of.ts
@@ -85,3 +85,6 @@ type Test9<T extends object> = Assignability9<T, keyof T>;
 type Assignability10<T extends UnknownRecord, _K extends WritableKeysOf<T>> = unknown;
 // @ts-expect-error
 type Test10<T extends UnknownRecord> = Assignability10<T, keyof T>;
+
+// @ts-expect-error
+type AllowsOnlyObjects = WritableKeysOf<string>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 12 of #450.

<br>

Will have to run through the entire list of types once to see if any other type requires a similar constraint. Like `Require*` family of types should also have an `object` constraint.