### PR TITLE
Modify `UnionToEnum` to use `Case` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ export type {IsFloat} from './source/is-float.d.ts';
 export type {TupleToObject} from './source/tuple-to-object.d.ts';
 export type {TupleToUnion} from './source/tuple-to-union.d.ts';
 export type {UnionToTuple} from './source/union-to-tuple.d.ts';
+export type {UnionToEnum} from './source/union-to-enum.d.ts';
 export type {IntRange} from './source/int-range.d.ts';
 export type {IntClosedRange} from './source/int-closed-range.d.ts';
 export type {IsEqual} from './source/is-equal.d.ts';

--- a/source/internal/cases.d.ts
+++ b/source/internal/cases.d.ts
@@ -111,6 +111,40 @@ Main utility type to apply a selected case transformation to a given string or o
 
 The type of transformation (`Type`) is chosen from `Cases`, and it automatically infers the correct
 options structure depending on the strategy (e.g., `delimiter` is added for Delimiter cases).
+
+@example
+```
+type Phrase = 'foo bar_baz-case';
+
+type T1 = Case<'Camel', Phrase>;
+//=> 'fooBarBazCase'
+
+type T2 = Case<'Kebab', Phrase>
+//=> 'foo-bar-baz-case';
+
+type T3 = Case<'Delimiter', Phrase, {delimiter: '#'}>
+//=> 'foo#bar#baz#case';
+```
+
+@example
+```
+type Template = {
+	'foo bar': string,
+	bar_baz: number,
+	baz1: 'foo',
+};
+
+type T = Case<'KebabProp', Template, {splitOnNumbers: true}>
+//=> {
+//   'foo-bar': string;
+//   'bar-baz': number;
+//   'baz-1': 'foo';
+// };
+```
+
+@author benzaria
+@category Change case
+@category Template literal
 */
 export type Case<
 	Type extends CaseKeys, Value,

