### PR TITLE
add global `Case` transformation type

### DIFF
--- a/source/internal/cases.d.ts
+++ b/source/internal/cases.d.ts
@@ -111,6 +111,40 @@ Main utility type to apply a selected case transformation to a given string or o
 
 The type of transformation (`Type`) is chosen from `Cases`, and it automatically infers the correct
 options structure depending on the strategy (e.g., `delimiter` is added for Delimiter cases).
+
+@example
+```
+type Phrase = 'foo bar_baz-case';
+
+type T1 = Case<'Camel', Phrase>;
+//=> 'fooBarBazCase'
+
+type T2 = Case<'Kebab', Phrase>
+//=> 'foo-bar-baz-case';
+
+type T3 = Case<'Delimiter', Phrase, {delimiter: '#'}>
+//=> 'foo#bar#baz#case';
+```
+
+@example
+```
+type Template = {
+	'foo bar': string,
+	bar_baz: number,
+	baz1: 'foo',
+};
+
+type T = Case<'KebabProp', Template, {splitOnNumbers: true}>
+//=> {
+//   'foo-bar': string;
+//   'bar-baz': number;
+//   'baz-1': 'foo';
+// };
+```
+
+@author benzaria
+@category Change case
+@category Template literal
 */
 export type Case<
 	Type extends CaseKeys, Value,

--- a/source/internal/cases.d.ts
+++ b/source/internal/cases.d.ts
@@ -1,0 +1,118 @@
+import type {DelimiterCasedProperties} from '../delimiter-cased-properties.d.ts';
+import type {PascalCasedProperties} from '../pascal-cased-properties.d.ts';
+import type {CamelCasedProperties} from '../camel-cased-properties.d.ts';
+import type {KebabCasedProperties} from '../kebab-cased-properties.d.ts';
+import type {SnakeCasedProperties} from '../snake-cased-properties.d.ts';
+import type {CamelCase, CamelCaseOptions} from '../camel-case.d.ts';
+import type {DelimiterCase} from '../delimiter-case.d.ts';
+import type {UnionToTuple} from '../union-to-tuple.d.ts';
+import type {PascalCase} from '../pascal-case.d.ts';
+import type {KebabCase} from '../kebab-case.d.ts';
+import type {SnakeCase} from '../snake-case.d.ts';
+import type {WordsOptions} from '../words.d.ts';
+import type {Simplify} from '../simplify.d.ts';
+
+/**
+Represents the merged and flattened configuration options used across different casing strategies.
+
+It recursively combines the option types of all case transformation strategies defined in `Cases`.
+
+This is useful for normalizing the structure of options passed to `Case` implementations.
+*/
+export type CaseOptions<T = UnionToTuple<Cases[CaseKeys]['Opts']>, Acc = {}> =
+	T extends [infer H, ...infer R]
+		? CaseOptions<R, Acc & H>
+		: Acc;
+
+/**
+Infer a Value from an object if found, else return the specified default value
+*/
+type InferDefault<
+	Options extends CaseOptions,
+	Key extends keyof Options,
+	Default extends Options[Key],
+> = Options[Key] extends infer Value
+	? undefined extends Value
+		? Default
+		: Value
+	: never;
+
+/**
+Defines the transformation logic for various string casing strategies and property casing strategies.
+
+Each key in the object corresponds to a different case transformation variant (e.g., Camel, Pascal, Snake).
+
+It returns both the type of options (`Opts`) accepted and the transformed result (`Type`).
+
+More `Cases` can be added in future by following the same pattern.
+*/
+type Cases<Value = never, Options extends CaseOptions = {}> = {
+	Camel: {
+		Opts: CamelCaseOptions;
+		Type: CamelCase<Value, Options>;
+	};
+	CamelProp: {
+		Opts: CamelCaseOptions;
+		Type: CamelCasedProperties<Value, Options>;
+	};
+	Pascal: {
+		Opts: CamelCaseOptions;
+		Type: PascalCase<Value, Options>;
+	};
+	PascalProp: {
+		Opts: CamelCaseOptions;
+		Type: PascalCasedProperties<Value, Options>;
+	};
+	Kebab: {
+		Opts: WordsOptions;
+		Type: KebabCase<Value, Options>;
+	};
+	KebabProp: {
+		Opts: WordsOptions;
+		Type: KebabCasedProperties<Value, Options>;
+	};
+	Snake: {
+		Opts: WordsOptions;
+		Type: SnakeCase<Value, Options>;
+	};
+	SnakeProp: {
+		Opts: WordsOptions;
+		Type: SnakeCasedProperties<Value, Options>;
+	};
+	Delimiter: {
+		Opts: WordsOptions & {delimiter?: string}; // More Options can be added
+		Type: DelimiterCase<Value, InferDefault<Options, 'delimiter', '#'>, Options>;
+	}; //								↑ And Can be infered using thes type
+	DelimiterProp: {
+		Opts: WordsOptions & {delimiter?: string};
+		Type: DelimiterCasedProperties<Value, InferDefault<Options, 'delimiter', '#'>, Options>;
+	};
+};
+
+/**
+Represents all keys of the `Cases` object, including both string and property casing strategies.
+*/
+export type CaseKeys = Simplify<keyof Cases>;
+
+/**
+Extracts only the string-based casing strategy keys from `Cases`.
+Used when transforming standalone string values.
+*/
+export type StringCaseKeys = Exclude<CaseKeys, `${string}Prop`>;
+
+/**
+Extracts only the property-based casing strategy keys from `Cases`.
+Used when transforming the keys of object types.
+*/
+export type PropCaseKeys = Exclude<CaseKeys, StringCaseKeys>;
+
+/**
+Main utility type to apply a selected case transformation to a given string or object.
+
+The type of transformation (`Type`) is chosen from `Cases`, and it automatically infers the correct
+options structure depending on the strategy (e.g., `delimiter` is added for Delimiter cases).
+*/
+export type Case<
+	Type extends CaseKeys, Value,
+	Options extends Cases[Type]['Opts'] = {},
+> = Cases<Value, Options>[Type]['Type'];

