### PR TITLE
`SetRequired` / `SetOptional` / `SetReadonly`: Fix behaviour with functions containing properties

### DIFF
--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -28,6 +28,12 @@ type SomeOptional = SetOptional<Foo, 'b' | 'c'>;
 @category Object
 */
 export type SetOptional<BaseType, Keys extends keyof BaseType> =
+	(BaseType extends (...arguments_: never) => any
+		? (...arguments_: Parameters<BaseType>) => ReturnType<BaseType>
+		: unknown)
+	& _SetOptional<BaseType, Keys>;
+
+type _SetOptional<BaseType, Keys extends keyof BaseType> =
 	BaseType extends unknown // To distribute `BaseType` when it's a union type.
 		? Simplify<
 		// Pick just the keys that are readonly from the base type.

--- a/source/set-readonly.d.ts
+++ b/source/set-readonly.d.ts
@@ -28,10 +28,13 @@ type SomeReadonly = SetReadonly<Foo, 'b' | 'c'>;
 @category Object
 */
 export type SetReadonly<BaseType, Keys extends keyof BaseType> =
-	// `extends unknown` is always going to be the case and is used to convert any
-	// union into a [distributive conditional
-	// type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
-	BaseType extends unknown
+	(BaseType extends (...arguments_: never) => any
+		? (...arguments_: Parameters<BaseType>) => ReturnType<BaseType>
+		: unknown)
+	& _SetReadonly<BaseType, Keys>;
+
+export type _SetReadonly<BaseType, Keys extends keyof BaseType> =
+	BaseType extends unknown // To distribute `BaseType` when it's a union type.
 		? Simplify<
 		Except<BaseType, Keys> &
 		Readonly<HomomorphicPick<BaseType, Keys>>

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -35,6 +35,12 @@ type ArrayExample = SetRequired<[number?, number?, number?], 0 | 1>;
 @category Object
 */
 export type SetRequired<BaseType, Keys extends keyof BaseType> =
+	(BaseType extends (...arguments_: never) => any
+		? (...arguments_: Parameters<BaseType>) => ReturnType<BaseType>
+		: unknown)
+	& _SetRequired<BaseType, Keys>;
+
+type _SetRequired<BaseType, Keys extends keyof BaseType> =
 	BaseType extends UnknownArray
 		? SetArrayRequired<BaseType, Keys> extends infer ResultantArray
 			? If<IsArrayReadonly<BaseType>, Readonly<ResultantArray>, ResultantArray>

--- a/test-d/set-optional.ts
+++ b/test-d/set-optional.ts
@@ -1,5 +1,5 @@
 import {expectNotAssignable, expectType} from 'tsd';
-import type {SetOptional} from '../index.d.ts';
+import type {SetOptional, Simplify} from '../index.d.ts';
 
 // Update one required and one optional to optional.
 declare const variation1: SetOptional<{a: number; b?: string; c: boolean}, 'b' | 'c'>;
@@ -36,3 +36,16 @@ expectType<{a?: number; readonly b?: string; readonly c: boolean}>(variation8);
 // Works with index signatures
 declare const variation9: SetOptional<{[k: string]: unknown; a: number; b?: string}, 'a' | 'b'>;
 expectType<{[k: string]: unknown; a?: number; b?: string}>(variation9);
+
+// Works with functions containing properties
+declare const variation10: SetOptional<{(a1: string, a2: number): boolean; p1: string; readonly p2?: number}, 'p1'>;
+expectType<boolean>(variation10('foo', 1));
+expectType<{p1?: string; readonly p2?: number}>({} as Simplify<typeof variation10>); // `Simplify` removes the call signature from `typeof variation10`
+
+declare const variation11: SetOptional<{(a1: boolean, ...a2: string[]): number; p1: string; readonly p2: number; p3: boolean}, 'p1' | 'p2'>;
+expectType<number>(variation11(true, 'foo', 'bar', 'baz'));
+expectType<{p1?: string; readonly p2?: number; p3: boolean}>({} as Simplify<typeof variation11>);
+
+// Functions without properties are returned as is
+declare const variation12: SetOptional<(a: string) => number, never>;
+expectType<number>(variation12('foo'));

--- a/test-d/set-readonly.ts
+++ b/test-d/set-readonly.ts
@@ -1,5 +1,5 @@
 import {expectNotAssignable, expectType} from 'tsd';
-import type {SetReadonly} from '../index.d.ts';
+import type {SetReadonly, Simplify} from '../index.d.ts';
 
 // Update one readonly and one non readonly to readonly.
 declare const variation1: SetReadonly<{a: number; readonly b: string; c: boolean}, 'b' | 'c'>;
