### PR TITLE
Add `Filter` type

### DIFF
--- a/source/array-filter.d.ts
+++ b/source/array-filter.d.ts
@@ -1,0 +1,51 @@
+import type {CleanEmpty, EmptyArray, IsLeadingRestElement} from './internal/array.d.ts';
+import type {Extends, IsTruthy} from './internal/type.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+import type {If} from './if.d.ts';
+
+/**
+Determines whether a value `T` should be kept based on the filtering type `U`.
+
+If `U` is `Boolean`, it checks whether `T` is `truthy` like `Boolean(T)` does.
+
+Otherwise, it uses `Extends<T, U, S>` to check if `T extends U` with strict or loose mode.
+*/
+export type FilterType<T, U, S extends boolean> = Boolean extends U ? IsTruthy<T> : Extends<T, U, S>;
+
+/**
+Filters elements from an `Array_` based on whether they match the given `Type`.
+
+If `Type` is `Boolean`, it filters out `falsy` values like `Boolean(T)` does.
+
+Strict controls whether strict or loose type comparison is used (defaults to loose).
+*/
+export type ArrayFilter<
+	Array_ extends UnknownArray, Type,
+	Strict extends boolean = false,
+> = CleanEmpty<_ArrayFilter<Array_, Type, Strict>>;
+
+/**
+Internal implementation of {@link ArrayFilter}.
+
+Iterates through the array and includes elements in the accumulator if they pass `FilterType`.
+*/
+type _ArrayFilter<Array_ extends UnknownArray, Type, Strict extends boolean, HeadAcc extends any[] = [], TailAcc extends any[] = []> = Array_ extends EmptyArray ? [...HeadAcc, ...TailAcc]
+	: IsLeadingRestElement<Array_> extends false
+		? (Array_ extends readonly [infer Head, ...infer Tail] ? [false, Head, Tail]
+			: Array_ extends readonly [(infer Head)?, ...infer Tail] ? [true, Head, Tail]
+				: never) extends [infer IsOptional extends boolean, infer Head, infer Tail extends UnknownArray]
+			? FilterType<Head, Type, Strict> extends true
+				? _ArrayFilter<Tail, Type, Strict, [...HeadAcc, ...If<IsOptional, [Head?], [Head]>], TailAcc>
+				: _ArrayFilter<Tail, Type, Strict, HeadAcc, TailAcc>
+			: 'never_A'
+		: Array_ extends readonly [...infer Head, infer Tail]
+			? FilterType<Tail, Type, Strict> extends true
+				? _ArrayFilter<Head, Type, Strict, HeadAcc, [Tail, ...TailAcc]>
+				: _ArrayFilter<Head, Type, Strict, HeadAcc, TailAcc>
+			: FilterType<Array_[number], Type, Strict> extends true
+				? _ArrayFilter<[], Type, Strict, HeadAcc, [...Array_, ...TailAcc]>
+				: _ArrayFilter<[], Type, Strict, HeadAcc, TailAcc>
+; // TODO: need improvements (use `SplitOnRestElement`).
+
+type A = ArrayFilter<[true, string, true?, number?, ...string[]], string | true>;
+//   ^?

--- a/source/array-filter.d.ts
+++ b/source/array-filter.d.ts
@@ -7,16 +7,16 @@ import type {If} from './if.d.ts';
 /**
 Determines whether a value `T` should be kept based on the filtering type `U`.
 
-If `U` is `Boolean`, it checks whether `T` is `truthy` like `Boolean(T)` does.
+If `U` is `Boolean`, it checks whether `T` is `truthy` like {@link Boolean `Boolean(T)`} does.
 
-Otherwise, it uses `Extends<T, U, S>` to check if `T extends U` with strict or loose mode.
+Otherwise, it uses {@link Extends `Extends<T, U, S>`} to check if `T extends U` with strict or loose mode.
 */
 export type FilterType<T, U, S extends boolean> = Boolean extends U ? IsTruthy<T> : Extends<T, U, S>;
 
 /**
 Filters elements from an `Array_` based on whether they match the given `Type`.
 
-If `Type` is `Boolean`, it filters out `falsy` values like `Boolean(T)` does.
+If `Type` is `Boolean`, it filters out `falsy` values like {@link Boolean `Boolean(T)`} does.
 
 Strict controls whether strict or loose type comparison is used (defaults to loose).
 */