--- a/source/internal/index.d.ts
+++ b/source/internal/index.d.ts
@@ -1,4 +1,5 @@
 export type * from './array.d.ts';
+export type * from './cases.d.ts';
 export type * from './characters.d.ts';
 export type * from './keys.d.ts';
 export type * from './numeric.d.ts';

--- a/test-d/cases.ts
+++ b/test-d/cases.ts
@@ -1,0 +1,102 @@
+import {expectType} from 'tsd';
+import type {Case} from '../source/internal/index.d.ts';
+
+type Phrase = 'foo bar_baz-case';
+
+expectType<Case<'Camel', Phrase>>('fooBarBazCase');
+expectType<Case<'Pascal', Phrase>>('FooBarBazCase');
+expectType<Case<'Kebab', Phrase>>('foo-bar-baz-case');
+expectType<Case<'Snake', Phrase>>('foo_bar_baz_case');
+expectType<Case<'Delimiter', Phrase>>('foo#bar#baz#case');
+expectType<Case<'Delimiter', Phrase, {delimiter: '/'}>>('foo/bar/baz/case');
+
+type Template = {
+	'write file': 'write file';
+	'write folder': 'write folder';
+	'write link': 'write link';
+	'read file': 'read file';
+	'read folder': 'read folder';
+	'read link': 'read link';
+	'delete file': 'delete file';
+	'delete folder': 'delete folder';
+	'delete link': 'delete link';
+};
+
+type CamelTemplate = Case<'CamelProp', Template>;
+type PascalTemplate = Case<'PascalProp', Template>;
+type KebabTemplate = Case<'KebabProp', Template>;
+type SnakeTemplate = Case<'SnakeProp', Template>;
+type DelimiterTemplate = Case<'DelimiterProp', Template>;
+type DelimiterTemplate_ = Case<'DelimiterProp', Template, {delimiter: '/'}>;
+
+expectType<CamelTemplate>({
+	writeFile: 'write file',
+	writeFolder: 'write folder',
+	writeLink: 'write link',
+	readFile: 'read file',
+	readFolder: 'read folder',
+	readLink: 'read link',
+	deleteFile: 'delete file',
+	deleteFolder: 'delete folder',
+	deleteLink: 'delete link',
+} as const);
+
+expectType<PascalTemplate>({
+	WriteFile: 'write file',
+	WriteLink: 'write link',
+	WriteFolder: 'write folder',
+	ReadLink: 'read link',
+	ReadFile: 'read file',
+	ReadFolder: 'read folder',
+	DeleteLink: 'delete link',
+	DeleteFile: 'delete file',
+	DeleteFolder: 'delete folder',
+} as const);
+
+expectType<KebabTemplate>({
+	'write-link': 'write link',
+	'write-file': 'write file',
+	'write-folder': 'write folder',
+	'read-link': 'read link',
+	'read-file': 'read file',
+	'read-folder': 'read folder',
+	'delete-link': 'delete link',
+	'delete-file': 'delete file',
+	'delete-folder': 'delete folder',
+} as const);
+
+expectType<SnakeTemplate>({
+	write_file: 'write file',
+	write_link: 'write link',
+	write_folder: 'write folder',
+	read_link: 'read link',
+	read_file: 'read file',
+	read_folder: 'read folder',
+	delete_link: 'delete link',
+	delete_file: 'delete file',
+	delete_folder: 'delete folder',
+} as const);
+
+expectType<DelimiterTemplate>({
+	'write#file': 'write file',
+	'write#folder': 'write folder',
+	'write#link': 'write link',
+	'read#file': 'read file',
+	'read#folder': 'read folder',
+	'read#link': 'read link',
+	'delete#file': 'delete file',
+	'delete#folder': 'delete folder',
+	'delete#link': 'delete link',
+} as const);
+
+expectType<DelimiterTemplate_>({
+	'write/file': 'write file',
+	'write/folder': 'write folder',
+	'write/link': 'write link',
+	'read/file': 'read file',
+	'read/folder': 'read folder',
+	'read/link': 'read link',
+	'delete/file': 'delete file',
+	'delete/folder': 'delete folder',
+	'delete/link': 'delete link',
+} as const);