--- a/source/internal/cases.d.ts
+++ b/source/internal/cases.d.ts
@@ -1,0 +1,118 @@
+import type {DelimiterCasedProperties} from '../delimiter-cased-properties.d.ts';
+import type {PascalCasedProperties} from '../pascal-cased-properties.d.ts';
+import type {CamelCasedProperties} from '../camel-cased-properties.d.ts';
+import type {KebabCasedProperties} from '../kebab-cased-properties.d.ts';
+import type {SnakeCasedProperties} from '../snake-cased-properties.d.ts';
+import type {CamelCase, CamelCaseOptions} from '../camel-case.d.ts';
+import type {DelimiterCase} from '../delimiter-case.d.ts';
+import type {UnionToTuple} from '../union-to-tuple.d.ts';
+import type {PascalCase} from '../pascal-case.d.ts';
+import type {KebabCase} from '../kebab-case.d.ts';
+import type {SnakeCase} from '../snake-case.d.ts';
+import type {WordsOptions} from '../words.d.ts';
+import type {Simplify} from '../simplify.d.ts';
+
+/**
+Represents the merged and flattened configuration options used across different casing strategies.
+
+It recursively combines the option types of all case transformation strategies defined in `Cases`.
+
+This is useful for normalizing the structure of options passed to `Case` implementations.
+*/
+export type CaseOptions<T = UnionToTuple<Cases[CaseKeys]['Opts']>, Acc = {}> =
+	T extends [infer H, ...infer R]
+		? CaseOptions<R, Acc & H>
+		: Acc;
+
+/**
+Infer a Value from an object if found, else return the specified default value
+*/
+type InferDefault<
+	Options extends CaseOptions,
+	Key extends keyof Options,
+	Default extends Options[Key],
+> = Options[Key] extends infer Value
+	? undefined extends Value
+		? Default
+		: Value
+	: never;
+
+/**
+Defines the transformation logic for various string casing strategies and property casing strategies.
+
+Each key in the object corresponds to a different case transformation variant (e.g., Camel, Pascal, Snake).
+
+It returns both the type of options (`Opts`) accepted and the transformed result (`Type`).
+
+More `Cases` can be added in future by following the same pattern.
+*/
+type Cases<Value = never, Options extends CaseOptions = {}> = {
+	Camel: {
+		Opts: CamelCaseOptions;
+		Type: CamelCase<Value, Options>;
+	};
+	CamelProp: {
+		Opts: CamelCaseOptions;
+		Type: CamelCasedProperties<Value, Options>;
+	};
+	Pascal: {
+		Opts: CamelCaseOptions;
+		Type: PascalCase<Value, Options>;
+	};
+	PascalProp: {
+		Opts: CamelCaseOptions;
+		Type: PascalCasedProperties<Value, Options>;
+	};
+	Kebab: {
+		Opts: WordsOptions;
+		Type: KebabCase<Value, Options>;
+	};
+	KebabProp: {
+		Opts: WordsOptions;
+		Type: KebabCasedProperties<Value, Options>;
+	};
+	Snake: {
+		Opts: WordsOptions;
+		Type: SnakeCase<Value, Options>;
+	};
+	SnakeProp: {
+		Opts: WordsOptions;
+		Type: SnakeCasedProperties<Value, Options>;
+	};
+	Delimiter: {
+		Opts: WordsOptions & {delimiter?: string}; // More Options can be added
+		Type: DelimiterCase<Value, InferDefault<Options, 'delimiter', '#'>, Options>;
+	}; //								↑ And Can be infered using thes type
+	DelimiterProp: {
+		Opts: WordsOptions & {delimiter?: string};
+		Type: DelimiterCasedProperties<Value, InferDefault<Options, 'delimiter', '#'>, Options>;
+	};
+};
+
+/**
+Represents all keys of the `Cases` object, including both string and property casing strategies.
+*/
+export type CaseKeys = Simplify<keyof Cases>;
+
+/**
+Extracts only the string-based casing strategy keys from `Cases`.
+Used when transforming standalone string values.
+*/
+export type StringCaseKeys = Exclude<CaseKeys, `${string}Prop`>;
+
+/**
+Extracts only the property-based casing strategy keys from `Cases`.
+Used when transforming the keys of object types.
+*/
+export type PropCaseKeys = Exclude<CaseKeys, StringCaseKeys>;
+
+/**
+Main utility type to apply a selected case transformation to a given string or object.
+
+The type of transformation (`Type`) is chosen from `Cases`, and it automatically infers the correct
+options structure depending on the strategy (e.g., `delimiter` is added for Delimiter cases).
+*/
+export type Case<
+	Type extends CaseKeys, Value,
+	Options extends Cases[Type]['Opts'] = {},
+> = Cases<Value, Options>[Type]['Type'];

--- a/source/internal/index.d.ts
+++ b/source/internal/index.d.ts
@@ -1,4 +1,5 @@
 export type * from './array.d.ts';
+export type * from './cases.d.ts';
 export type * from './characters.d.ts';
 export type * from './keys.d.ts';
 export type * from './numeric.d.ts';

