### PR TITLE
`Schema`: Remove `undefined` as a valid value for `recurseIntoArrays` option

### DIFF
--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -11,25 +11,22 @@ export type SchemaOptions = {
 	```
 	import type {Schema} from 'type-fest';
 
-	type Form = {
-		id: number;
-		personal: {
-			name: string;
-			email: string;
-		};
-		skills: string[];
+	type Participants = {
+		attendees: string[];
+		speakers: string[];
 	};
 
-	type FormFieldVisibility = Schema<Form, boolean, {recurseIntoArrays: false}>;
+	type ParticipantsWithMetadata = Schema<Participants, {id: number; name: string}, {recurseIntoArrays: true}>;
+	//=> {
+	// 	attendees: Array<{id: number; name: string}>;
+	// 	speakers: Array<{id: number; name: string}>;
+	// };
 
-	const formFieldVisibility: FormFieldVisibility = {
-		id: true,
-		personal: {
-			name: true,
-			email: false,
-		},
-		skills: false,
-	};
+	type ParticipantsCount = Schema<Participants, number, {recurseIntoArrays: false}>;
+	//=> {
+	// 	attendees: number;
+	// 	speakers: number;
+	// };
 	```
 
 	@default true

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -93,19 +93,27 @@ export type SchemaOptions = {
 
 	@example
 	```
-	type UserMask = Schema<User, 'mask' | 'hide' | 'show', {recurseIntoArrays: false}>;
+	import type {Schema} from 'type-fest';
 
-	const userMaskSettings: UserMask = {
-		id: 'show',
-		name: {
-			firstname: 'show',
-			lastname: 'mask',
+	type Form = {
+		id: number;
+		personal: {
+			name: string;
+			email: string;
+		};
+		skills: string[];
+	};
+
+	type FormFieldVisibility = Schema<Form, boolean, {recurseIntoArrays: false}>;
+
+	const formFieldVisibility: FormFieldVisibility = {
+		id: true,
+		personal: {
+			name: true,
+			email: false,
 		},
-		created: 'show',
-		active: 'show',
-		passwordHash: 'hide',
-		attributes: 'hide'
-	}
+		skills: false,
+	};
 	```
 
 	@default true

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,3 +1,5 @@
+import type {ApplyDefaultOptions} from './internal/object.js';
+
 /**
 @see {@link Schema}
 */
@@ -32,6 +34,10 @@ export type SchemaOptions = {
 	@default true
 	*/
 	readonly recurseIntoArrays?: boolean;
+};
+
+type DefaultSchemaOptions = {
+	recurseIntoArrays: true;
 };
 
 /**
@@ -77,7 +83,10 @@ const userMaskSettings: UserMask = {
 
 @category Object
 */
-export type Schema<ObjectType, ValueType, Options extends SchemaOptions = {}> = ObjectType extends string
+export type Schema<ObjectType, ValueType, Options extends SchemaOptions = {}> =
+	_Schema<ObjectType, ValueType, ApplyDefaultOptions<SchemaOptions, DefaultSchemaOptions, Options>>;
+
+type _Schema<ObjectType, ValueType, Options extends Required<SchemaOptions>> = ObjectType extends string
 	? ValueType
 	: ObjectType extends Map<unknown, unknown>
 		? ValueType
@@ -109,7 +118,7 @@ Same as `Schema`, but accepts only `object`s as inputs. Internal helper for `Sch
 type SchemaObject<
 	ObjectType extends object,
 	K,
-	Options extends SchemaOptions,
+	Options extends Required<SchemaOptions>,
 > = {
 	[KeyType in keyof ObjectType]: ObjectType[KeyType] extends
 	| readonly unknown[]

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -97,7 +97,7 @@ type _Schema<ObjectType, ValueType, Options extends Required<SchemaOptions>> = O
 				: ObjectType extends ReadonlySet<unknown>
 					? ValueType
 					: ObjectType extends Array<infer U>
-						? Options['recurseIntoArrays'] extends false | undefined
+						? Options['recurseIntoArrays'] extends false
 							? ValueType
 							: Array<Schema<U, ValueType>>
 						: ObjectType extends (...arguments_: unknown[]) => unknown
@@ -123,7 +123,7 @@ type SchemaObject<
 	[KeyType in keyof ObjectType]: ObjectType[KeyType] extends
 	| readonly unknown[]
 	| unknown[]
-		? Options['recurseIntoArrays'] extends false | undefined
+		? Options['recurseIntoArrays'] extends false
 			? K
 			: Schema<ObjectType[KeyType], K, Options>
 		: Schema<ObjectType[KeyType], K, Options> | K;

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -33,7 +33,7 @@ export type SchemaOptions = {
 
 	@default true
 	*/
-	readonly recurseIntoArrays?: boolean;
+	recurseIntoArrays?: boolean;
 };
 
 type DefaultSchemaOptions = {

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -37,6 +37,8 @@ const userMaskSettings: UserMask = {
 }
 ```
 
+@see {@link SchemaOptions}
+
 @category Object
 */
 export type Schema<ObjectType, ValueType, Options extends SchemaOptions = {}> = ObjectType extends string
@@ -83,7 +85,7 @@ type SchemaObject<
 };
 
 /**
-@see Schema
+@see {@link Schema}
 */
 export type SchemaOptions = {
 	/**

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -34,7 +34,7 @@ export type SchemaOptions = {
 
 	@default true
 	*/
-	readonly recurseIntoArrays?: boolean | undefined;
+	readonly recurseIntoArrays?: boolean;
 };
 
 /**

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,4 +1,43 @@
 /**
+@see {@link Schema}
+*/
+export type SchemaOptions = {
+	/**
+	By default, this affects elements in array and tuple types. You can change this by passing `{recurseIntoArrays: false}` as the third type argument:
+	- If `recurseIntoArrays` is set to `true` (default), array elements will be recursively processed as well.
+	- If `recurseIntoArrays` is set to `false`, arrays will not be recursively processed, and the entire array will be replaced with the given value type.
+
+	@example
+	```
+	import type {Schema} from 'type-fest';
+
+	type Form = {
+		id: number;
+		personal: {
+			name: string;
+			email: string;
+		};
+		skills: string[];
+	};
+
+	type FormFieldVisibility = Schema<Form, boolean, {recurseIntoArrays: false}>;
+
+	const formFieldVisibility: FormFieldVisibility = {
+		id: true,
+		personal: {
+			name: true,
+			email: false,
+		},
+		skills: false,
+	};
+	```
+
+	@default true
+	*/
+	readonly recurseIntoArrays?: boolean | undefined;
+};
+
+/**
 Create a deep version of another object type where property values are recursively replaced into a given value type.
 
 Use-cases:
@@ -82,43 +121,4 @@ type SchemaObject<
 			? K
 			: Schema<ObjectType[KeyType], K, Options>
 		: Schema<ObjectType[KeyType], K, Options> | K;
-};
-
-/**
-@see {@link Schema}
-*/
-export type SchemaOptions = {
-	/**
-	By default, this affects elements in array and tuple types. You can change this by passing `{recurseIntoArrays: false}` as the third type argument:
-	- If `recurseIntoArrays` is set to `true` (default), array elements will be recursively processed as well.
-	- If `recurseIntoArrays` is set to `false`, arrays will not be recursively processed, and the entire array will be replaced with the given value type.
-
-	@example
-	```
-	import type {Schema} from 'type-fest';
-
-	type Form = {
-		id: number;
-		personal: {
-			name: string;
-			email: string;
-		};
-		skills: string[];
-	};
-
-	type FormFieldVisibility = Schema<Form, boolean, {recurseIntoArrays: false}>;
-
-	const formFieldVisibility: FormFieldVisibility = {
-		id: true,
-		personal: {
-			name: true,
-			email: false,
-		},
-		skills: false,
-	};
-	```
-
-	@default true
-	*/
-	readonly recurseIntoArrays?: boolean | undefined;
 };

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -128,7 +128,7 @@ expectType<readonly [ComplexOption]>(complexBarSchema.readonlyTuple);
 expectType<ComplexOption>(complexBarSchema.regExp);
 
 // With Options and `recurseIntoArrays` set to `false`
-type FooSchemaWithOptionsNoRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: false | undefined}>;
+type FooSchemaWithOptionsNoRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: false}>;
 
 const fooSchemaWithOptionsNoRecurse: FooSchemaWithOptionsNoRecurse = {
 	baz: 'A',
@@ -157,7 +157,7 @@ expectNotAssignable<FooSchemaWithOptionsNoRecurse>({key: 'value'});
 expectNotAssignable<FooSchemaWithOptionsNoRecurse>(new Date());
 expectType<FooOption>(fooSchemaWithOptionsNoRecurse.baz);
 
-const barSchemaWithOptionsNoRecurse = fooSchemaWithOptionsNoRecurse.bar as Schema<typeof foo['bar'], FooOption, {recurseIntoArrays: false | undefined}>;
+const barSchemaWithOptionsNoRecurse = fooSchemaWithOptionsNoRecurse.bar as Schema<typeof foo['bar'], FooOption, {recurseIntoArrays: false}>;
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.function);
 expectType<FooOption | {key: FooOption}>(barSchemaWithOptionsNoRecurse.object);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.string);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 11 of #450.

<br>

Also, discovered the following issues with `Schema`:
- Adds extraneous type for nested structures

  ```ts
  type Current = SimplifyDeep<Schema<{foo: {bar: number; baz: number}}, boolean>>;
  //   ^? type Current = {
  //          foo: boolean | {
  //              bar: boolean;
  //              baz: boolean;
  //          };
  //      }
  
  type Ideal = SimplifyDeep<Schema<{foo: {bar: number; baz: number}}, boolean>>;
  //   ^? type Ideal = {
  //          foo: {
  //              bar: boolean;
  //              baz: boolean;
  //          };
  //      }
  ```
  
  Not sure if this is intended, probably not, because I don't see any tests verifying this behaviour.
  
- Doesn't preserve array structures
  ```ts
  type Current = SimplifyDeep<Schema<{foo: [string, string]}, boolean>>;
  //   ^? type Current = {
  //          foo: boolean[];
  //      }
  
  type Ideal = SimplifyDeep<Schema<{foo: [string, string]}, boolean>>;
  //   ^? type Ideal = {
  //          foo: [boolean, boolean];
  //      }
  ```
  
Will create separate PRs for both!