--- a/test-d/internal/cases.ts
+++ b/test-d/internal/cases.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {Case} from '../source/internal/index.d.ts';
+import type {Case} from '../../source/internal/index.d.ts';
 
 type Phrase = 'foo bar_baz-case';
 

--- a/test-d/internal/cases.ts
+++ b/test-d/internal/cases.ts
@@ -39,7 +39,7 @@ expectType<CamelTemplate>({
 	deleteFile: 'delete file',
 	deleteFolder: 'delete folder',
 	deleteLink: 'delete link',
-} as const);
+});
 
 expectType<PascalTemplate>({
 	WriteFile: 'write file',
@@ -51,7 +51,7 @@ expectType<PascalTemplate>({
 	DeleteLink: 'delete link',
 	DeleteFile: 'delete file',
 	DeleteFolder: 'delete folder',
-} as const);
+});
 
 expectType<KebabTemplate>({
 	'write-link': 'write link',
@@ -63,7 +63,7 @@ expectType<KebabTemplate>({
 	'delete-link': 'delete link',
 	'delete-file': 'delete file',
 	'delete-folder': 'delete folder',
-} as const);
+});
 
 expectType<SnakeTemplate>({
 	write_file: 'write file',
@@ -75,7 +75,7 @@ expectType<SnakeTemplate>({
 	delete_link: 'delete link',
 	delete_file: 'delete file',
 	delete_folder: 'delete folder',
-} as const);
+});
 
 expectType<DelimiterTemplate>({
 	'write#file': 'write file',
@@ -87,7 +87,7 @@ expectType<DelimiterTemplate>({
 	'delete#file': 'delete file',
 	'delete#folder': 'delete folder',
 	'delete#link': 'delete link',
-} as const);
+});
 
 expectType<DelimiterTemplate_>({
 	'write/file': 'write file',
@@ -99,4 +99,4 @@ expectType<DelimiterTemplate_>({
 	'delete/file': 'delete file',
 	'delete/folder': 'delete folder',
 	'delete/link': 'delete link',
-} as const);
+});


### PR DESCRIPTION
Add `Case` type, a global case transformation type

**example**

```ts

type level = 'DEBUG' | 'INFO' | 'ERROR' | 'WARNING';

expectType<Case<'Camel', UnionToEnum<level>>>({
	debug: 'DEBUG',
	info: 'INFO',
	error: 'ERROR',
	warning: 'WARNING',
});

expectType<Case<'Delimiter', UnionToEnum<`${level}Key`>, {delimiter: '#'}>>({
	'debug#key': 'DEBUGKey',
	'info#key': 'INFOKey',
	'error#key': 'ERRORKey',
	'warning#key': 'WARNINGKey',
});

```