### PR TITLE
`ArrayTail`: Enable `preserveReadonly` option by default

### DIFF
--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -9,7 +9,7 @@ type ArrayTailOptions = {
 	/**
 	Return a readonly array if the input array is readonly.
 
-	@default false
+	@default true
 
 	@example
 	```
@@ -32,7 +32,7 @@ type ArrayTailOptions = {
 };
 
 type DefaultArrayTailOptions = {
-	preserveReadonly: false;
+	preserveReadonly: true;
 };
 
 /**

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -1,39 +1,6 @@
 import type {If} from './if.d.ts';
-import type {ApplyDefaultOptions, IsArrayReadonly} from './internal/index.d.ts';
+import type {IsArrayReadonly} from './internal/index.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
-
-/**
-@see {@link ArrayTail}
-*/
-type ArrayTailOptions = {
-	/**
-	Return a readonly array if the input array is readonly.
-
-	@default true
-
-	@example
-	```
-	import type {ArrayTail} from 'type-fest';
-
-	type Example1 = ArrayTail<readonly [string, number, boolean], {preserveReadonly: true}>;
-	//=> readonly [number, boolean]
-
-	type Example2 = ArrayTail<[string, number, boolean], {preserveReadonly: true}>;
-	//=> [number, boolean]
-
-	type Example3 = ArrayTail<readonly [string, number, boolean], {preserveReadonly: false}>;
-	//=> [number, boolean]
-
-	type Example4 = ArrayTail<[string, number, boolean], {preserveReadonly: false}>;
-	//=> [number, boolean]
-	```
-	*/
-	preserveReadonly?: boolean;
-};
-
-type DefaultArrayTailOptions = {
-	preserveReadonly: true;
-};
 
 /**
 Extracts the type of an array or tuple minus the first element.
@@ -55,18 +22,12 @@ add3(4);
 //=> 7
 ```
 
-@see {@link ArrayTailOptions}
-
 @category Array
 */
-export type ArrayTail<TArray extends UnknownArray, Options extends ArrayTailOptions = {}> =
-	ApplyDefaultOptions<ArrayTailOptions, DefaultArrayTailOptions, Options> extends infer ResolvedOptions extends Required<ArrayTailOptions>
-		? TArray extends UnknownArray // For distributing `TArray`
-			? _ArrayTail<TArray> extends infer Result
-				? ResolvedOptions['preserveReadonly'] extends true
-					? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
-					: Result
-				: never // Should never happen
+export type ArrayTail<TArray extends UnknownArray> =
+	TArray extends UnknownArray // For distributing `TArray`
+		? _ArrayTail<TArray> extends infer Result
+			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
 			: never // Should never happen
 		: never; // Should never happen
 

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -86,7 +86,7 @@ type OmitRestTypeHelper<
 	Tail extends UnknownArrayOrTuple,
 	Type extends UnknownArrayOrTuple,
 	Result extends UnknownArrayOrTuple = [],
-> = Tail extends []
+> = Tail extends readonly []
 	? Result
 	: OmitRestType<Tail, [...Result, FirstArrayElement<Type>]>;
 

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -7,19 +7,19 @@ expectType<[]>(getArrayTail([]));
 expectType<[]>(getArrayTail(['a']));
 expectType<[]>(getArrayTail(['a', 'b', 'c']));
 
-expectType<[]>(getArrayTail([] as const));
-expectType<[]>(getArrayTail(['a'] as const));
-expectType<['b', 'c']>(getArrayTail(['a', 'b', 'c'] as const));
+expectType<readonly []>(getArrayTail([] as const));
+expectType<readonly []>(getArrayTail(['a'] as const));
+expectType<readonly ['b', 'c']>(getArrayTail(['a', 'b', 'c'] as const));
 
 // Optional elements tests
-expectType<[undefined, 'c']>(getArrayTail(['a', undefined, 'c'] as const));
+expectType<readonly [undefined, 'c']>(getArrayTail(['a', undefined, 'c'] as const));
 
 // Mixed optional/required
 type MixedArray = [string, undefined?, number?];
 expectType<[undefined?, number?]>(getArrayTail(['hello'] as MixedArray));
 
 // Optional numbers
-expectType<[undefined, 3]>(getArrayTail([1, undefined, 3] as const));
+expectType<readonly [undefined, 3]>(getArrayTail([1, undefined, 3] as const));
 
 // Complex mixed case
 type ComplexArray = [string, boolean, number?, string?];
@@ -30,19 +30,19 @@ expectType<['b'?]>([] as ArrayTail<['a'?, 'b'?]>);
 
 // Union of tuples
 expectType<[] | ['b']>([] as ArrayTail<[] | ['a', 'b']>);
-expectType<['y'?] | ['b', ...string[]] | []>([] as ArrayTail<readonly ['x'?, 'y'?] | ['a', 'b', ...string[]] | readonly string[]>);
+expectType<readonly ['y'?] | ['b', ...string[]] | readonly []>([] as ArrayTail<readonly ['x'?, 'y'?] | ['a', 'b', ...string[]] | readonly string[]>);
 
 // `preserveReadonly` option
-type ReadonlyPreservingArrayTail<Type extends UnknownArray> = ArrayTail<Type, {preserveReadonly: true}>;
+type NotReadonlyPreservingArrayTail<Type extends UnknownArray> = ArrayTail<Type, {preserveReadonly: false}>;
 
-expectType<[]>({} as ReadonlyPreservingArrayTail<[]>);
-expectType<readonly []>({} as ReadonlyPreservingArrayTail<readonly []>);
-expectType<[number?, ...string[]]>({} as ReadonlyPreservingArrayTail<[string?, number?, ...string[]]>);
-expectType<readonly [number?, ...string[]]>({} as ReadonlyPreservingArrayTail<readonly [string?, number?, ...string[]]>);
+expectType<[]>({} as NotReadonlyPreservingArrayTail<[]>);
+expectType<[]>({} as NotReadonlyPreservingArrayTail<readonly []>);
+expectType<[number?, ...string[]]>({} as NotReadonlyPreservingArrayTail<[string?, number?, ...string[]]>);
+expectType<[number?, ...string[]]>({} as NotReadonlyPreservingArrayTail<readonly [string?, number?, ...string[]]>);
 
-expectType<[number] | readonly [boolean, string?]>({} as ReadonlyPreservingArrayTail<[string, number] | readonly [number, boolean, string?]>);
-expectType<readonly [number] | readonly []>({} as ReadonlyPreservingArrayTail<readonly [string, number] | readonly string[]>);
-expectType<[number?] | [boolean, string?] | []>({} as ReadonlyPreservingArrayTail<[string?, number?] | [number, boolean, string?] | [...string[], number]>);
+expectType<[number] | [boolean, string?]>({} as NotReadonlyPreservingArrayTail<[string, number] | readonly [number, boolean, string?]>);
+expectType<[number] | []>({} as NotReadonlyPreservingArrayTail<readonly [string, number] | readonly string[]>);
+expectType<[number?] | [boolean, string?] | []>({} as NotReadonlyPreservingArrayTail<[string?, number?] | [number, boolean, string?] | [...string[], number]>);
 
-expectType<[]>({} as ReadonlyPreservingArrayTail<string[]>);
-expectType<readonly []>({} as ReadonlyPreservingArrayTail<readonly string[]>);
+expectType<[]>({} as NotReadonlyPreservingArrayTail<string[]>);
+expectType<[]>({} as NotReadonlyPreservingArrayTail<readonly string[]>);

--- a/test-d/array-tail.ts
+++ b/test-d/array-tail.ts
@@ -1,11 +1,11 @@
 import {expectType} from 'tsd';
-import type {ArrayTail, UnknownArray} from '../index.d.ts';
+import type {ArrayTail} from '../index.d.ts';
 
 declare const getArrayTail: <T extends readonly unknown[]>(array: T) => ArrayTail<T>;
 
-expectType<[]>(getArrayTail([]));
-expectType<[]>(getArrayTail(['a']));
-expectType<[]>(getArrayTail(['a', 'b', 'c']));
+expectType<[]>(getArrayTail([] as []));
+expectType<[]>(getArrayTail(['a'] as ['a']));
+expectType<['b', 'c']>(getArrayTail(['a', 'b', 'c'] as ['a', 'b', 'c']));
 
 expectType<readonly []>(getArrayTail([] as const));
 expectType<readonly []>(getArrayTail(['a'] as const));
@@ -27,22 +27,23 @@ expectType<[boolean, number?, string?]>(getArrayTail(['test', false] as ComplexA
 
 // All optional elements
 expectType<['b'?]>([] as ArrayTail<['a'?, 'b'?]>);
+expectType<readonly [number?]>({} as ArrayTail<readonly [string?, number?]>);
+
+// Rest element
+expectType<readonly [number, boolean, ...string[]]>({} as ArrayTail<readonly [string, number, boolean, ...string[]]>); // Required & Rest
+expectType<readonly [number?, boolean?, ...string[]]>({} as ArrayTail<readonly [string?, number?, boolean?, ...string[]]>); // Optional & Rest
+expectType<readonly [number, boolean?, ...string[]]>({} as ArrayTail<readonly [string, number, boolean?, ...string[]]>); // Required, Optional & Rest
+// expectType<readonly [...string[], string, number]>({} as ArrayTail<readonly [...string[], string, number]>); // Rest & Required
+expectType<readonly [number, ...string[], boolean, bigint]>({} as ArrayTail<readonly [string, number, ...string[], boolean, bigint]>); // Required, Rest & Required
 
 // Union of tuples
 expectType<[] | ['b']>([] as ArrayTail<[] | ['a', 'b']>);
 expectType<readonly ['y'?] | ['b', ...string[]] | readonly []>([] as ArrayTail<readonly ['x'?, 'y'?] | ['a', 'b', ...string[]] | readonly string[]>);
+expectType<[number] | readonly [boolean, string?]>({} as ArrayTail<[string, number] | readonly [number, boolean, string?]>);
+expectType<readonly [number] | readonly []>({} as ArrayTail<readonly [string, number] | readonly string[]>);
 
-// `preserveReadonly` option
-type NotReadonlyPreservingArrayTail<Type extends UnknownArray> = ArrayTail<Type, {preserveReadonly: false}>;
-
-expectType<[]>({} as NotReadonlyPreservingArrayTail<[]>);
-expectType<[]>({} as NotReadonlyPreservingArrayTail<readonly []>);
-expectType<[number?, ...string[]]>({} as NotReadonlyPreservingArrayTail<[string?, number?, ...string[]]>);
-expectType<[number?, ...string[]]>({} as NotReadonlyPreservingArrayTail<readonly [string?, number?, ...string[]]>);
-
-expectType<[number] | [boolean, string?]>({} as NotReadonlyPreservingArrayTail<[string, number] | readonly [number, boolean, string?]>);
-expectType<[number] | []>({} as NotReadonlyPreservingArrayTail<readonly [string, number] | readonly string[]>);
-expectType<[number?] | [boolean, string?] | []>({} as NotReadonlyPreservingArrayTail<[string?, number?] | [number, boolean, string?] | [...string[], number]>);
-
-expectType<[]>({} as NotReadonlyPreservingArrayTail<string[]>);
-expectType<[]>({} as NotReadonlyPreservingArrayTail<readonly string[]>);
+// Non tuple arrays
+expectType<[]>({} as ArrayTail<string[]>);
+expectType<readonly []>({} as ArrayTail<readonly string[]>);
+expectType<[]>({} as ArrayTail<never[]>);
+expectType<[]>({} as ArrayTail<any[]>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Completes point no. 3 of #450.

<br>

IMO, instead of flipping the default value for `preserveReadonly`, we should remove the option altogether. Because, otherwise, this option should ideally be present on all array types. 

And removing `readonly` from an array is pretty straightforward anyway.

```ts
type T = Writable<ArrayTail<readonly [number, string]>>
//=> [number]
```