--- a/source/union-to-enum.d.ts
+++ b/source/union-to-enum.d.ts
@@ -1,0 +1,125 @@
+import type {Case, CaseOptions, StringCaseKeys as CaseKeys} from './internal/cases.d.ts';
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {UnionToTuple} from './union-to-tuple.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+import type {BuildTuple} from './internal/tuple.d.ts';
+import type {Simplify} from './simplify.d.ts';
+import type {IsNever} from './is-never.d.ts';
+
+/**
+{@link UnionToEnum} Options.
+*/
+export type UnionToEnumOptions = Simplify<CaseOptions & {
+	/**
+	The starting **Index** of Numeric enums.
+
+	@default 1
+	*/
+	startIndex?: number;
+	/**
+	Whether to use change the **Case** of property names.
+
+	@default null
+	*/
+	propertyCase?: null | Simplify<CaseKeys>;
+}>;
+
+type DefaultUnionToEnumOptions = {
+	startIndex: 1;
+	delimiter: '#';
+	propertyCase: null;
+	splitOnNumbers: false;
+	preserveConsecutiveUppercase: false;
+};
+
+/**
+Converts a union or tuple of property keys (string, number, or symbol) into an **Enum**-like object.
+
+The keys are preserved, and their values are either:
+
+- Their own literal values (by default)
+- Or numeric indices (`1`, `2`, ...) if `Numeric` is `true`
+
+By default, **Property** names are not **CamelCased** and **Numeric Enums** start from **Index `1`**. See {@link UnionToEnumOptions} to change this behaviour.
+
+This is useful for creating strongly typed enums from a union of literals.
+
+@example-types
+```
+type E1 = UnionToEnum<'A' | 'B' | 'C'>;
+//=> { A: 'A'; B: 'B'; C: 'C' }
+
+type E2 = UnionToEnum<'X' | 'Y' | 'Z', true>;
+//=> { X: 1; Y: 2; Z: 3 }
+
+type E3 = UnionToEnum<['Play', 'Pause', 'Stop'], true, {startIndex: 3}>;
+//=> { Play: 3; Pause: 4; Stop: 5 }
+
+type E4 = UnionToEnum<['some_key', 'another_key'], false, {propertyCase: 'Kebab'}>;
+//=> { 'some-key': 'some_key'; 'another-key': 'another_key' }
+
+type E5 = UnionToEnum<never>;
+//=> {}
+```
+
+@example-function
+```
+const verb = ['write', 'read', 'delete'] as const;
+const resrc = ['file', 'folder', 'link'] as const;
+
+declare function createEnum<
+	const T extends readonly string[],
+	const U extends readonly string[],
+>(x: T, y: U): UnionToEnum<`${T[number]}_${U[number]}`, false, {propertyCase: 'Camel'}>;
+
+const Template = createEnum(verb, resrc);
+//=> {
+//    writeFile: 'write_file',
+//    writeFolder: 'write_folder',
+//    writeLink: 'write_link',
+//    readFile: 'read_file',
+//    readFolder: 'read_folder',
+//    readLink: 'read_link',
+//    deleteFile: 'delete_file',
+//    deleteFolder: 'delete_folder',
+//    deleteLink: 'delete_link',
+// }
+```
+
+@author benzaria
+@see UnionToTuple
+@category Object
+*/
+export type UnionToEnum<
+	Keys extends PropertyKey | readonly PropertyKey[],
+	Numeric extends boolean = false,
+	Options extends UnionToEnumOptions = {},
+> = ApplyDefaultOptions<UnionToEnumOptions, DefaultUnionToEnumOptions, Options> extends infer ResolvedOptions extends Required<UnionToEnumOptions>
+	? IsNever<Keys> extends true ? {}
+		: _UnionToEnum<[
+			...BuildTuple<ResolvedOptions['startIndex']>,
+			...[Keys] extends [UnknownArray] ? Keys : UnionToTuple<Keys>,
+		], Numeric, ResolvedOptions>
+	: never;
+
+/**
+Core type for {@link UnionToEnum}.
+*/
+type _UnionToEnum<
+	Keys extends UnknownArray,
+	Numeric extends boolean,
+	Options extends Required<UnionToEnumOptions>,
+> = Simplify<{readonly [
+	K in keyof Keys as K extends `${number}`
+		? Keys[K] extends PropertyKey
+			? Options['propertyCase'] extends CaseKeys
+				? Case<Options['propertyCase'], Keys[K], Options>
+				: Keys[K]
+			: never
+		: never
+	]: Numeric extends true
+		? K extends `${infer N extends number}`
+			? N
+			: never
+		: Keys[K]
+}>;

