### PR TITLE
`IsStringLiteral`: Fix behaviour with uncollapsed unions like `"foo" | "bar" | (string & {})`

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -231,3 +231,36 @@ export type ApplyDefaultOptions<
 		]: SpecifiedOptions[Key]
 	}> & Required<Options>> // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
 	>>;
+
+/**
+Collapses literal types in a union into their corresponding primitive types, when possible. For example, `CollapseLiterals<'foo' | 'bar' | (string & {})>` returns `string`.
+
+Note: This doesn't collapse literals within tagged types. For example, `CollapseLiterals<Tagged<'foo' | (string & {}), 'Tag'>>` returns `("foo" & Tag<"Tag", never>) | (string & Tag<"Tag", never>)` and not `string & Tag<"Tag", never>`.
+
+Use-case: For collapsing unions created using {@link LiteralUnion}.
+
+@example
+```
+import type {LiteralUnion} from 'type-fest';
+
+type A = CollapseLiterals<'foo' | 'bar' | (string & {})>;
+//=> string
+
+type B = CollapseLiterals<LiteralUnion<1 | 2 | 3, number>>;
+//=> number
+
+type C = CollapseLiterals<LiteralUnion<'onClick' | 'onChange', `on${string}`>>;
+//=> `on${string}`
+
+type D = CollapseLiterals<'click' | 'change' | (`on${string}` & {})>;
+//=> 'click' | 'change' | `on${string}`
+
+type E = CollapseLiterals<LiteralUnion<'foo' | 'bar', string> | null | undefined>;
+//=> string | null | undefined
+```
+*/
+export type CollapseLiterals<T> = {} extends T
+	? T
+	: T extends infer U & {}
+		? U
+		: T;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,6 +1,6 @@
 import type {Primitive} from './primitive.d.ts';
 import type {Numeric} from './numeric.d.ts';
-import type {IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
+import type {CollapseLiterals, IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.js';
 
@@ -115,7 +115,7 @@ type L2 = Length<`${number}`>;
 @category Utilities
 */
 export type IsStringLiteral<S> = IfNotAnyOrNever<S,
-_IsStringLiteral<S extends TagContainer<any> ? UnwrapTagged<S> : S>,
+_IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>,
 false, false>;
 
 export type _IsStringLiteral<S> =

--- a/test-d/internal/collapse-literals-in-union.ts
+++ b/test-d/internal/collapse-literals-in-union.ts
@@ -1,0 +1,37 @@
+import {expectType} from 'tsd';
+import type {CollapseLiterals} from '../../source/internal/object.js';
+
+declare const sym1: unique symbol;
+declare const sym2: unique symbol;
+
+// Uncollapsed unions
+expectType<string>({} as CollapseLiterals<'foo' | 'bar' | (string & {})>);
+expectType<number>({} as CollapseLiterals<1 | 2 | (number & {})>);
+expectType<symbol>({} as CollapseLiterals<typeof sym1 | typeof sym2 | (symbol & {})>);
+expectType<bigint>({} as CollapseLiterals<1n | 2n | (bigint & {})>);
+expectType<`on${string}`>({} as CollapseLiterals<'onChange' | 'onClick' | (`on${string}` & {})>);
+expectType<'change' | 'click' | `on${string}`>({} as CollapseLiterals<'change' | 'click' | (`on${string}` & {})>);
+expectType<'drag' | `on${string}`>({} as CollapseLiterals<'drag' | 'onChange' | 'onClick' | (`on${string}` & {})>);
+
+expectType<null | undefined | string>({} as CollapseLiterals<null | undefined | 'foo' | 'bar' | (string & {})>);
+expectType<'foo' | Uppercase<string> | number>({} as CollapseLiterals<'foo' | 'BAR' | (Uppercase<string> & {}) | number>);
+expectType<typeof sym1 | 'foo' | 'bar' | number>({} as CollapseLiterals<typeof sym1 | 'foo' | 'bar' | (number & {})>);
+
+// Already collapsed unions are returned as-is
+expectType<string>({} as CollapseLiterals<string>);
+expectType<bigint>({} as CollapseLiterals<bigint>);
+expectType<false>({} as CollapseLiterals<false>);
+expectType<number | bigint>({} as CollapseLiterals<number | bigint>);
+expectType<null | undefined>({} as any as CollapseLiterals<null | undefined>);
+expectType<'foo' | 'bar'>({} as CollapseLiterals<'foo' | 'bar'>);
+expectType<string | number | boolean>({} as CollapseLiterals<string | number | boolean>);
+expectType<unknown>({} as CollapseLiterals<unknown>);
+expectType<string[] | [string, string]>({} as CollapseLiterals<string[] | [string, string]>);
+expectType<Record<string, string> | {a: string; b: number}>(
+	{} as CollapseLiterals<Record<string, string> | {a: string; b: number}>,
+);
+
+// Boundary types
+expectType<{}>({} as CollapseLiterals<{}>);
+expectType<never>({} as CollapseLiterals<never>);
+expectType<any>({} as CollapseLiterals<any>);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -89,6 +89,7 @@ expectType<IsStringLiteral<object>>(false);
 expectType<IsStringLiteral<false | undefined | null>>(false);
 
 // Boundary types
+expectType<IsStringLiteral<{}>>(false);
 expectType<IsStringLiteral<any>>(false);
 expectType<IsStringLiteral<never>>(false);
 
@@ -127,6 +128,15 @@ expectType<IsStringLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false
 expectType<IsStringLiteral<Tagged<'foo', 'Tag'> | Tagged<'bar', 'Tag'>>>(true);
 expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | Tagged<number, 'Tag'>>>({} as boolean);
 expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | number>>({} as boolean);
+
+// Uncollapsed unions (e.g., `'foo' | 'bar' | (string & {})`)
+expectType<IsStringLiteral<'foo' | 'bar' | (string & {})>>(false);
+expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', string>>>(false);
+expectType<IsStringLiteral<LiteralUnion<'onClick' | 'onMouseDown', `on${string}`>>>(false);
+expectType<IsStringLiteral<LiteralUnion<'press' | 'onClick' | 'onMouseDown', `on${string}`>>>({} as boolean);
+expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', number>>>({} as boolean);
+expectType<IsStringLiteral<Tagged<LiteralUnion<'foo' | 'bar', string>, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<LiteralUnion<'click' | 'onMouseDown', `on${string}`>, 'Tag'>>>({} as boolean);
 
 expectType<IsNumericLiteral<Tagged<number, 'Tag'>>>(false);
 expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'>>>(false);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

> Behaviour with types like `"foo" | "bar" | (string & {})` is also incorrect. Currently, `IsStringLiteral<"foo" | "bar" | (string & {})>` returns `boolean`, it should instead return `false`, because `"foo" | "bar" | (string & {})` is technically just `string`.
> 
> This would also align the behaviour with `IsNumericLiteral`, which correctly returns `false` for `IsNumericLiteral<1 | 2 | (number & {})>`. I'll create a follow-up PR for this.

Fixes behaviour of `IsStringLiteral` as mentioned in #1147. So, uncollapsed unions are now first collapsed, and then the literalness is calculated.
