### PR TITLE
Union support for `Simplify`

### DIFF
--- a/source/conditional-simplify-deep.d.ts
+++ b/source/conditional-simplify-deep.d.ts
@@ -63,9 +63,13 @@ type SimplifyDeepTypeAB = ConditionalSimplifyDeep<TypeA & TypeB, SomeComplexType
 
 @see SimplifyDeep
 @category Object
+@category Array
+@category Union
 */
-export type ConditionalSimplifyDeep<Type, ExcludeType = never, IncludeType = unknown> = Type extends ExcludeType
-	? Type
-	: Type extends IncludeType
-		? {[TypeKey in keyof Type]: ConditionalSimplifyDeep<Type[TypeKey], ExcludeType, IncludeType>}
-		: Type;
+export type ConditionalSimplifyDeep<Type, ExcludeType = never, IncludeType = unknown> = {
+	[Member in Type as '_']: Member extends ExcludeType
+		? Member
+		: Member extends IncludeType
+			? {[Key in keyof Member]: ConditionalSimplifyDeep<Member[Key], ExcludeType, IncludeType>}
+			: Member
+}['_'];

--- a/source/conditional-simplify.d.ts
+++ b/source/conditional-simplify.d.ts
@@ -40,9 +40,13 @@ type C = Simplify<{a: number} & {b: string}>;
 
 @see ConditionalSimplifyDeep
 @category Object
+@category Array
+@category Union
 */
-export type ConditionalSimplify<Type, ExcludeType = never, IncludeType = unknown> = Type extends ExcludeType
-	? Type
-	: Type extends IncludeType
-		? {[TypeKey in keyof Type]: Type[TypeKey]}
-		: Type;
+export type ConditionalSimplify<Type, ExcludeType = never, IncludeType = unknown> = {
+	[Member in Type as '_']: Member extends ExcludeType
+		? Member
+		: Member extends IncludeType
+			? {[Key in keyof Member]: Member[Key]}
+			: Member;
+}['_'];

--- a/source/simplify-deep.d.ts
+++ b/source/simplify-deep.d.ts
@@ -1,5 +1,5 @@
 import type {ConditionalSimplifyDeep} from './conditional-simplify-deep.d.ts';
-import type {NonRecursiveType} from './internal/index.d.ts';
+import type {NonRecursiveType} from './internal/type.d.ts';
 
 /**
 Deeply simplifies an object type.
@@ -106,10 +106,11 @@ type SimplifyDeepProperties = SimplifyDeep<Properties1 & Properties2, ComplexTyp
 
 @see Simplify
 @category Object
+@category Array
+@category Union
 */
-export type SimplifyDeep<Type, ExcludeType = never> =
-	ConditionalSimplifyDeep<
-		Type,
+export type SimplifyDeep<Type, ExcludeType = never> = ConditionalSimplifyDeep<
+	Type,
 	ExcludeType | NonRecursiveType | Set<unknown> | Map<unknown, unknown>,
 	object
-	>;
+>;

--- a/source/simplify-deep.d.ts
+++ b/source/simplify-deep.d.ts
@@ -2,11 +2,13 @@ import type {ConditionalSimplifyDeep} from './conditional-simplify-deep.d.ts';
 import type {NonRecursiveType} from './internal/type.d.ts';
 
 /**
-Deeply simplifies an object type.
+Deeply simplifies an object, array or union type.
 
 You can exclude certain types from being simplified by providing them in the second generic `ExcludeType`.
 
 Useful to flatten the type output to improve type hints shown in editors.
+
+And also to transform an interface into a type to aide with assignability.
 
 @example
 ```

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -1,3 +1,6 @@
+import type {ConditionalSimplify} from './conditional-simplify.d.ts';
+import type {NonRecursiveType} from './internal/type.d.ts';
+
 /**
 Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 
@@ -54,5 +57,11 @@ fn(someInterface as Simplify<SomeInterface>); // Good: transform an `interface` 
 @link https://github.com/microsoft/TypeScript/issues/15300
 @see SimplifyDeep
 @category Object
+@category Array
+@category Union
 */