@@ -56,5 +56,4 @@ type _ArrayFilter<
 			? FilterType<Tail, Type, Strict> extends true
 				? _ArrayFilter<Head, Type, Strict, HeadAcc, [...If<IsRest, Array_, [Tail]>, ...TailAcc]>
 				: _ArrayFilter<Head, Type, Strict, HeadAcc, TailAcc>
-			: never
-;
+			: never;

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -9,17 +9,44 @@ Extracts the type of an array or tuple minus the first element.
 ```
 import type {ArrayTail} from 'type-fest';
 
-declare const curry: <Arguments extends unknown[], Return>(
-	function_: (...arguments_: Arguments) => Return,
-	...arguments_: ArrayTail<Arguments>
-) => (...arguments_: ArrayTail<Arguments>) => Return;
+type A = ArrayTail<[1, 2, 3]>;
+//=> [2, 3]
 
-const add = (a: number, b: number) => a + b;
+type B = ArrayTail<readonly [1, 2, 3]>;
+//=> readonly [2, 3]
 
-const add3 = curry(add, 3);
+type C = ArrayTail<[1, 2, 3?, ...string[]]>;
+//=> [2, 3?, ...string[]]
 
-add3(4);
-//=> 7
+type D = ArrayTail<readonly [1]>;
+//=> readonly []
+
+type E = ArrayTail<[]>;
+//=> []
+
+type F = ArrayTail<string[]>;
+//=> string[]
+
+type G = ArrayTail<readonly [...string[], 1, 2]>;
+//=> readonly [...string[], 1, 2]
+```
+
+@example
+```
+import type {ArrayTail} from 'type-fest';
+
+type Curry<Func> = Func extends (...agruments_: infer Arguments) => infer Return
+	? Arguments extends readonly []
+		? Return
+		: (agrument: Arguments[0]) => Curry<(...agruments_: ArrayTail<Arguments>) => Return>
+	: never;
+
+declare function curry<Func extends Function>(fn: Func): Curry<Func>;
+
+declare function searchBooks(genre: string, minRating: number, available: boolean): string[];
+
+const availableTopSciFi = curry(searchBooks)('sci-fi')(4.5)(true);
+//=> string[]
 ```
 
 @category Array

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,7 +1,10 @@
 import type {If} from '../if.d.ts';
+import type {IsAny} from '../is-any.d.ts';
 import type {IsNever} from '../is-never.d.ts';
-import type {OptionalKeysOf} from '../optional-keys-of.d.ts';
+import type {IsUnion} from '../is-union.d.ts';
+import type {EmptyObject} from '../empty-object.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
+import type {OptionalKeysOf} from '../optional-keys-of.d.ts';
 import type {IsExactOptionalPropertyTypesEnabled, IfNotAnyOrNever} from './type.d.ts';
 
 /**
@@ -156,3 +159,22 @@ type _CollapseRestElement<
 				>
 				: never // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
 		: never; // Should never happen
+
+/**
+Represents a empty array, the `readonly? []` value.
+*/
+export type EmptyArray = readonly [] | [];
+
+/**
+Cleans any extra empty arrays/objects from a union
+*/
+type CleanEmpty<T> = IsUnion<T> extends true
+	? T extends EmptyArray | EmptyObject
+		? never
+		: T
+	: T;
+
+type IsLeadingRestElement<T extends UnknownArray> =
+	If<IsAny<T>, false, number extends T['length']
+		? T[number] extends T[0] ? true : false
+		: false>;

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -168,13 +168,42 @@ export type EmptyArray = readonly [] | [];
 /**
 Cleans any extra empty arrays/objects from a union
 */
-type CleanEmpty<T> = IsUnion<T> extends true
+export type CleanEmpty<T> = IsUnion<T> extends true
 	? T extends EmptyArray | EmptyObject
 		? never
 		: T
 	: T;
 
