### PR TITLE
`IsStringLiteral`: Fix behaviour with tagged types

### DIFF
--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,8 +1,8 @@
 import type {Primitive} from './primitive.d.ts';
 import type {Numeric} from './numeric.d.ts';
-import type {IsNotFalse, IsPrimitive} from './internal/index.d.ts';
+import type {IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
-import type {If} from './if.js';
+import type {TagContainer, UnwrapTagged} from './tagged.js';
 
 /**
 Returns a boolean for whether the given type `T` is the specified `LiteralType`.
@@ -114,14 +114,18 @@ type L2 = Length<`${number}`>;
 @category Type Guard
 @category Utilities
 */
-export type IsStringLiteral<T> = If<IsNever<T>, false,
+export type IsStringLiteral<S> = IfNotAnyOrNever<S,
+_IsStringLiteral<S extends TagContainer<any> ? UnwrapTagged<S> : S>,
+false, false>;
+
+export type _IsStringLiteral<S> =
 // If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
 // and since `{}` extends index signatures, the result becomes `false`.
-T extends string
-	? {} extends Record<T, never>
+S extends string
+	? {} extends Record<S, never>
 		? false
 		: true
-	: false>;
+	: false;
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -6,6 +6,7 @@ import type {
 	IsBooleanLiteral,
 	IsSymbolLiteral,
 	Tagged,
+	LiteralUnion,
 } from '../index.d.ts';
 
 const stringLiteral = '';
@@ -78,6 +79,14 @@ expectType<IsStringLiteral<Lowercase<'xyz'> | Capitalize<'abc'>>>(true);
 expectType<IsStringLiteral<Uppercase<string> | 'abc'>>({} as boolean);
 expectType<IsStringLiteral<Lowercase<string> | 'Abc'>>({} as boolean);
 expectType<IsStringLiteral<null | '1' | '2' | '3'>>({} as boolean);
+expectType<IsStringLiteral<1 | 2 | '3'>>({} as boolean);
+expectType<IsStringLiteral<'foo' | 'bar' | number>>({} as boolean);
+
+// Types other than string return `false`
+expectType<IsStringLiteral<bigint>>(false);
+expectType<IsStringLiteral<1 | 2 | 3>>(false);
+expectType<IsStringLiteral<object>>(false);
+expectType<IsStringLiteral<false | undefined | null>>(false);
 
 // Boundary types
 expectType<IsStringLiteral<any>>(false);
@@ -106,7 +115,18 @@ type A3 = IsBooleanLiteral;
 // @ts-expect-error
 type A4 = IsSymbolLiteral;
 
-// Tagged types should be false
+// Tagged types
 expectType<IsStringLiteral<Tagged<string, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<Uppercase<string>, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<number, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'>>>(true);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar' | `on${string}`, 'Tag'>>>({} as boolean);
+expectType<IsStringLiteral<Tagged<'1st' | '2nd' | '3rd' | number, 'Tag'>>>({} as boolean);
+
+expectType<IsStringLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<'foo', 'Tag'> | Tagged<'bar', 'Tag'>>>(true);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | Tagged<number, 'Tag'>>>({} as boolean);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | number>>({} as boolean);
+
 expectType<IsNumericLiteral<Tagged<number, 'Tag'>>>(false);
 expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'>>>(false);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

`IsStringLiteral` currently always returns `false` when instantiated with tagged types. This PR fixes this behaviour, ensuring that `IsStringLiteral` computes its result after unwrapping tagged types.

```ts
type Current = IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'>>;
//   ^? type Current = false

type Updated = IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'>>;
//   ^? type Updated = true
```

```ts
type Current = IsStringLiteral<Tagged<'1st' | '2nd' | '3rd' | number, 'Tag'>>;
//   ^? type Current = false

type Updated = IsStringLiteral<Tagged<'1st' | '2nd' | '3rd' | number, 'Tag'>>;
//   ^? type Updated = boolean
```

<hr>

Behaviour with types like `"foo" | "bar" | (string & {})` is also incorrect. Currently, `IsStringLiteral<"foo" | "bar" | (string & {})>` returns `boolean`, it should instead return `false`, because `"foo" | "bar" | (string & {})` is technically just `string`. 

This would also align the behaviour with `IsNumericLiteral`, which correctly returns `false` for `IsNumericLiteral<1 | 2 | (number & {})>`. I'll create a follow-up PR for this. 