### PR TITLE
`IsLiteral`: Update example in JSDoc

### DIFF
--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -303,31 +303,6 @@ type K = IsLiteral<boolean>;
 //=> false
 ```
 
-@example
-```
-import type {IsLiteral} from 'type-fest';
-
-// https://github.com/inocan-group/inferred-types/blob/master/modules/types/src/string-literals/StripLeading.ts
-export type StripLeading<A, B> =
-	A extends string
-		? B extends string
-			? IsLiteral<A> extends true
-				? string extends B ? never : A extends `${B & string}${infer After}` ? After : A
-				: string
-			: A
-		: A;
-
-function stripLeading<Input extends string, Strip extends string>(input: Input, strip: Strip) {
-	return input.replace(new RegExp(`^${strip}`), '') as StripLeading<Input, Strip>;
-}
-
-stripLeading('abc123', 'abc');
-//=> '123'
-
-stripLeading('abc123' as string, 'abc');
-//=> string
-```
-
 @category Type Guard
 @category Utilities
 */

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -268,6 +268,45 @@ Useful for:
 ```
 import type {IsLiteral} from 'type-fest';
 
+type A = IsLiteral<1>;
+//=> true
+
+type B = IsLiteral<number>;
+//=> false
+
+type C = IsLiteral<1n>;
+//=> true
+
+type D = IsLiteral<bigint>;
+//=> false
+
+type E = IsLiteral<'type-fest'>;
+//=> true
+
+type F = IsLiteral<string>;
+//=> false
+
+type G = IsLiteral<`on${string}`>;
+//=> false
+
+declare const symbolLiteral: unique symbol;
+type H = IsLiteral<typeof symbolLiteral>;
+//=> true
+
+type I = IsLiteral<symbol>;
+//=> false
+
+type J = IsLiteral<true>;
+//=> true
+
+type K = IsLiteral<boolean>;
+//=> false
+```
+
+@example
+```
+import type {IsLiteral} from 'type-fest';
+
 // https://github.com/inocan-group/inferred-types/blob/master/modules/types/src/string-literals/StripLeading.ts
 export type StripLeading<A, B> =
 	A extends string

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -279,7 +279,7 @@ export type StripLeading<A, B> =
 		: A;
 
 function stripLeading<Input extends string, Strip extends string>(input: Input, strip: Strip) {
-	return input.replace(`^${strip}`, '') as StripLeading<Input, Strip>;
+	return input.replace(new RegExp(`^${strip}`), '') as StripLeading<Input, Strip>;
 }
 
 stripLeading('abc123', 'abc');

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -285,9 +285,7 @@ function stripLeading<Input extends string, Strip extends string>(input: Input, 
 stripLeading('abc123', 'abc');
 //=> '123'
 
-const str = 'abc123' as string;
-
-stripLeading(str, 'abc');
+stripLeading('abc123' as string, 'abc');
 //=> string
 ```
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes the replacer in the example, should be a regex for `^` to work.
https://github.com/sindresorhus/type-fest/blob/5dbd7aed6ac6bb561229761ff7a3061098e47704/source/is-literal.d.ts#L282

<hr>

Also, I think the way `IsLiteral` is used within `StripLiteral` doesn’t showcase a very good use case—especially now that we’ve fixed the behavior of `IsStringLiteral` to return `false` for all infinite string types.

The `IsLiteral` check should be on the `Prefix`, not on the input type `S` (see the example below). So, I think we should either remove this example or update its implementation.

```ts
type StripLeading<S extends string, Prefix extends string> = S extends string // For distributing `S`
  ? Prefix extends string // For distributing `Suffix`
    ? IsLiteral<S> extends true
      ? string extends Prefix
        ? never
        : S extends `${Prefix}${infer After}`
          ? After
          : S
      : string
    : never
  : never;

type T11 = StripLeading<`on${Capitalize<string>}`, 'on'>; // The result here could have been more precise
//   ^? type T11 = string

type T12 = StripLeading<'foobar', string>; // `never` makes the output unusable, should have been `string` instead
//   ^? type T12 = never
```

```ts
type NewStripLeading<S extends string, Prefix extends string> = S extends string // For distributing `S`
  ? Prefix extends string // For distributing `Suffix`
    ? IsLiteral<Prefix> extends true
      ? S extends `${Prefix}${infer After}`
        ? After
        : string
      : string
    : never
  : never;

type T21 = NewStripLeading<`on${Capitalize<string>}`, 'on'>;
//   ^? type T21 = Capitalize<string>

type T22 = NewStripLeading<'foobar', string>;
//   ^? type T22 = string
```
[Playground](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true&module=1&exactOptionalPropertyTypes=false#code/JYWwDg9gTgLgBAbzgSQM4BlgwKZQIYA2cAvnAGZQQhwDkMAnmNgLRnaow0DcAsAFD8GTOAGUYUYGHTY8AE2AA7AOYAeEXGwAPHAtmo4HCcoA0cAApRsZYJo3bsu-YcVKAfHAC8ouzr0HxLnAA9EFwAGLQcPLOAEYArjCBAAYiSfxwcAD85pbWtlq+TgHKwaERUFHAsQnJInFkeWl8GRnZaJg4+ARq7gUOfuJx2Oktrf5GSj79+hZWNiOjYwrYAG64C4sAXN59jnBJACQIs3nER4psFQCCZJ3ETYuL2TedG4-bIm9w287KG9vLNZQEYA1a4XgCPhCbBwAAqAEZ4Z5RAEpDJ5MoVEkIAojgBhPBgLCEYAAL2wKl+bnuphoOJori4pThAAsYZZUHECPA2ZY4ABjCBc2RwFl4NZwGLYBxwEDQGFgSz8qrDPghFoAPWy0LhiORVP4gkYMIRACZkWIJGi5C4VDQyBAIDE8FAaKYqYzmUlAbgkrK8ABrdhwGBsuBCmBgBJwOIKOKoPAxAjYd0soUEEViiVSmVJKl+xQcdH8dUZLUh42681eH3AyE6gBy2AA7pbJNIbZj1Ls-FTTCcbFM9h6LUPe8VJurypVqokSikHlkcnN8vZhxPmdPogF4nPJil6o0Nm0MFhcIQVAPNL01wMoEMvtlu7f9IdjrkbGcEBdcHAXrh7i+MZ-zrR4Mh+CcvggiZ-jgWsQTgsEoAhI1hFhU0kS8JtW1RDsMVUbFcQQAkiRgElyUpCdXBpWh6UZEtQjLbVK3QzC4BI4kCDJCkPUNKEWNNas4GwttrXwu0HSdF03XGFx6LVRi4HLHV0KEg0+CAA)

<hr>

On a different note, maybe we can consider adding a `StripLeading` type?