-type IsLeadingRestElement<T extends UnknownArray> =
-	If<IsAny<T>, false, number extends T['length']
-		? T[number] extends T[0] ? true : false
-		: false>;
+/**
+Determines whether the first element of a tuple is a rest element (e.g., `...string[]`).
+
+This is useful for identifying tuple types that begin with a variadic segment.
+
+@example
+```
+type A = IsLeadingRestElement<[...string[], number]>;
+//=> true
+
+type B = IsLeadingRestElement<[number, string]>;
+//=> false
+
+type C = IsLeadingRestElement<[...any[]]>;
+//=> true
+
+type D = IsLeadingRestElement<[]>;
+//=> false
+
+type E = IsLeadingRestElement<[undefined, ...number[]]>;
+//=> false
+```
+*/
+// ! This type is not perfect wet but its working fine with `Filter` for now.
+export type IsLeadingRestElement<T extends UnknownArray> =
+	IsAny<T> extends true ? false
+		: number extends T['length']
+			? T[number] extends T[0]
+				? T extends [infer H, ...infer R] // Prevent `[type, ...type[]]` from being `true`
+					? false
+					: true
+				: false
+			: false;

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -2,6 +2,7 @@ import type {If} from '../if.d.ts';
 import type {IsAny} from '../is-any.d.ts';
 import type {IsNever} from '../is-never.d.ts';
 import type {Primitive} from '../primitive.d.ts';
+import type {ExtendsStrict} from '../extends-strict.d.ts';
 
 /**
 Matches any primitive, `void`, `Date`, or `RegExp` value.
@@ -100,9 +101,45 @@ type C = IfNotAnyOrNever<never, 'VALID', 'IS_ANY', 'IS_NEVER'>;
 export type IfNotAnyOrNever<T, IfNotAnyOrNever, IfAny = any, IfNever = never> =
 	If<IsAny<T>, IfAny, If<IsNever<T>, IfNever, IfNotAnyOrNever>>;
 
-/*
+/**
 Indicates the value of `exactOptionalPropertyTypes` compiler option.
 */
 export type IsExactOptionalPropertyTypesEnabled = [(string | undefined)?] extends [string?]
 	? false
 	: true;
+
+/**
+Evaluates whether type `T extends U`, using either strict or loose comparison.
+
+ - Strict mode, {@link ExtendsStrict `ExtendsStrict<T, U>`} is used.
+ - Loose mode, {@link ExtendsLoose `ExtendsLoose<T, U>`} is used.
+*/
+export type Extends<T, U, S extends boolean = false> = {
+	true: ExtendsStrict<T, U>;
+	false: ExtendsLoose<T, U>;
+}[`${S}`];
+
+/**
+Performs a loose type comparison: checks if wheither of the members in `T` extends `U`.
+
+This is useful when needing to know if `T extends U` without distributing `T` in Main type
+*/
+export type ExtendsLoose<T, U> = IsNotFalse<T extends U ? true : false>;
+
+/**
+A union of `falsy` types in JS.
+*/
+type Falsy = false | 0 | '' | null | undefined; // `| never`
+
+/**
+Checks if `T` is {@link Falsy `falsy`} similar to `Boolean(T)`.
+*/
+type IsTruthy<T> =
+	IsNever<T> extends true ? false
+		: T extends Falsy ? false
+			: true;
+
+/**
+Prevents TS from expanding the underline type definition.
+*/
+export type Obfuscate<T> = T & Record<never, never>;

--- a/source/is-union.d.ts
+++ b/source/is-union.d.ts
@@ -19,8 +19,7 @@ export type IsUnion<T> = InternalIsUnion<T>;
 /**
 The actual implementation of `IsUnion`.
 */
