### PR TITLE
Add custom lint rule to ensure import paths end with `.d.ts` extension

### DIFF
--- a/lint-rules/import-path.js
+++ b/lint-rules/import-path.js
@@ -1,0 +1,52 @@
+import path from 'node:path';
+
+export const importPathRule = /** @type {const} */ ({
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Enforces import paths to end with a \'.d.ts\' extension.',
+		},
+		fixable: 'code',
+		messages: {
+			incorrectImportPath:
+                'Import path \'{{importPath}}\' must end with a \'.d.ts\' extension. Use \'{{fixedImportPath}}\' instead.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		return {
+			ImportDeclaration(node) {
+				const importPath = node.source.value;
+
+				// Skip if not relative path
+				if (!(importPath.startsWith('./') || importPath.startsWith('../'))) {
+					return;
+				}
+
+				const filename = path.basename(importPath);
+				const firstDotIndex = filename.indexOf('.');
+				const extension = firstDotIndex === -1 ? '' : filename.slice(firstDotIndex);
+
+				// Skip if the import path already ends with `.d.ts`
+				if (extension === '.d.ts') {
+					return;
+				}
+
+				const importPathWithoutExtension = extension.length > 0
+					? importPath.slice(0, -extension.length)
+					: importPath;
+				const fixedImportPath = `${importPathWithoutExtension}.d.ts`;
+
+				context.report({
+					node: node.source,
+					messageId: 'incorrectImportPath',
+					fix(fixer) {
+						return fixer.replaceText(node.source, `'${fixedImportPath}'`);
+					},
+					data: {importPath, fixedImportPath},
+				});
+			},
+		};
+	},
+});

--- a/package.json
+++ b/package.json
@@ -58,75 +58,8 @@
 		"npm-run-all2": "^8.0.1",
 		"tsd": "^0.32.0",
 		"typescript": "~5.8.3",
-		"xo": "^1.0.0"
+		"xo": "^1.0.5"
 	},