@@ -36,3 +36,16 @@ expectType<{a: number; readonly b: string; readonly c: boolean}>(variation8);
 // Works with index signatures
 declare const variation9: SetReadonly<{[k: string]: unknown; a: number; readonly b: string}, 'a' | 'b'>;
 expectType<{[k: string]: unknown; readonly a: number; readonly b: string}>(variation9);
+
+// Works with functions containing properties
+declare const variation10: SetReadonly<{(a1: string, a2: number): boolean; p1: string; readonly p2?: number}, 'p1'>;
+expectType<boolean>(variation10('foo', 1));
+expectType<{readonly p1: string; readonly p2?: number}>({} as Simplify<typeof variation10>); // Simplify removes the call signature from `typeof variation10`
+
+declare const variation11: SetReadonly<{(a1: boolean, ...a2: string[]): number; p1: string; p2?: number; p3: boolean}, 'p1' | 'p2'>;
+expectType<number>(variation11(true, 'foo', 'bar', 'baz'));
+expectType<{readonly p1: string; readonly p2?: number; p3: boolean}>({} as Simplify<typeof variation11>);
+
+// Functions without properties are returned as is
+declare const variation12: SetReadonly<(a: string) => number, never>;
+expectType<number>(variation12('foo'));

--- a/test-d/set-required.ts
+++ b/test-d/set-required.ts
@@ -1,5 +1,5 @@
 import {expectNotAssignable, expectType} from 'tsd';
-import type {SetRequired} from '../index.d.ts';
+import type {SetRequired, Simplify} from '../index.d.ts';
 
 // Update one required and one optional to required.
 declare const variation1: SetRequired<{a?: number; b: string; c?: boolean}, 'b' | 'c'>;
@@ -40,6 +40,19 @@ expectType<{a?: number; readonly b?: string; readonly c: boolean}>(variation9);
 // Works with index signatures
 declare const variation10: SetRequired<{[k: string]: unknown; a?: number; b: string}, 'a' | 'b'>;
 expectType<{[k: string]: unknown; a: number; b: string}>(variation10);
+
+// Works with functions containing properties
+declare const variation11: SetRequired<{(a1: string, a2: number): boolean; p1?: string; readonly p2: number}, 'p1'>;
+expectType<boolean>(variation11('foo', 1));
+expectType<{p1: string; readonly p2: number}>({} as Simplify<typeof variation11>);
+
+declare const variation12: SetRequired<{(a1: boolean, ...a2: string[]): number; p1?: string; readonly p2?: number; p3?: boolean}, 'p1' | 'p2'>;
+expectType<number>(variation12(true, 'foo', 'bar', 'baz'));
+expectType<{p1: string; readonly p2: number; p3?: boolean}>({} as Simplify<typeof variation12>);
+
+// Functions without properties are returned as is
+declare const variation13: SetRequired<(a: string) => number, never>;
+expectType<number>(variation13('foo'));
 
 // =================
 // Works with arrays


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Similar to #1108, this PR fixes behaviour of `SetRequired`, `SetOptional` and `SetReadonly` types when instantiated with functions containing properties.

```ts
type Current = SetRequired<{ (x: string): number; p1?: number; p2: number }, 'p1'>; // The call signature gets lost
//   ^? type Current = { p2: number; p1: number; }

type Updated = SetRequired<{ (x: string): number; p1?: number; p2: number }, 'p1'>; // The call signature is preserved
//   ^? type Updated = { (x: string): number; p2: number; p1: number; }  
```

Functions w/o properties are now returned as is, instead of being returned as an empty object.
```ts
type Current = SetRequired<(x: string): number, never>;
//   ^? type Current = {}

type Updated = SetRequired<(x: string): number, never>;
//   ^? type Updated = (x: string): number
```

<br>

Points to discuss:
1. Should these types have a constraint of `object` on their first type argument, like:
    ```diff
    - type SetReadonly<BaseType, Keys extends keyof BaseType>
    + type SetReadonly<BaseType extends object, Keys extends keyof BaseType>
    ```

2. Also, there's no `SetWritable` type, it's actually called just `Writable`. IMO, we should rename it to `SetWritable`, and drop support for second type argument from `Writable`. This would make it more consistent with built-in utility types like `Partial`, `Readonly`, and `Required`, which also don’t take a second type argument.

    ```ts
    type Writable<BaseType> = SetWritable<BaseType, any>
    ```