### PR TITLE
Add `IsOptionalKeyOf`, `IsReadonlyKeyOf`, `IsRequiredKeyOf`, and `IsWritableKeyOf` types

### DIFF
--- a/source/optional-keys-of.d.ts
+++ b/source/optional-keys-of.d.ts
@@ -1,5 +1,5 @@
 /**
-Extract all optional keys from the given type.
+Extract all optional keys from the given `Type`.
 
 This is useful when you want to create a new type that contains different type values for the optional keys only.
 
@@ -45,7 +45,7 @@ export type OptionalKeysOf<Type extends object> =
 /**
 Returns a boolean to whether `Key` is an optional key of `Type`.
 
-This is useful when you want to create a new type that contains different type values for the optional keys only.
+This is useful when writing utility types or schema validators that need to differentiate `optional` keys.
 
 @example
 ```
@@ -72,7 +72,10 @@ type T2 = IsOptionalKeyOf<User, 'name'>
 type T3 = IsOptionalKeyOf<User, 'name' | 'luckyNumber'>
 //=> boolean
 
-type T4 = IsOptionalKeyOf<User | Admin, 'surname'>
+type T4 = IsOptionalKeyOf<User | Admin, 'name'>
+//=> false
+
+type T5 = IsOptionalKeyOf<User | Admin, 'surname'>
 //=> boolean
 ```
 

--- a/source/optional-keys-of.d.ts
+++ b/source/optional-keys-of.d.ts
@@ -31,9 +31,57 @@ const update2: UpdateOperation<User> = {
 
 @category Utilities
 */
-export type OptionalKeysOf<BaseType extends object> =
-	BaseType extends unknown // For distributing `BaseType`
+export type OptionalKeysOf<Type extends object> =
+	Type extends unknown // For distributing `Type`
 		? (keyof {
-			[Key in keyof BaseType as BaseType extends Record<Key, BaseType[Key]> ? never : Key]: never
-		}) & (keyof BaseType) // Intersect with `keyof BaseType` to ensure result of `OptionalKeysOf<BaseType>` is always assignable to `keyof BaseType`
+			[Key in keyof Type as 
+				IsOptionalKeyOf<Type, Key> extends false 
+					? never 
+					: Key
+			]: never
+		}) & keyof Type // Intersect with `keyof Type` to ensure result of `OptionalKeysOf<Type>` is always assignable to `keyof Type`
+		: never; // Should never happen
+
+/**
+Returns a boolean to whether `Key` is an optional key of `Type`.
+
+This is useful when you want to create a new type that contains different type values for the optional keys only.
+
+@example
+```
+import type {IsOptionalKeyOf} from 'type-fest';
+
+interface User {
+	name: string;
+	surname: string;
+
+	luckyNumber?: number;
+}
+
+interface Admin {
+	name: string;
+	surname?: string
+}
+
+type T1 = IsOptionalKeyOf<User, 'luckyNumber'>
+//=> true
+
+type T2 = IsOptionalKeyOf<User, 'name'>
+//=> false
+
+type T3 = IsOptionalKeyOf<User, 'name' | 'luckyNumber'>
+//=> boolean
+
+type T4 = IsOptionalKeyOf<User | Admin, 'surname'>
+//=> boolean
+```
+
+@category Type Guard
+@category Utilities
+*/
+export type IsOptionalKeyOf<Type extends object, Key extends keyof Type> =
+	Key extends unknown // For distributing `Key`
+		? Type extends Record<Key, Type[Key]> 
+			? false 
+			: true
 		: never; // Should never happen

--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,4 +1,4 @@
-import type {WritableKeysOf} from './writable-keys-of.d.ts';
+import type {IsEqual} from './is-equal.js';
 
 /**
 Extract all readonly keys from the given type.
@@ -24,7 +24,20 @@ const update1: UpdateResponse<User> = {
 
 @category Utilities
 */
-export type ReadonlyKeysOf<T extends object> =
-	T extends unknown // For distributing `T`
-		? Exclude<keyof T, WritableKeysOf<T>>
+export type ReadonlyKeysOf<Type extends object> =
+	Type extends unknown // For distributing `Type`
+		? (keyof {
+			[Key in keyof Type as IsReadonlyKeyOf<Type, Key> extends true 
+				? Key 
+				: never
+			]: never
+		}) & keyof Type // Intersect with `keyof Type` to ensure result of `ReadonlyKeysOf<Type>` is always assignable to `keyof Type`
+		: never; // Should never happen
+
+export type IsReadonlyKeyOf<Type extends object, Key extends keyof Type> =
+	Key extends unknown // For distributing `Key`
+		? IsEqual<
+			{[K in Key]: Type[Key]},
+			{readonly [K in Key]: Type[Key]}
+		>
 		: never; // Should never happen