-	"xo": [
-		{
-			"rules": {
-				"@typescript-eslint/no-extraneous-class": "off",
-				"@typescript-eslint/ban-ts-comment": "off",
-				"@typescript-eslint/ban-types": "off",
-				"@typescript-eslint/naming-convention": "off",
-				"@typescript-eslint/no-redeclare": "off",
-				"@typescript-eslint/no-confusing-void-expression": "off",
-				"@typescript-eslint/no-unsafe-argument": "off",
-				"@typescript-eslint/no-restricted-types": "off",
-				"@typescript-eslint/no-empty-object-type": "off",
-				"@typescript-eslint/no-unsafe-function-type": "off",
-				"@typescript-eslint/no-deprecated": "off",
-				"@typescript-eslint/no-wrapper-object-types": "off",
-				"@typescript-eslint/consistent-indexed-object-style": "off",
-				"@stylistic/quote-props": "off",
-				"@stylistic/function-paren-newline": "off",
-				"@stylistic/object-curly-newline": "off",
-				"n/file-extension-in-import": "off",
-				"object-curly-newline": [
-					"error",
-					{
-						"multiline": true,
-						"consistent": true
-					}
-				],
-				"import-x/consistent-type-specifier-style": [
-					"error",
-					"prefer-top-level"
-				]
-			}
-		},
-		{
-			"files": "source/**/*.d.ts",
-			"rules": {
-				"no-restricted-imports": [
-					"error",
-					{
-						"paths": ["tsd", "expect-type"],
-						"patterns": [
-							{
-								"group": ["*.js", "*.ts", "!*.d.ts"],
-								"message": "Use `.d.ts` extension."
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"files": "test-d/**/*.ts",
-			"rules": {
-				"no-restricted-imports": [
-					"error",
-					{
-						"patterns": [
-							{
-								"group": ["*.js", "*.ts", "!*.d.ts"],
-								"message": "Use `.d.ts` extension."
-							}
-						]
-					}
-				]
-			}
-		}
-	],
 	"tsd": {
 		"compilerOptions": {
 			"noUnusedLocals": false

--- a/source/pick-deep.d.ts
+++ b/source/pick-deep.d.ts
@@ -1,8 +1,8 @@
 import type {BuildObject, BuildTuple, NonRecursiveType, ObjectValue} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {Paths} from './paths.d.ts';
-import type {Simplify} from './simplify.d.d.ts';
-import type {UnionToIntersection} from './union-to-intersection.d.d.ts';
+import type {Simplify} from './simplify.d.ts';
+import type {UnionToIntersection} from './union-to-intersection.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
 /**

--- a/test-d/internal/is-number-like.ts
+++ b/test-d/internal/is-number-like.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {IsNumberLike} from '../../source/internal/numeric.d.d.ts';
+import type {IsNumberLike} from '../../source/internal/numeric.d.ts';
 
 expectType<IsNumberLike<'1'>>(true);
 expectType<IsNumberLike<1>>(true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"noEmit": true,
+		"allowJs": true,
 		"noUnusedLocals": false, // Allow unused variables in test-d/*.ts files
 		"module": "node18",
 		"target": "ES2023", // Node.js 20

--- a/xo.config.js
+++ b/xo.config.js
@@ -1,0 +1,64 @@
+// @ts-check
+import {importPathRule} from './lint-rules/import-path.js';
+
+/** @type {import('xo').FlatXoConfig} */
+const xoConfig = [
+	{
+		rules: {
+			'@typescript-eslint/no-extraneous-class': 'off',
+			'@typescript-eslint/ban-ts-comment': 'off',
+			'@typescript-eslint/ban-types': 'off',
+			'@typescript-eslint/naming-convention': 'off',
+			'@typescript-eslint/no-redeclare': 'off',
+			'@typescript-eslint/no-confusing-void-expression': 'off',
+			'@typescript-eslint/no-unsafe-argument': 'off',
+			'@typescript-eslint/no-restricted-types': 'off',
+			'@typescript-eslint/no-empty-object-type': 'off',
+			'@typescript-eslint/no-unsafe-function-type': 'off',
+			'@typescript-eslint/no-deprecated': 'off',
+			'@typescript-eslint/no-wrapper-object-types': 'off',
+			'@typescript-eslint/consistent-indexed-object-style': 'off',
+			'@stylistic/quote-props': 'off',
+			'@stylistic/function-paren-newline': 'off',
+			'@stylistic/object-curly-newline': 'off',
+			'n/file-extension-in-import': 'off',
+			'object-curly-newline': [
+				'error',
+				{
+					multiline: true,
+					consistent: true,
+				},
+			],
+			'import-x/consistent-type-specifier-style': [
+				'error',
+				'prefer-top-level',
+			],
+		},
+	},
+	{
+		files: 'source/**/*.d.ts',
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					paths: ['tsd', 'expect-type'],
+				},
+			],
+		},
+	},
+	{
+		files: ['source/**/*.d.ts', 'test-d/**/*.ts'],
+		plugins: {
+			'type-fest': {
+				rules: {
+					'import-path': importPathRule,
+				},
+			},
+		},
+		rules: {
+			'type-fest/import-path': 'error',
+		},
+	},
+];
+
+export default xoConfig;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

- Adds an auto-fixable solution for #1152, improving DX as mentioned in [this comment](https://github.com/sindresorhus/type-fest/pull/1152#issuecomment-2910311853).
 
  https://github.com/user-attachments/assets/d13cf93a-fe11-40be-a2d2-ba7a53cd899e

  <img width="988" alt="image" src="https://github.com/user-attachments/assets/ceb132a6-ed11-444c-8835-401e79a43f8b" />

- Updates `xo` because there are some bugs in the existing version.

- Enables the `allowJS` flag in `tsconfig.json` to ensure the `xo.config.js` file is checked. This shouldn't be a problem because we have `noEmit` enabled, so it shouldn't matter if `.js` files are part of the program. Also, this doesn't check all `.js` files for errors, only those that have the `@ts-check` directive.
  
- This is kinda better than the `no-restricted-imports` rule, because that restricts certain extensions, whereas this enforces the desired one. 
    And interestingly, it also catches some existing errors that weren't caught earlier. And these errors are not because of any of our recent changes, these were there since the very beginning.
    https://github.com/sindresorhus/type-fest/blob/d71242aee4f6a285ed2b20da8dba03111650d2bd/source/pick-deep.d.ts#L4-L5
    https://github.com/sindresorhus/type-fest/blob/d71242aee4f6a285ed2b20da8dba03111650d2bd/test-d/internal/is-number-like.ts#L2