### PR TITLE
`ApplyDefaultOptions`: Remove `strictNullChecks: false` workaround

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -226,11 +226,7 @@ export type ApplyDefaultOptions<
 	IfNever<SpecifiedOptions, Defaults,
 	Simplify<Merge<Defaults, {
 		[Key in keyof SpecifiedOptions
-		as Key extends OptionalKeysOf<Options>
-			? Extract<SpecifiedOptions[Key], undefined> extends never
-				? Key
-				: never
-			: Key
+		as Key extends OptionalKeysOf<Options> ? undefined extends SpecifiedOptions[Key] ? never : Key : Key
 		]: SpecifiedOptions[Key]
 	}> & Required<Options>> // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
 	>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 14 of #450.

> [!NOTE]
> This means that none of the types that have options would work properly if `strictNullChecks` is disabled.

@sindresorhus If you feel this is too much, we can skip this change—the workaround isn't that bad.