### PR TITLE
Add `AndAll` and `OrAll` types

### DIFF
--- a/source/and.d.ts
+++ b/source/and.d.ts
@@ -1,5 +1,5 @@
 import type {IsTrue} from './internal/type.d.ts';
-import type {Includes} from'./includes.d.ts';
+import type {Includes} from './includes.d.ts';
 import type {IsAny} from './is-any.d.ts';
 
 /**
@@ -27,7 +27,7 @@ And<false, boolean>;
 
 @see Or, AndAll
 */
-export type And<A extends boolean, B extends boolean> = AndAll<[A, B]>
+export type And<A extends boolean, B extends boolean> = AndAll<[A, B]>;
 
 /**
 Returns a boolean for whether All given types are true.
@@ -62,4 +62,4 @@ export type AndAll<T extends boolean[]> = (
 				? false
 				: never
 		: never
-) 
+);

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -121,4 +121,4 @@ export type IfNotAnyOrNever<T, IfNotAnyOrNever, IfAny = any, IfNever = never> =
 /**
 Determines if a type is either `never` or `any`.
 */
-export type IsAnyOrNever<T> = Or<IsAny<T>, IsNever<T>>
+export type IsAnyOrNever<T> = Or<IsAny<T>, IsNever<T>>;

--- a/source/or.d.ts
+++ b/source/or.d.ts
@@ -27,7 +27,7 @@ Or<false, booelan>;
 
 @see And, OrAll
 */