--- a/test-d/cases.ts
+++ b/test-d/cases.ts
@@ -1,0 +1,102 @@
+import {expectType} from 'tsd';
+import type {Case} from '../source/internal/index.d.ts';
+
+type Phrase = 'foo bar_baz-case';
+
+expectType<Case<'Camel', Phrase>>('fooBarBazCase');
+expectType<Case<'Pascal', Phrase>>('FooBarBazCase');
+expectType<Case<'Kebab', Phrase>>('foo-bar-baz-case');
+expectType<Case<'Snake', Phrase>>('foo_bar_baz_case');
+expectType<Case<'Delimiter', Phrase>>('foo#bar#baz#case');
+expectType<Case<'Delimiter', Phrase, {delimiter: '/'}>>('foo/bar/baz/case');
+
+type Template = {
+	'write file': 'write file';
+	'write folder': 'write folder';
+	'write link': 'write link';
+	'read file': 'read file';
+	'read folder': 'read folder';
+	'read link': 'read link';
+	'delete file': 'delete file';
+	'delete folder': 'delete folder';
+	'delete link': 'delete link';
+};
+
+type CamelTemplate = Case<'CamelProp', Template>;
+type PascalTemplate = Case<'PascalProp', Template>;
+type KebabTemplate = Case<'KebabProp', Template>;
+type SnakeTemplate = Case<'SnakeProp', Template>;
+type DelimiterTemplate = Case<'DelimiterProp', Template>;
+type DelimiterTemplate_ = Case<'DelimiterProp', Template, {delimiter: '/'}>;
+
+expectType<CamelTemplate>({
+	writeFile: 'write file',
+	writeFolder: 'write folder',
+	writeLink: 'write link',
+	readFile: 'read file',
+	readFolder: 'read folder',
+	readLink: 'read link',
+	deleteFile: 'delete file',
+	deleteFolder: 'delete folder',
+	deleteLink: 'delete link',
+} as const);
+
+expectType<PascalTemplate>({
+	WriteFile: 'write file',
+	WriteLink: 'write link',
+	WriteFolder: 'write folder',
+	ReadLink: 'read link',
+	ReadFile: 'read file',
+	ReadFolder: 'read folder',
+	DeleteLink: 'delete link',
+	DeleteFile: 'delete file',
+	DeleteFolder: 'delete folder',
+} as const);
+
+expectType<KebabTemplate>({
+	'write-link': 'write link',
+	'write-file': 'write file',
+	'write-folder': 'write folder',
+	'read-link': 'read link',
+	'read-file': 'read file',
+	'read-folder': 'read folder',
+	'delete-link': 'delete link',
+	'delete-file': 'delete file',
+	'delete-folder': 'delete folder',
+} as const);
+
+expectType<SnakeTemplate>({
+	write_file: 'write file',
+	write_link: 'write link',
+	write_folder: 'write folder',
+	read_link: 'read link',
+	read_file: 'read file',
+	read_folder: 'read folder',
+	delete_link: 'delete link',
+	delete_file: 'delete file',
+	delete_folder: 'delete folder',
+} as const);
+
+expectType<DelimiterTemplate>({
+	'write#file': 'write file',
+	'write#folder': 'write folder',
+	'write#link': 'write link',
+	'read#file': 'read file',
+	'read#folder': 'read folder',
+	'read#link': 'read link',
+	'delete#file': 'delete file',
+	'delete#folder': 'delete folder',
+	'delete#link': 'delete link',
+} as const);
+
+expectType<DelimiterTemplate_>({
+	'write/file': 'write file',
+	'write/folder': 'write folder',
+	'write/link': 'write link',
+	'read/file': 'read file',
+	'read/folder': 'read folder',
+	'read/link': 'read link',
+	'delete/file': 'delete file',
+	'delete/folder': 'delete folder',
+	'delete/link': 'delete link',
+} as const);

--- a/test-d/internal/cases.ts
+++ b/test-d/internal/cases.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {Case} from '../source/internal/index.d.ts';
+import type {Case} from '../../source/internal/index.d.ts';
 
 type Phrase = 'foo bar_baz-case';
 