-type InternalIsUnion<T, U = T> =
-(
+type InternalIsUnion<T, U = T> = (
 	IsNever<T> extends true
 		? false
 		: T extends any

--- a/source/object-filter.d.ts
+++ b/source/object-filter.d.ts
@@ -1,0 +1,25 @@
+import type {UnknownRecord} from './unknown-record.d.ts';
+import type {CleanEmpty} from './internal/array.d.ts';
+import type {FilterType} from './array-filter.d.ts';
+import type {Simplify} from './simplify.d.ts';
+
+/**
+Filters properties from an object where the property value matches the given type.
+
+If `Type` is `Boolean`, it filters out `falsy` values like `Boolean(T)` does.
+
+Strict controls whether strict or loose type comparison is used (defaults to loose).
+*/
+export type ObjectFilter<
+	Object_ extends UnknownRecord, Type,
+	Strict extends boolean = false,
+> = CleanEmpty<Simplify<{
+	[K in keyof Object_ as FilterType<Object_[K], Type, Strict> extends true
+		? K
+		: never
+	]: Object_[K]
+}>>;
+
+type O = ObjectFilter<{true: true; false: false; stringOrNumbe: string | number; full: {d: string}; empty: {}; 'dd': 'dd'; '': ''; 0: 0} | {never: never; ddd: 'ddd'; 5: '5'},
+//   ^?
+	`${number}` | number, true>;

--- a/test-d/array-filter.ts
+++ b/test-d/array-filter.ts
@@ -91,10 +91,6 @@ expectType<ArrayFilter<['foo1', 'bar2', 'foo3'], `foo${number}`>>(['foo1', 'foo3
 class Foo {}
 expectType<ArrayFilter<[typeof Foo, {}, null, undefined], Boolean>>([Foo, {}]);
 
-// Filtering tuples with mixed optional and required elements
-type Tuple = [string, number?, boolean?];
-expectType<ArrayFilter<Tuple, number>>([/* should be [number?] filtered out? */]);
-
 // Filtering with strict = true and union including literals and primitives
 expectType<ArrayFilter<[1, '1', 2, '2', true, false], number | `${number}`, true>>([1, '1', 2, '2']);
 
@@ -110,14 +106,26 @@ expectType<ArrayFilter<['', 'non-empty'], '', true>>(['']);
 // Filtering with loose mode for literal union type and matching subset
 expectType<ArrayFilter<[1, 2, 3, 4, 5], 2 | 3>>([2, 3]);
 
+// Filtering tuples with mixed optional and required elements
+type Tuple = [string, number?, boolean?];
+expectType<ArrayFilter<Tuple, number>>({} as [number?]);
+expectType<ArrayFilter<Tuple, string | boolean>>({} as [string, boolean?]);
+
 // Rest elements
 expectType<ArrayFilter<['f', ...string[], 's'], string>>({} as ['f', ...string[], 's']);
 expectType<ArrayFilter<['f', ...string[], 's'], 'f' | 's'>>({} as ['f', 's']);
+expectType<ArrayFilter<[string, ...string[]], string>>({} as [string, ...string[]]);
+expectType<ArrayFilter<[string, ...string[], number], string>>({} as [string, ...string[]]);
+
+// Rest and Optiona
+expectType<ArrayFilter<[true, number?, ...string[]], string>>({} as string[]);
+expectType<ArrayFilter<[true, number?, ...string[]], number | string>>({} as [number?, ...string[]]);
+expectType<ArrayFilter<[string?, ...string[]], number | string>>({} as [string?, ...string[]]);
 
 // Edge cases
 expectType<ArrayFilter<any, never>>([]);
 expectType<ArrayFilter<any[], never>>([]);
 expectType<ArrayFilter<any[], any>>({} as []);
-expectType<ArrayFilter<any, any>>({} as [unknown]);
+expectType<ArrayFilter<any, any>>({} as []);
 expectType<ArrayFilter<never, never>>({} as never);
 expectType<ArrayFilter<never, any>>({} as never);

--- a/test-d/array-filter.ts
+++ b/test-d/array-filter.ts
@@ -1,50 +1,31 @@
 import {expectType} from 'tsd';
 import type {ArrayFilter} from '../source/array-filter.d.ts';
 
-// Basic loose filtering by number
-expectType<ArrayFilter<[1, '2', 3, 'hello', false], number>>([1, 3]);
-
-// Basic loose filtering by string
-expectType<ArrayFilter<[1, '2', 3, 'hello', false], string>>(['2', 'hello']);
+// Basic loose filtering
+expectType<ArrayFilter<[1, '2', 3, 'foo', false], number>>([1, 3]);
+expectType<ArrayFilter<[1, '2', 3, 'foo', false], string>>(['2', 'foo']);
 
 // Filtering Boolean (keep truthy values)
+expectType<ArrayFilter<[true, false, boolean, 0, 1], Boolean>>([true, 1]);
+expectType<ArrayFilter<[true, false, boolean, 0, 1], Boolean, true>>([true, 1]);
+expectType<ArrayFilter<[0, '', false, null, undefined, 'ok', 42], Boolean>>(['ok', 42]);
 expectType<ArrayFilter<[true, false, 0, 1, '', 'text', null, undefined], Boolean>>([true, 1, 'text']);
 
-// Strict filtering by literal string 'hello'
-expectType<ArrayFilter<['hello', 'world', 'hello', 'foo'], 'hello', true>>(['hello', 'hello']);
-
-// Strict filtering by literal number 3
+// Strict filtering by literals
 expectType<ArrayFilter<[1, 2, 3, 3, 4], 3, true>>([3, 3]);
+expectType<ArrayFilter<[1, '2', 3, 'foo', false], string | number>>([1, '2', 3, 'foo']);
+expectType<ArrayFilter<['foo', 'baz', 'foo', 'foo'], 'foo', true>>(['foo', 'foo', 'foo']);
+expectType<ArrayFilter<[1, '2', 3, 'foo', false], string | number, true>>([1, '2', 3, 'foo']);
 
-// Loose filtering by union string | number
-expectType<ArrayFilter<[1, '2', 3, 'hello', false], string | number>>([1, '2', 3, 'hello']);
-
-// Strict filtering by union string | number (exact matches)
-expectType<ArrayFilter<[1, '2', 3, 'hello', false], string | number, true>>([1, '2', 3, 'hello']);
-
-// Filtering with template literal `${number}`
 expectType<ArrayFilter<['1', '2', 3, 4, 'foo'], `${number}`>>(['1', '2']);
-
-// Filtering falsy values (should remove falsy)
-expectType<ArrayFilter<[0, '', false, null, undefined, 'ok', 42], Boolean>>(['ok', 42]);
-
-// Filtering strict by boolean true
-expectType<ArrayFilter<[true, false, true, 0, 1], true, true>>([true, true]);
-
-// Filtering strict by boolean false
-expectType<ArrayFilter<[true, false, true, 0, 1], false, true>>([false]);
-
-// Empty array input
-expectType<ArrayFilter<[], number>>([]);
-
-// Array of never type (should result empty)
-expectType<ArrayFilter<[never, never], number>>([]);
+expectType<ArrayFilter<[true, false, true, 0, 1], boolean>>([true, false, true]);
+expectType<ArrayFilter<[true, false, true, 0, 1], true>>([true, true]);
 
 // Filtering union with objects
 type Object1 = {a: number};
 type Object2 = {b: string};
-expectType<ArrayFilter<[Object1, Object2, {a: number; b: string}], Object1>>([{a: 1}, {a: 1, b: 'b'}]);
-expectType<ArrayFilter<[Object1, Object2, {a: number; b: string}], Object1, true>>([{a: 1}, {a: 1, b: 'b'}]);
+expectType<ArrayFilter<[Object1, Object2, Object1 & Object2], Object1>>([{a: 1}, {a: 1, b: 'b'}]);
+expectType<ArrayFilter<[Object1, Object2, Object1 & Object2], Object1, true>>([{a: 1}, {a: 1, b: 'b'}]);
 
 // Loose filtering by boolean or number
 expectType<ArrayFilter<[true, 0, 1, false, 'no'], boolean | number>>([true, 0, 1, false]);
@@ -61,12 +42,6 @@ expectType<ArrayFilter<[1, 'a', true], any>>([1, 'a', true]);
 // Filtering with never type (should remove everything)
 expectType<ArrayFilter<[1, 2, 3], never>>([]);
 // ? Shoud we change this behavior ?
-
-// Filtering with Boolean loose
-expectType<ArrayFilter<[true, false, 0, 1], Boolean>>([true, 1]);
-
-// Filtering with Boolean strict
-expectType<ArrayFilter<[true, false, 0, 1], Boolean, true>>([true, 1]);
 
 // Filtering array of arrays by array type
 expectType<ArrayFilter<[[number], string[], number[]], number[]>>([[1], [2, 3]]);
@@ -129,3 +104,8 @@ expectType<ArrayFilter<any[], any>>({} as []);
 expectType<ArrayFilter<any, any>>({} as []);
 expectType<ArrayFilter<never, never>>({} as never);
 expectType<ArrayFilter<never, any>>({} as never);
+
+expectType<ArrayFilter<[], number>>([]);
+expectType<ArrayFilter<[never, never], number>>([]);
+expectType<ArrayFilter<[never, never], never>>([]);
+expectType<ArrayFilter<[never, never], never, true>>({} as [never, never]);

--- a/test-d/array-filter.ts
+++ b/test-d/array-filter.ts
@@ -1,0 +1,123 @@
+import {expectType} from 'tsd';
+import type {ArrayFilter} from '../source/array-filter.d.ts';
+
+// Basic loose filtering by number
+expectType<ArrayFilter<[1, '2', 3, 'hello', false], number>>([1, 3]);
+
+// Basic loose filtering by string
+expectType<ArrayFilter<[1, '2', 3, 'hello', false], string>>(['2', 'hello']);
+
+// Filtering Boolean (keep truthy values)
+expectType<ArrayFilter<[true, false, 0, 1, '', 'text', null, undefined], Boolean>>([true, 1, 'text']);
+
+// Strict filtering by literal string 'hello'
+expectType<ArrayFilter<['hello', 'world', 'hello', 'foo'], 'hello', true>>(['hello', 'hello']);
+
+// Strict filtering by literal number 3
+expectType<ArrayFilter<[1, 2, 3, 3, 4], 3, true>>([3, 3]);
+
+// Loose filtering by union string | number
+expectType<ArrayFilter<[1, '2', 3, 'hello', false], string | number>>([1, '2', 3, 'hello']);
+
+// Strict filtering by union string | number (exact matches)
+expectType<ArrayFilter<[1, '2', 3, 'hello', false], string | number, true>>([1, '2', 3, 'hello']);
+
+// Filtering with template literal `${number}`
+expectType<ArrayFilter<['1', '2', 3, 4, 'foo'], `${number}`>>(['1', '2']);
+
+// Filtering falsy values (should remove falsy)
+expectType<ArrayFilter<[0, '', false, null, undefined, 'ok', 42], Boolean>>(['ok', 42]);
+
+// Filtering strict by boolean true
+expectType<ArrayFilter<[true, false, true, 0, 1], true, true>>([true, true]);
+
+// Filtering strict by boolean false
+expectType<ArrayFilter<[true, false, true, 0, 1], false, true>>([false]);
+
+// Empty array input
+expectType<ArrayFilter<[], number>>([]);
+
+// Array of never type (should result empty)
+expectType<ArrayFilter<[never, never], number>>([]);
+
+// Filtering union with objects
+type Object1 = {a: number};
+type Object2 = {b: string};
+expectType<ArrayFilter<[Object1, Object2, {a: number; b: string}], Object1>>([{a: 1}, {a: 1, b: 'b'}]);
+expectType<ArrayFilter<[Object1, Object2, {a: number; b: string}], Object1, true>>([{a: 1}, {a: 1, b: 'b'}]);
+
+// Loose filtering by boolean or number
+expectType<ArrayFilter<[true, 0, 1, false, 'no'], boolean | number>>([true, 0, 1, false]);
+
+// Filtering array containing null | undefined | string
+expectType<ArrayFilter<[null, undefined, 'foo', ''], string>>(['foo', '']);
+
+// Filtering with unknown type (should keep everything)
+expectType<ArrayFilter<[1, 'a', true], unknown>>([1, 'a', true]);
+
+// Filtering with any type (should keep everything)
+expectType<ArrayFilter<[1, 'a', true], any>>([1, 'a', true]);
+
+// Filtering with never type (should remove everything)
+expectType<ArrayFilter<[1, 2, 3], never>>([]);
+// ? Shoud we change this behavior ?
+
+// Filtering with Boolean loose
+expectType<ArrayFilter<[true, false, 0, 1], Boolean>>([true, 1]);
+
+// Filtering with Boolean strict
+expectType<ArrayFilter<[true, false, 0, 1], Boolean, true>>([true, 1]);
+
+// Filtering array of arrays by array type
+expectType<ArrayFilter<[[number], string[], number[]], number[]>>([[1], [2, 3]]);
+
+// Filtering by a union including literal and broader type
+expectType<ArrayFilter<[1, 2, 3, 'foo', 'bar'], 1 | string>>([1, 'foo', 'bar']);
+
+// Filtering complex nested union types
+type Nested = {x: string} | {y: number} | null;
+expectType<ArrayFilter<[ {x: 'a'}, {y: 2}, null, {z: true} ], Nested>>([{x: 'a'}, {y: 2}, null]);
+
+// Filtering with boolean type but array has no boolean values
+expectType<ArrayFilter<[1, 2, 3], Boolean>>([1, 2, 3]);
+
+// Filtering with boolean type but array has falsy values
+expectType<ArrayFilter<[0, '', false, null, undefined], Boolean>>([]);
+
+// Filtering string literals with template literal union
+expectType<ArrayFilter<['foo1', 'bar2', 'foo3'], `foo${number}`>>(['foo1', 'foo3']);
+
+// Filtering with `Boolean` type but including custom objects with truthy/falsy behavior
+class Foo {}
+expectType<ArrayFilter<[typeof Foo, {}, null, undefined], Boolean>>([Foo, {}]);
+
+// Filtering tuples with mixed optional and required elements
+type Tuple = [string, number?, boolean?];
+expectType<ArrayFilter<Tuple, number>>([/* should be [number?] filtered out? */]);
+
+// Filtering with strict = true and union including literals and primitives
+expectType<ArrayFilter<[1, '1', 2, '2', true, false], number | `${number}`, true>>([1, '1', 2, '2']);
+
+// Filtering falsy values mixed with ({} | [] is truthy)
+expectType<ArrayFilter<[false, 0, '', null, undefined, {}, []], Boolean>>([{}, []]);
+
+// Filtering with `true` literal (strict) but array contains boolean and number
+expectType<ArrayFilter<[true, false, 1, 0], true, true>>([true]);
+
+// Filtering empty string literal type with strict mode
+expectType<ArrayFilter<['', 'non-empty'], '', true>>(['']);
+
+// Filtering with loose mode for literal union type and matching subset
+expectType<ArrayFilter<[1, 2, 3, 4, 5], 2 | 3>>([2, 3]);
+
+// Rest elements
+expectType<ArrayFilter<['f', ...string[], 's'], string>>({} as ['f', ...string[], 's']);
+expectType<ArrayFilter<['f', ...string[], 's'], 'f' | 's'>>({} as ['f', 's']);
+
+// Edge cases
+expectType<ArrayFilter<any, never>>([]);
+expectType<ArrayFilter<any[], never>>([]);
+expectType<ArrayFilter<any[], any>>({} as []);
+expectType<ArrayFilter<any, any>>({} as [unknown]);
+expectType<ArrayFilter<never, never>>({} as never);
+expectType<ArrayFilter<never, any>>({} as never);

--- a/test-d/internal/is-leading-rest-element.ts
+++ b/test-d/internal/is-leading-rest-element.ts
@@ -1,0 +1,87 @@
+import {expectType} from 'tsd';
+import type {IsLeadingRestElement} from '../../source/internal/array.d.ts';
+
+// ✅ TRUE CASES (leading rest)
+
+expectType<IsLeadingRestElement<[...string[], number]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...any[], string, boolean]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...unknown[], 'a']>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...readonly number[], 1, 2]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...string[]]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...any[]]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<[...string[], ...[number]]>>(true);
+//     ^?
+
+// ❌ FALSE CASES (not leading rest)
+
+expectType<IsLeadingRestElement<[...[string], ...number[]]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[string, number]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[undefined, ...number[]]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[never, ...string[]]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[boolean]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[() => void]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[1, 2, 3]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<['a', ...string[]]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[null, ...string[]]>>(false);
+//     ^?
+
+// Edge cases
+
+expectType<IsLeadingRestElement<any>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<never>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<string[]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<number[]>>(true);
+//     ^?
+
+expectType<IsLeadingRestElement<readonly []>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[string?]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[...[], number]>>(false);
+//     ^?
+
+expectType<IsLeadingRestElement<[string, ...string[]]>>(false);
+//     ^?
+
+// ! Need Fix: `[...string[]] extends [string?, ...string[]]`
+expectType<IsLeadingRestElement<[string?, ...string[]]>>(true);
+//     ^?


### PR DESCRIPTION
Filters elements from an `Array` based on whether they match the given `Type`.
If `Type` is `Boolean`, it filters out `falsy` values like `Boolean(T)` does.

Strict controls whether strict or loose type comparison is used (defaults to loose).