--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,7 +1,7 @@
 import type {IsEqual} from './is-equal.js';
 
 /**
-Extract all readonly keys from the given type.
+Extract all readonly keys from the given `Type`.
 
 This is useful when you want to create a new type that contains readonly keys only.
 
@@ -27,13 +27,53 @@ const update1: UpdateResponse<User> = {
 export type ReadonlyKeysOf<Type extends object> =
 	Type extends unknown // For distributing `Type`
 		? (keyof {
-			[Key in keyof Type as IsReadonlyKeyOf<Type, Key> extends true 
-				? Key 
-				: never
+			[Key in keyof Type as 
+				IsReadonlyKeyOf<Type, Key> extends false 
+					? never
+					: Key 
 			]: never
 		}) & keyof Type // Intersect with `keyof Type` to ensure result of `ReadonlyKeysOf<Type>` is always assignable to `keyof Type`
 		: never; // Should never happen
 
+/**
+Returns a boolean to whether `Key` is a readonly key of `Type`.
+
+This is useful when writing utility types or schema validators that need to differentiate `readonly` keys.
+
+@example
+```
+import type {IsReadonlyKeyOf} from 'type-fest';
+
+interface User {
+	name: string;
+	surname: string;
+	readonly id: number;
+}
+
+interface Admin {
+	name: string;
+	id: string
+}
+
+type T1 = IsReadonlyKeyOf<User, 'id'>
+//=> true
+
+type T2 = IsReadonlyKeyOf<User, 'name'>
+//=> false
+
+type T3 = IsReadonlyKeyOf<User, 'name' | 'id'>
+//=> boolean
+
+type T4 = IsReadonlyKeyOf<User | Admin, 'name'>
+//=> false
+
+type T5 = IsReadonlyKeyOf<User | Admin, 'id'>
+//=> boolean
+```
+
+@category Type Guard
+@category Utilities
+*/
 export type IsReadonlyKeyOf<Type extends object, Key extends keyof Type> =
 	Key extends unknown // For distributing `Key`
 		? IsEqual<

--- a/source/readonly-keys-of.d.ts
+++ b/source/readonly-keys-of.d.ts
@@ -1,4 +1,4 @@
-import type {IsEqual} from './is-equal.js';
+import type {IsEqual} from './is-equal.d.ts';
 
 /**
 Extract all readonly keys from the given `Type`.

--- a/source/required-keys-of.d.ts
+++ b/source/required-keys-of.d.ts
@@ -1,4 +1,5 @@
-import type {OptionalKeysOf} from './optional-keys-of.d.ts';
+import type {IsOptionalKeyOf, OptionalKeysOf} from './optional-keys-of.d.ts';
+import type {Not} from './internal/type.js';
 
 /**
 Extract all required keys from the given type.
@@ -24,7 +25,9 @@ const validator2 = createValidation<User>('surname', value => value.length < 25)
 
 @category Utilities
 */
-export type RequiredKeysOf<BaseType extends object> =
-	BaseType extends unknown // For distributing `BaseType`
-		? Exclude<keyof BaseType, OptionalKeysOf<BaseType>>
+export type RequiredKeysOf<Type extends object> =
+	Type extends unknown // For distributing `Type`
+		? Exclude<keyof Type, OptionalKeysOf<Type>>
 		: never; // Should never happen
+
+export type IsRequiredKeyOf<Type extends object, Key extends keyof Type> = Not<IsOptionalKeyOf<Type, Key>>

--- a/source/required-keys-of.d.ts
+++ b/source/required-keys-of.d.ts
@@ -1,5 +1,5 @@
 import type {IsOptionalKeyOf, OptionalKeysOf} from './optional-keys-of.d.ts';