-export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};
+export type Simplify<Type, ExcludeType = never> = ConditionalSimplify<
+	Type,
+	ExcludeType | NonRecursiveType | Set<unknown> | Map<unknown, unknown>,
+	object
+>;

--- a/source/simplify.d.ts
+++ b/source/simplify.d.ts
@@ -2,7 +2,13 @@ import type {ConditionalSimplify} from './conditional-simplify.d.ts';
 import type {NonRecursiveType} from './internal/type.d.ts';
 
 /**
-Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
+Simplify a object, array or union types
+
+You can exclude certain types from being simplified by providing them in the second generic `ExcludeType`.
+
+Useful to flatten the type output to improve type hints shown in editors.
+
+And also to transform an interface into a type to aide with assignability.
 
 @example
 ```

--- a/test-d/conditional-simplify-deep.ts
+++ b/test-d/conditional-simplify-deep.ts
@@ -24,11 +24,9 @@ const someNode = {parent: positionAndSize, childs: [{parent: positionAndSize}, {
 expectType<SomeNodeSimplified>(someNode);
 
 // Should simplify interface deeply excluding Function type.
-// TODO: Convert this to a `type`.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-interface MovablePosition extends Position {
+type MovablePosition = Position & {
 	move(position: Position): Position;
-}
+};
 
 type MovableCollection = {
 	position: MovablePosition;
@@ -68,3 +66,19 @@ expectType<ExcludeFunctionAndSize1>(movableNode);
 // Same as above but using `IncludeType` parameter (mainly visual, mouse over the statement).
 type ExcludeFunctionAndSize2 = ConditionalSimplifyDeep<MovableCollection, Function, MovableCollection | Position>;
 expectType<ExcludeFunctionAndSize2>(movableNode);
+
+declare const sym: unique symbol;
+
+type Sym = typeof sym;
+type SomeFunction = (type: string) => string;
+
+type Union1 = 'a' | Sym | null | ['b', 5];
+type Union2 = 2 | void | string | SomeFunction;
+
+type UnSimplifiedUnion = Union1 | Union2;
+type UnSimplifiedObject = {prop: UnSimplifiedUnion};
+
+const unSimpleObject: UnSimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` dont show it's types
+
+// Shoud simplify the union members (mainly visual, mouse over the statement).
+const simpleObject: ConditionalSimplifyDeep<UnSimplifiedObject, Function> = {prop: 'a'}; // Hovering over object or `prop` show it's types

--- a/test-d/conditional-simplify-deep.ts
+++ b/test-d/conditional-simplify-deep.ts
@@ -77,8 +77,11 @@ type Union2 = 2 | void | string | SomeFunction;
 
 type UnSimplifiedUnion = Union1 | Union2;
 type UnSimplifiedObject = {prop: UnSimplifiedUnion};
+type SimplifiedObject = ConditionalSimplifyDeep<UnSimplifiedObject, Function>;
 
 const unSimpleObject: UnSimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` dont show it's types
+expectType<UnSimplifiedObject>(unSimpleObject);
 
 // Shoud simplify the union members (mainly visual, mouse over the statement).
-const simpleObject: ConditionalSimplifyDeep<UnSimplifiedObject, Function> = {prop: 'a'}; // Hovering over object or `prop` show it's types
+const simpleObject: SimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` show it's types
+expectType<SimplifiedObject>(simpleObject);

--- a/test-d/conditional-simplify.ts
+++ b/test-d/conditional-simplify.ts
@@ -35,7 +35,9 @@ type UnSimplifiedUnion = Union1 | Union2;
 type UnSimplifiedObject = {prop: UnSimplifiedUnion}; // Hovering over `prop` dont show it's types
 type SimplifiedObject = {prop: ConditionalSimplify<UnSimplifiedUnion>}; // Hovering over `prop` show it's types
 
-const unSimpleObject: UnSimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` dont show it's types
+const unSimpleObject: UnSimplifiedObject = {prop: 'a'}; // Hovering over `prop` dont show it's types
+expectType<UnSimplifiedObject>(unSimpleObject);
 
 // Shoud simplify the union members (mainly visual, mouse over the statement).
-const simpleObject: SimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` show it's types
+const simpleObject: SimplifiedObject = {prop: 'a'}; // Hovering over `prop` show it's types
+expectType<SimplifiedObject>(simpleObject);

--- a/test-d/conditional-simplify.ts
+++ b/test-d/conditional-simplify.ts
@@ -23,3 +23,19 @@ declare const simplifiedFunctionPass: SimplifiedFunctionPass;
 
 expectNotAssignable<SomeFunction>(simplifiedFunctionFail);
 expectType<SomeFunction>(simplifiedFunctionPass);
+
+declare const sym: unique symbol;
+
+type Sym = typeof sym;
+
+type Union1 = 'a' | Sym | null | ['b', 5];
+type Union2 = 2 | void | string | SomeFunction;
+
+type UnSimplifiedUnion = Union1 | Union2;
+type UnSimplifiedObject = {prop: UnSimplifiedUnion}; // Hovering over `prop` dont show it's types
+type SimplifiedObject = {prop: ConditionalSimplify<UnSimplifiedUnion>}; // Hovering over `prop` show it's types
+
+const unSimpleObject: UnSimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` dont show it's types
+
+// Shoud simplify the union members (mainly visual, mouse over the statement).
+const simpleObject: SimplifiedObject = {prop: 'a'}; // Hovering over object or `prop` show it's types

--- a/test-d/simplify.ts
+++ b/test-d/simplify.ts
@@ -44,32 +44,28 @@ expectAssignable<Record<string, unknown>>(valueAsLiteral);
 expectAssignable<Record<string, unknown>>(valueAsSimplifiedInterface);
 expectNotAssignable<Record<string, unknown>>(valueAsInterface); // Index signature is missing in interface
 
-// The following tests should be fixed once we have determined the cause of the bug reported in https://github.com/sindresorhus/type-fest/issues/436
-
+// Should return the original type if it is not simplifiable
 type SomeFunction = (type: string) => string;
-type SimplifiedFunction = Simplify<SomeFunction>; // Return '{}' expected 'SomeFunction'
+type SimplifiedFunction = Simplify<SomeFunction>; // Return '(type: string) => string'
 
 declare const someFunction: SimplifiedFunction;
-
 expectNotAssignable<SomeFunction>(someFunction);
 
-// // Should return the original type if it is not simplifiable, like a function.
-// type SomeFunction = (type: string) => string;
-// expectType<Simplify<SomeFunction>>((type: string) => type);
+class SomeClass {
+	id: string;
 
-// class SomeClass {
-// 	id: string;
+	private readonly code: number;
 
-// 	private readonly code: number;
+	constructor() {
+		this.id = 'some-class';
+		this.code = 42;
+	}
 
-// 	constructor() {
-// 		this.id = 'some-class';
-// 		this.code = 42;
-// 	}
+	someMethod() {
+		return this.code;
+	}
+}
 
-// 	someMethod() {
-// 		return this.code;
-// 	}
-// }
+type SimplifiedClass = Simplify<typeof SomeClass>;
 
-// expectType<Simplify<SomeClass>>(new SomeClass());
+expectType<SimplifiedClass>(SomeClass);


### PR DESCRIPTION
Add `Simplify` support for unions

 - fix: `Simplify` return `{}` for functions.
 - feat: refactor `ConditionalSimplify` and `ConditionalSimplifyDeep` types for Union support and improved clarity.
 - feat: add new tests covering these changes.
 - feat: remove unnecessary interface in `ConditionalSimplifyDeep` test file (TODO)
 - doc: improve jsDoc for `Simplify` and `SimplifyDeep`