-export type Or<A extends boolean, B extends boolean> = OrAll<[A, B]>
+export type Or<A extends boolean, B extends boolean> = OrAll<[A, B]>;
 
 /**
 Returns a boolean for whether either of All given types are true.
@@ -62,4 +62,4 @@ export type OrAll<T extends boolean[]> = (
 				? true
 				: never
 		: never
-)
+);

--- a/test-d/and.ts
+++ b/test-d/and.ts
@@ -1,5 +1,5 @@
-import { expectType } from 'tsd';
-import type { And, AndAll } from '../source/and.d.ts';
+import {expectType} from 'tsd';
+import type {And, AndAll} from '../source/and.d.ts';
 
 declare const never: never;
 
@@ -21,33 +21,33 @@ expectType<And<true, never>>(true);
 expectType<And<never, never>>(never);
 
 // AndAll
-expectType<AndAll<[true, true, true]>>(true)
-expectType<AndAll<[false, true, true,]>>(false)
-expectType<AndAll<[false, false, true,]>>(false)
-expectType<AndAll<[false, false, false,]>>(false)
-expectType<AndAll<[true, false, false,]>>(false)
-expectType<AndAll<[true, true, false,]>>(false)
+expectType<AndAll<[true, true, true]>>(true);
+expectType<AndAll<[false, true, true]>>(false);
+expectType<AndAll<[false, false, true]>>(false);
+expectType<AndAll<[false, false, false]>>(false);
+expectType<AndAll<[true, false, false]>>(false);
+expectType<AndAll<[true, true, false]>>(false);
 
 // @ts-expect-error
-expectType<And<>>({} as any)
-expectType<AndAll<[]>>(never)
-expectType<And<never, any>>(never)
-expectType<And<any, any>>(never)
+expectType<And>({} as any);
+expectType<AndAll<[]>>(never);
+expectType<And<never, any>>(never);
+expectType<And<any, any>>(never);
 
 // Single value
-expectType<AndAll<[true]>>(true)
-expectType<AndAll<[false]>>(false)
-expectType<AndAll<[boolean]>>(never)
-expectType<AndAll<[never]>>(never)
-expectType<AndAll<[any]>>(never)
+expectType<AndAll<[true]>>(true);
+expectType<AndAll<[false]>>(false);
+expectType<AndAll<[boolean]>>(never);
+expectType<AndAll<[never]>>(never);
+expectType<AndAll<[any]>>(never);
 
 // Test if boolean is position dependent
-expectType<AndAll<[boolean, true, true, true]>>(never)
-expectType<AndAll<[true, boolean, true, true]>>(never)
-expectType<AndAll<[true, true, boolean, true]>>(never)
-expectType<AndAll<[true, true, true, boolean]>>(never)
+expectType<AndAll<[boolean, true, true, true]>>(never);
+expectType<AndAll<[true, boolean, true, true]>>(never);
+expectType<AndAll<[true, true, boolean, true]>>(never);
+expectType<AndAll<[true, true, true, boolean]>>(never);
 
-expectType<AndAll<[boolean, false, false, false]>>(false)
-expectType<AndAll<[false, boolean, false, false]>>(false)
-expectType<AndAll<[false, false, boolean, false]>>(false)
-expectType<AndAll<[false, false, false, boolean]>>(false)
+expectType<AndAll<[boolean, false, false, false]>>(false);
+expectType<AndAll<[false, boolean, false, false]>>(false);
+expectType<AndAll<[false, false, boolean, false]>>(false);
+expectType<AndAll<[false, false, false, boolean]>>(false);

--- a/test-d/or.ts
+++ b/test-d/or.ts
@@ -1,5 +1,5 @@
-import { expectType } from 'tsd';
-import type { Or, OrAll } from '../source/or.d.ts';
+import {expectType} from 'tsd';
+import type {Or, OrAll} from '../source/or.d.ts';
 
 declare const never: never;
 
@@ -21,33 +21,33 @@ expectType<Or<true, never>>(true);
 expectType<Or<never, never>>(never);
 
 // OrAll
-expectType<OrAll<[true, true, true]>>(true)
-expectType<OrAll<[false, true, true]>>(true)
-expectType<OrAll<[false, false, true]>>(true)
-expectType<OrAll<[false, false, false]>>(false)
-expectType<OrAll<[true, false, false]>>(true)
-expectType<OrAll<[true, true, false]>>(true)
+expectType<OrAll<[true, true, true]>>(true);
+expectType<OrAll<[false, true, true]>>(true);
+expectType<OrAll<[false, false, true]>>(true);
+expectType<OrAll<[false, false, false]>>(false);
+expectType<OrAll<[true, false, false]>>(true);
+expectType<OrAll<[true, true, false]>>(true);
 
 // @ts-expect-error
-expectType<Or<>>({} as any)
-expectType<OrAll<[]>>(never)
-expectType<Or<never, any>>(never)
-expectType<Or<any, any>>(never)
+expectType<Or>({} as any);
+expectType<OrAll<[]>>(never);
+expectType<Or<never, any>>(never);
+expectType<Or<any, any>>(never);
 
 // Single value
-expectType<OrAll<[true]>>(true)
-expectType<OrAll<[false]>>(false)
-expectType<OrAll<[boolean]>>(never)
-expectType<OrAll<[never]>>(never)
-expectType<OrAll<[any]>>(never)
+expectType<OrAll<[true]>>(true);
+expectType<OrAll<[false]>>(false);
+expectType<OrAll<[boolean]>>(never);
+expectType<OrAll<[never]>>(never);
+expectType<OrAll<[any]>>(never);
 
 // Test if boolean is position dependent
-expectType<OrAll<[boolean, true, true, true]>>(true)
-expectType<OrAll<[true, boolean, true, true]>>(true)
-expectType<OrAll<[true, true, boolean, true]>>(true)
-expectType<OrAll<[true, true, true, boolean]>>(true)
+expectType<OrAll<[boolean, true, true, true]>>(true);
+expectType<OrAll<[true, boolean, true, true]>>(true);
+expectType<OrAll<[true, true, boolean, true]>>(true);
+expectType<OrAll<[true, true, true, boolean]>>(true);
 
-expectType<OrAll<[boolean, false, false, false]>>(never)
-expectType<OrAll<[false, boolean, false, false]>>(never)
-expectType<OrAll<[false, false, boolean, false]>>(never)
-expectType<OrAll<[false, false, false, boolean]>>(never)
+expectType<OrAll<[boolean, false, false, false]>>(never);
+expectType<OrAll<[false, boolean, false, false]>>(never);
+expectType<OrAll<[false, false, boolean, false]>>(never);
+expectType<OrAll<[false, false, false, boolean]>>(never);


### PR DESCRIPTION
 **External**:
 - Adding `AndAll` Returns a boolean for whether All given types are true.
 - Adding `OrAll` Returns a boolean for whether either of All given types are true.
 - Changing: `And<A, B>`, `Or<A, B>` to use `AndAll<[A, B]>`, `OrAll<[A, B]>`.

 **Internal**:
 - Adding `IsTrue` Check if all value in giving union are true,
 - Adding `IsFalse` Check if all value in giving union are false,
 - Adding `IsAnyOrNever` Check if a value Any or Never,
 - Adding `Extends` Check if value A extends value B,

> [!NOTE]
> `Xor`, `XorAll`: depends on #1155