-import type {Not} from './internal/type.js';
+import type {Not} from './internal/type.d.ts';
 
 /**
 Extract all required keys from the given type.

--- a/source/required-keys-of.d.ts
+++ b/source/required-keys-of.d.ts
@@ -30,4 +30,44 @@ export type RequiredKeysOf<Type extends object> =
 		? Exclude<keyof Type, OptionalKeysOf<Type>>
 		: never; // Should never happen
 
+/**
+Returns a boolean to whether `Key` is a required key of `Type`.
+
+This is useful when writing utility types or schema validators that need to differentiate `required` keys.
+
+@example
+```
+import type {IsRequiredKeyOf} from 'type-fest';
+
+interface User {
+	name: string;
+	surname: string;
+
+	luckyNumber?: number;
+}
+
+interface Admin {
+	name: string;
+	surname?: string
+}
+
+type T1 = IsRequiredKeyOf<User, 'name'>
+//=> true
+
+type T2 = IsRequiredKeyOf<User, 'luckyNumber'>
+//=> false
+
+type T3 = IsRequiredKeyOf<User, 'name' | 'luckyNumber'>
+//=> boolean
+
+type T4 = IsRequiredKeyOf<User | Admin, 'name'>
+//=> true
+
+type T5 = IsRequiredKeyOf<User | Admin, 'surname'>
+//=> boolean
+```
+
+@category Type Guard
+@category Utilities
+*/
 export type IsRequiredKeyOf<Type extends object, Key extends keyof Type> = Not<IsOptionalKeyOf<Type, Key>>

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -1,4 +1,5 @@
-import type {IsEqual} from './is-equal.d.ts';
+import type {IsReadonlyKeyOf, ReadonlyKeysOf} from './readonly-keys-of.js';
+import type {Not} from './internal/type.js';
 
 /**
 Extract all writable keys from the given type.
@@ -25,9 +26,9 @@ const update1: UpdateRequest<User> = {
 
 @category Utilities
 */
-export type WritableKeysOf<T extends object> =
-	T extends unknown // For distributing `T`
-		? (keyof {
-			[P in keyof T as IsEqual<{[Q in P]: T[P]}, {readonly [Q in P]: T[P]}> extends false ? P : never]: never
-		}) & keyof T // Intersect with `keyof T` to ensure result of `WritableKeysOf<T>` is always assignable to `keyof T`
+export type WritableKeysOf<Type extends object> =
+	Type extends unknown // For distributing `Type`
+		? Exclude<keyof Type, ReadonlyKeysOf<Type>>
 		: never; // Should never happen
+
+export type IsWritableKeyOf<Type extends object, Key extends keyof Type> = Not<IsReadonlyKeyOf<Type, Key>>;

--- a/source/writable-keys-of.d.ts
+++ b/source/writable-keys-of.d.ts
@@ -1,5 +1,5 @@
-import type {IsReadonlyKeyOf, ReadonlyKeysOf} from './readonly-keys-of.js';
-import type {Not} from './internal/type.js';
+import type {IsReadonlyKeyOf, ReadonlyKeysOf} from './readonly-keys-of.d.ts';
+import type {Not} from './internal/type.d.ts';
 
 /**
 Extract all writable keys from the given type.
@@ -31,4 +31,43 @@ export type WritableKeysOf<Type extends object> =
 		? Exclude<keyof Type, ReadonlyKeysOf<Type>>
 		: never; // Should never happen
 
+/**
+Returns a boolean to whether `Key` is a readonly key of `Type`.
+
+This is useful when writing utility types or schema validators that need to differentiate `writable` keys.
+
+@example
+```
+import type {IsWritableKeyOf} from 'type-fest';
+
+interface User {
+	name: string;
+	surname: string;
+	readonly id: number;
+}
+
+interface Admin {
+	name: string;
+	id: string
+}
+
+type T1 = IsWritableKeyOf<User, 'name'>
+//=> true
+
+type T2 = IsWritableKeyOf<User, 'id'>
+//=> false
+
+type T3 = IsWritableKeyOf<User, 'name' | 'id'>
+//=> boolean
+
+type T4 = IsWritableKeyOf<User | Admin, 'name'>
+//=> true
+
+type T5 = IsWritableKeyOf<User | Admin, 'id'>
+//=> boolean
+```
+
+@category Type Guard
+@category Utilities
+*/
 export type IsWritableKeyOf<Type extends object, Key extends keyof Type> = Not<IsReadonlyKeyOf<Type, Key>>;


### PR DESCRIPTION
adding object/array keys type guards `Is*KeyOf` to check the state/modifier of key(s) 

> [!NOTE]
> Do they need seperated test ?
> I think that most of the cases are covered in `*KeysOf`, so if they ever fail we know that `Is*KeyOf` failed. 
> the only cases that should be tested is union of keys: `IsOptionalKeyOf<Type, 'a' | 'b'>`