### PR TITLE
`Every`: Fix behaviour when the target type is `never`

### DIFF
--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,4 +1,5 @@
 import type {If} from '../if.d.ts';
+import type {IsAny} from '../is-any.d.ts';
 import type {IsNever} from '../is-never.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
 
@@ -99,7 +100,7 @@ Returns a boolean for whether every element in an array type extends another typ
 
 Note:
 - This type is not designed to be used with non-tuple arrays (like `number[]`), tuples with optional elements (like `[1?, 2?, 3?]`), or tuples that contain a rest element (like `[1, 2, ...number[]]`).
-- The `never` type does not match the target type unless the target type itself is `never`. For example, `Every<[never, never], never>` returns `true`, but `Every<[never, number], number>` returns `false`.
+- The `never` type does not match the target type unless the target type is `never` or `any`. For example, `Every<[never, never], never>` returns `true`, but `Every<[never, number], number>` returns `false`.
 
 @example
 ```
@@ -118,10 +119,12 @@ type D = Every<[true, boolean, true], true>;
 //=> boolean
 ```
 */
-export type Every<TArray extends UnknownArray, Type> = TArray extends readonly [infer First, ...infer Rest]
+export type Every<TArray extends UnknownArray, Type> = If<IsAny<Type>, true, TArray extends readonly [infer First, ...infer Rest]
 	? IsNever<First> extends true
-		? IsNever<Type>
+		? IsNever<Type> extends true
+			? Every<Rest, Type>
+			: false
 		: First extends Type
 			? Every<Rest, Type>
 			: false
-	: true;
+	: true>;

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -2,6 +2,7 @@ import type {If} from '../if.d.ts';
 import type {IsAny} from '../is-any.d.ts';
 import type {IsNever} from '../is-never.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
+import type {IfNotAnyOrNever} from './type.d.ts';
 
 /**
 Infer the length of the given array `<T>`.
@@ -119,12 +120,14 @@ type D = Every<[true, boolean, true], true>;
 //=> boolean
 ```
 */
-export type Every<TArray extends UnknownArray, Type> = If<IsAny<Type>, true, TArray extends readonly [infer First, ...infer Rest]
-	? IsNever<First> extends true
-		? IsNever<Type> extends true
-			? Every<Rest, Type>
-			: false
-		: First extends Type
-			? Every<Rest, Type>
-			: false
-	: true>;
+export type Every<TArray extends UnknownArray, Type> = IfNotAnyOrNever<TArray, If<IsAny<Type>, true,
+	TArray extends readonly [infer First, ...infer Rest]
+		? IsNever<First> extends true
+			? IsNever<Type> extends true
+				? Every<Rest, Type>
+				: false
+			: First extends Type
+				? Every<Rest, Type>
+				: false
+		: true
+>, false, false>;

--- a/test-d/internal/every.ts
+++ b/test-d/internal/every.ts
@@ -44,3 +44,6 @@ expectType<Every<[never, number, never, any, never], never>>(false);
 expectType<Every<[never, any, never, any], never>>({} as boolean);
 expectType<Every<[1, 2, any], number>>({} as boolean);
 expectType<Every<[1, 2, never], number>>(false);
+
+expectType<Every<any, never>>(false);
+expectType<Every<never, any>>(false);

--- a/test-d/internal/every.ts
+++ b/test-d/internal/every.ts
@@ -33,9 +33,14 @@ expectType<Every<[true, false] | [true, boolean], true>>({} as boolean); // One 
 // Boundary cases
 expectType<Every<[], any>>(true);
 expectType<Every<[], never>>(true);
-expectType<Every<[1, 2, '3', true, false, string[]], any>>(true);
+expectType<Every<[1, 2, '3', true, false, string[], never], any>>(true);
 expectType<Every<[any, any], any>>(true);
+expectType<Every<[never, never], any>>(true);
 expectType<Every<[1, 2], never>>(false);
 expectType<Every<[never, never], never>>(true);
+expectType<Every<[never, never, number], never>>(false);
+expectType<Every<[number, never, never], never>>(false);
+expectType<Every<[never, number, never, any, never], never>>(false);
+expectType<Every<[never, any, never, any], never>>({} as boolean);
 expectType<Every<[1, 2, any], number>>({} as boolean);
 expectType<Every<[1, 2, never], number>>(false);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Just realised that there's a bug with `Every`, if the target type is `never`, it doesn't check if _all_ elements are `never`—it only checks the first one and returns a result. For example, currently `Every<[never, number]>` incorrectly returns `true`.

