### PR TITLE
`ArrayTail`: Fix incorrect JSDoc example

### DIFF
--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -35,10 +35,10 @@ type G = ArrayTail<readonly [...string[], 1, 2]>;
 ```
 import type {ArrayTail} from 'type-fest';
 
-type Curry<Func> = Func extends (...args_: infer Args) => infer ReturnValue
-	? Args extends readonly []
-		? ReturnValue
-		: (arg: Args[0]) => Curry<(...args: ArrayTail<Args>) => ReturnValue>
+type Curry<Func> = Func extends (...agruments_: infer Arguments) => infer Return
+	? Arguments extends readonly []
+		? Return
+		: (agrument: Arguments[0]) => Curry<(...agruments_: ArrayTail<Arguments>) => Return>
 	: never;
 
 declare function curry<Func extends Function>(fn: Func): Curry<Func>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

The `curry` implementation currently in the JSDoc is incorrect.
https://github.com/sindresorhus/type-fest/blob/f3aabd8a5dd5efb6e6bc5b414201b9c5e9ddcdf7/source/array-tail.d.ts#L12-L22

The error is evident if the function accepts more than two arguments. For example:
```ts
declare const curry: <Arguments extends unknown[], Return>(
  function_: (...arguments_: Arguments) => Return,
  ...arguments_: ArrayTail<Arguments>
) => (...arguments_: ArrayTail<Arguments>) => Return;

const test = (a: string, b: number, c: boolean) => [a, b, c];

// 1. Expects the last two arguments
const add3 = curry(test, 3, false); 

// 2. Again expects the last two arguments
add3(4, false);
```

This PR fixes the `curry` implementation and also adds a simpler set of examples.