--- a/test-d/union-to-enum.ts
+++ b/test-d/union-to-enum.ts
@@ -1,0 +1,150 @@
+import {expectType} from 'tsd';
+import type {UnionToEnum} from '../index.d.ts';
+import type {CaseOptions} from '../source/internal/cases.d.ts';
+import type {UnionToEnumOptions} from '../source/union-to-enum.d.ts';
+
+// Union input
+expectType<UnionToEnum<'b' | 'a' | 'd' | 'c'>>({b: 'b', a: 'a', d: 'd', c: 'c'} as const);
+expectType<UnionToEnum<3 | 2 | 4 | 1>>({1: 1, 2: 2, 3: 3, 4: 4} as const);
+
+// Tuple input
+expectType<UnionToEnum<['One', 'Two']>>({One: 'One', Two: 'Two'} as const);
+expectType<UnionToEnum<['X', 'Y', 'Z'], true>>({X: 1, Y: 2, Z: 3} as const);
+
+// Single element tuple
+expectType<UnionToEnum<['Only']>>({Only: 'Only'} as const);
+expectType<UnionToEnum<'Only', true>>({Only: 1} as const);
+
+// Tuple with numeric keys
+expectType<UnionToEnum<[1, 2, 3]>>({1: 1, 2: 2, 3: 3} as const);
+expectType<UnionToEnum<[1, 2, 3], true, {startIndex: 10}>>({1: 10, 2: 11, 3: 12} as const);
+
+// Mixed keys
+expectType<UnionToEnum<['a', 1, 'b']>>({a: 'a', 1: 1, b: 'b'} as const);
+expectType<UnionToEnum<['a', 1, 'b'], true, {startIndex: 0}>>({a: 0, 1: 1, b: 2} as const);
+
+// Literal const arrays
+const buttons = ['Play', 'Pause', 'Stop'] as const;
+
+expectType<UnionToEnum<typeof buttons>>({Play: 'Play', Pause: 'Pause', Stop: 'Stop'} as const);
+expectType<UnionToEnum<typeof buttons, true, {startIndex: 0}>>({Play: 0, Pause: 1, Stop: 2} as const);
+
+// Symbol keys
+declare const sym1: unique symbol;
+declare const sym2: unique symbol;
+
+expectType<UnionToEnum<typeof sym1 | typeof sym2>>({[sym1]: sym1, [sym2]: sym2} as const);
+expectType<UnionToEnum<[typeof sym1, typeof sym2]>>({[sym1]: sym1, [sym2]: sym2} as const);
+
+// Unordered union with numeric flag
+expectType<UnionToEnum<'left' | 'right' | 'up' | 'down', true>>({left: 1, right: 2, up: 3, down: 4} as const);
+
+// Large union
+type BigUnion = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g';
+expectType<UnionToEnum<BigUnion>>({a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g'} as const);
+
+// Non-literal input fallback
+expectType<UnionToEnum<string>>({} as Readonly<Record<string, string>>);
+expectType<UnionToEnum<number>>({} as Readonly<Record<number, number>>);
+expectType<UnionToEnum<symbol>>({} as Readonly<Record<symbol, symbol>>);
+
+expectType<UnionToEnum<string[]>>({} as const);
+expectType<UnionToEnum<number[]>>({} as const);
+expectType<UnionToEnum<symbol[]>>({} as const);
+
+// `never` / `any`
+expectType<UnionToEnum<never>>({} as const);
+expectType<UnionToEnum<any>>({} as const);
+
+// CamelCase
+const level = ['DEBUG', 'INFO', 'ERROR', 'WARNING'] as const;
+expectType<UnionToEnum<typeof buttons, false, {propertyCase: 'Camel'}>>({
+	play: 'Play',
+	pause: 'Pause',
+	stop: 'Stop',
+} as const);
+expectType<UnionToEnum<typeof level, false, {propertyCase: 'Camel'}>>({
+	debug: 'DEBUG',
+	info: 'INFO',
+	error: 'ERROR',
+	warning: 'WARNING',
+} as const);
+expectType<UnionToEnum<typeof level, true, {propertyCase: 'Pascal'}>>({
+	Debug: 1,
+	Info: 2,
+	Error: 3,
+	Warning: 4,
+} as const);
+
+// Dynamic Enum
+type verb = ['write', 'read', 'delete'];
+type resrc = ['file', 'folder', 'link'];
+
+declare function createEnum<
+	const T extends readonly string[],
+	const U extends readonly string[],
+	Case extends Required<UnionToEnumOptions>['propertyCase'],
+	Options extends CaseOptions = {},
+>(): UnionToEnum<`${T[number]} ${U[number]}`, false, {propertyCase: Case} & Options>;
+
+type CamelTemplate = ReturnType<typeof createEnum<verb, resrc, 'Camel'>>;
+type PascalTemplate = ReturnType<typeof createEnum<verb, resrc, 'Pascal'>>;
+type KebabTemplate = ReturnType<typeof createEnum<verb, resrc, 'Kebab'>>;
+type SnakeTemplate = ReturnType<typeof createEnum<verb, resrc, 'Snake'>>;
+type DelimiterTemplate = ReturnType<typeof createEnum<verb, resrc, 'Delimiter', {delimiter: '/'}>>;
+
+expectType<CamelTemplate>({
+	writeFile: 'write file',
+	writeFolder: 'write folder',
+	writeLink: 'write link',
+	readFile: 'read file',
+	readFolder: 'read folder',
+	readLink: 'read link',
+	deleteFile: 'delete file',
+	deleteFolder: 'delete folder',
+	deleteLink: 'delete link',
+} as const);
+expectType<PascalTemplate>({
+	WriteFile: 'write file',
+	WriteLink: 'write link',
+	WriteFolder: 'write folder',
+	ReadLink: 'read link',
+	ReadFile: 'read file',
+	ReadFolder: 'read folder',
+	DeleteLink: 'delete link',
+	DeleteFile: 'delete file',
+	DeleteFolder: 'delete folder',
+} as const);
+expectType<KebabTemplate>({
+	'write-link': 'write link',
+	'write-file': 'write file',
+	'write-folder': 'write folder',
+	'read-link': 'read link',
+	'read-file': 'read file',
+	'read-folder': 'read folder',
+	'delete-link': 'delete link',
+	'delete-file': 'delete file',
+	'delete-folder': 'delete folder',
+} as const);
+expectType<SnakeTemplate>({
+	write_file: 'write file',
+	write_link: 'write link',
+	write_folder: 'write folder',
+	read_link: 'read link',
+	read_file: 'read file',
+	read_folder: 'read folder',
+	delete_link: 'delete link',
+	delete_file: 'delete file',
+	delete_folder: 'delete folder',
+} as const);
+expectType<DelimiterTemplate>({
+	'write/link': 'write link',
+	'write/file': 'write file',
+	'write/folder': 'write folder',
+	'read/link': 'read link',
+	'read/file': 'read file',
+	'read/folder': 'read folder',
+	'delete/link': 'delete link',
+	'delete/file': 'delete file',
+	'delete/folder': 'delete folder',
+} as const);

--- a/test-d/union-to-enum.ts
+++ b/test-d/union-to-enum.ts
@@ -56,7 +56,7 @@ expectType<UnionToEnum<symbol[]>>({} as const);
 expectType<UnionToEnum<never>>({} as const);
 expectType<UnionToEnum<any>>({} as const);
 
-// CamelCase
+// Case transformation
 const level = ['DEBUG', 'INFO', 'ERROR', 'WARNING'] as const;
 expectType<UnionToEnum<typeof buttons, false, {propertyCase: 'Camel'}>>({
 	play: 'Play',
@@ -76,7 +76,7 @@ expectType<UnionToEnum<typeof level, true, {propertyCase: 'Pascal'}>>({
 	Warning: 4,
 } as const);
 
-// Dynamic Enum
+// Dynamic Enum Creation
 type verb = ['write', 'read', 'delete'];
 type resrc = ['file', 'folder', 'link'];
 
@@ -91,7 +91,8 @@ type CamelTemplate = ReturnType<typeof createEnum<verb, resrc, 'Camel'>>;
 type PascalTemplate = ReturnType<typeof createEnum<verb, resrc, 'Pascal'>>;
 type KebabTemplate = ReturnType<typeof createEnum<verb, resrc, 'Kebab'>>;
 type SnakeTemplate = ReturnType<typeof createEnum<verb, resrc, 'Snake'>>;
-type DelimiterTemplate = ReturnType<typeof createEnum<verb, resrc, 'Delimiter', {delimiter: '/'}>>;
+type DelimiterTemplate = ReturnType<typeof createEnum<verb, resrc, 'Delimiter'>>;
+type DelimiterTemplate_ = ReturnType<typeof createEnum<verb, resrc, 'Delimiter', {delimiter: '/'}>>;
 
 expectType<CamelTemplate>({
 	writeFile: 'write file',
@@ -138,6 +139,17 @@ expectType<SnakeTemplate>({
 	delete_folder: 'delete folder',
 } as const);
 expectType<DelimiterTemplate>({
+	'write#link': 'write link',
+	'write#file': 'write file',
+	'write#folder': 'write folder',
+	'read#link': 'read link',
+	'read#file': 'read file',
+	'read#folder': 'read folder',
+	'delete#link': 'delete link',
+	'delete#file': 'delete file',
+	'delete#folder': 'delete folder',
+} as const);
+expectType<DelimiterTemplate_>({
 	'write/link': 'write link',
 	'write/file': 'write file',
 	'write/folder': 'write folder',


### PR DESCRIPTION
Adding suggested modification in [`Case`](#1176 ) making `UnionToEnum` able to transform property keys into cases like (Camel, Pascal, Kebab, ....)
