### PR TITLE
Add `RemovePrefix` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,7 @@ export type {Get} from './source/get.d.ts';
 export type {LastArrayElement} from './source/last-array-element.d.ts';
 export type {ConditionalSimplify} from './source/conditional-simplify.d.ts';
 export type {ConditionalSimplifyDeep} from './source/conditional-simplify-deep.d.ts';
+export type {RemovePrefix} from './source/remove-prefix.d.ts';
 
 // Miscellaneous
 export type {GlobalThis} from './source/global-this.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,7 @@ Click the type names for complete docs.
 - [`Replace`](source/replace.d.ts) - Represents a string with some or all matches replaced by a replacement.
 - [`StringSlice`](source/string-slice.d.ts) - Returns a string slice of a given range, just like `String#slice()`.
 - [`StringRepeat`](source/string-repeat.d.ts) - Returns a new string which contains the specified number of copies of a given string, just like `String#repeat()`.
+- [`RemovePrefix`](source/remove-prefix.d.ts) - Removes the specified prefix from the start of a string.
 
 ### Array
 

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,6 +1,7 @@
 import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal/index.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
 import type {Merge} from './merge.d.ts';
+import type {RemovePrefix} from './remove-prefix.d.ts';
 import type {DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
 
 export type DefaultDelimiterCaseOptions = Merge<DefaultWordsOptions, {splitOnNumbers: false}>;
@@ -20,10 +21,6 @@ type DelimiterCaseFromArray<
 		StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
 	}${FirstWord}`>
 	: OutputString;
-
-type RemoveFirstLetter<S extends string> = S extends `${infer _}${infer Rest}`
-	? Rest
-	: '';
 
 /**
 Convert a string literal to a custom string delimiter casing.
@@ -71,8 +68,8 @@ export type DelimiterCase<
 > = Value extends string
 	? IsStringLiteral<Value> extends false
 		? Value
-		: Lowercase<RemoveFirstLetter<DelimiterCaseFromArray<
+		: Lowercase<RemovePrefix<DelimiterCaseFromArray<
 			Words<Value, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>,
 			Delimiter
-		>>>
+		>, string, {strict: false}>>
 	: Value;

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -8,7 +8,7 @@ import type {Or} from './or.d.ts';
 */
 type RemovePrefixOptions = {
 	/**
-	When enabled, instantiations with non-literal prefixes (e.g., `string`, `Uppercase<string>`, `` `on${string}` ``) simply return back `string`, since their precise structure cannot be statically determined.
+	When enabled, instantiations with non-literal prefixes (e.g., `string`, `Uppercase<string>`, `` `on${string}` ``) simply return `string`, since their precise structure cannot be statically determined.
 
 	Note: Disabling this option can produce misleading results that might not reflect the actual runtime behavior.
 	For example, ``RemovePrefix<'on-change', `${string}-`, {strict: false}>`` returns `'change'`, but at runtime, prefix could be `'handle-'` (which satisfies `` `${string}-` ``) and removing `'handle-'` from `'on-change'` would not result in `'change'`.
@@ -65,13 +65,13 @@ type RemovePrefixOptions = {
 	type A = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: true}>;
 	//=> `${string}/${number}`
 
-	type B = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: true}>;
+	type B = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: false}>;
 	//=> `${string}/${number}`
 
 	type C = RemovePrefix<'on-change', `${number}-`, {strict: true}>;
 	//=> 'on-change'
 
-	type D = RemovePrefix<'on-change', `${number}-`, {strict: true}>;
+	type D = RemovePrefix<'on-change', `${number}-`, {strict: false}>;
 	//=> 'on-change'
 	```
 	*/

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -1,0 +1,128 @@
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IfNotAnyOrNever, Not} from './internal/type.d.ts';
+import type {IsStringLiteral} from './is-literal.d.ts';
+import type {Or} from './or.d.ts';
+
+/**
+@see {@link RemovePrefix}
+*/
+type RemovePrefixOptions = {
+	/**
+	When enabled, instantiations with non-literal prefixes (e.g., `string`, `Uppercase<string>`, `` `on${string}` ``) simply return back `string`, since their precise structure cannot be statically determined.
+
+	Note: Disabling this option can produce misleading results that might not reflect the actual runtime behavior.
+	For example, ``RemovePrefix<'on-change', `${string}-`, {strict: false}>`` returns `'change'`, but at runtime, prefix could be `'handle-'` (which satisfies `` `${string}-` ``) and removing `'handle-'` from `'on-change'` would not result in `'change'`.
+
+	So, it is recommended to not disable this option unless you are aware of the implications.
+
+	@default true
+
+	@example
+	```
+	type A = RemovePrefix<'on-change', `${string}-`, {strict: true}>;
+	//=> string
+
+	type B = RemovePrefix<'on-change', `${string}-`, {strict: false}>;
+	//=> 'change'
+
+	type C = RemovePrefix<'on-change', string, {strict: true}>;
+	//=> string
+
+	type D = RemovePrefix<'on-change', string, {strict: false}>;
+	//=> 'n-change'
+
+	type E = RemovePrefix<`${string}/${number}`, `${string}/`, {strict: true}>;
+	//=> string
+
+	type F = RemovePrefix<`${string}/${number}`, `${string}/`, {strict: false}>;
+	//=> `${number}`
+	```
+
+	Note: This option has no effect when only the input string type is non-literal. For example, ``RemovePrefix<`on-${string}`, 'on-'>`` will always return `string`.
+
+	@example
+	```
+	import type {RemovePrefix} from 'type-fest';
+
+	type A = RemovePrefix<`on-${string}`, 'on-', {strict: true}>;
+	//=> string
+
+	type B = RemovePrefix<`on-${string}`, 'on-', {strict: false}>;
+	//=> string
+
+	type C = RemovePrefix<`id-${number}`, 'id-', {strict: true}>;
+	//=> `${number}`
+
+	type D = RemovePrefix<`id-${number}`, 'id-', {strict: false}>;
+	//=> `${number}`
+	```
+
+	Note: If it can be statically determined that the input string can never start with the specified non-literal prefix, then the input string is returned as-is, regardless of the value of this option.
+	For example, ``RemovePrefix<`${string}/${number}`, `${string}:`>`` returns `` `${string}/${number}` ``, since a string of type `` `${string}/${number}` `` can never start with a prefix of type `` `${string}:` ``.
+	```
+	import type {RemovePrefix} from 'type-fest';
+
+	type A = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: true}>;
+	//=> `${string}/${number}`
+
+	type B = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: true}>;
+	//=> `${string}/${number}`
+
+	type C = RemovePrefix<'on-change', `${number}-`, {strict: true}>;
+	//=> 'on-change'
+
+	type D = RemovePrefix<'on-change', `${number}-`, {strict: true}>;
+	//=> 'on-change'
+	```
+	*/
+	strict?: boolean;
+};
+
+type DefaultRemovePrefixOptions = {
+	strict: true;
+};
+
+/**
+Removes the specified prefix from the start of a string.
+
+@example
+```
+import type {RemovePrefix} from 'type-fest';
+
+type A = RemovePrefix<'on-change', 'on-'>;
+//=> 'change'
+
+type B = RemovePrefix<'sm:flex' | 'sm:p-4' | 'sm:gap-2', 'sm:'>;
+//=> 'flex' | 'p-4' | 'gap-2'
+
+type C = RemovePrefix<'on-change', 'off-'>;
+//=> 'on-change'
+
+type D = RemovePrefix<`handle${Capitalize<string>}`, 'handle'>;
+//=> Capitalize<string>
+```
+
+@see {@link RemovePrefixOptions}
+
+@category String
+@category Template literal
+*/
+export type RemovePrefix<S extends string, Prefix extends string, Options extends RemovePrefixOptions = {}> =
+IfNotAnyOrNever<
+	S,
+	IfNotAnyOrNever<
+		Prefix,
+		_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>,
+		string,
+		S
+	>
+>;
+
+type _RemovePrefix<S extends string, Prefix extends string, Options extends Required<RemovePrefixOptions>> =
+Prefix extends string // For distributing `Prefix`
+	? S extends `${Prefix}${infer Rest}`
+		? Or<IsStringLiteral<Prefix>, Not<Options['strict']>> extends true
+			? Rest
+			: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
+		: S // Return back `S` when `Prefix` is not present at the start of `S`
+	: never;

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -1,0 +1,95 @@
+import {expectType} from 'tsd';
+import type {RemovePrefix} from '../source/remove-prefix.d.ts';
+
+expectType<'change'>({} as RemovePrefix<'on-change', 'on-'>);
+expectType<'Click'>({} as RemovePrefix<'handleClick', 'handle'>);
+expectType<'vscode'>({} as RemovePrefix<'.vscode', '.'>);
+expectType<'whitespace'>({} as RemovePrefix<' whitespace', ' '>);
+
+// Prefix not present
+expectType<''>({} as RemovePrefix<'', 'foo'>);
+expectType<'on-mouse-move'>({} as RemovePrefix<'on-mouse-move', 'click'>);
+
+// Empty prefix
+expectType<'baz'>({} as RemovePrefix<'baz', ''>);
+
+// Prefix completely matches the input string
+expectType<''>({} as RemovePrefix<'click', 'click'>);
+
+// Prefix partially matches the input string
+expectType<'foobar'>({} as RemovePrefix<'foobar', 'foobaz'>);
+expectType<'hello'>({} as RemovePrefix<'hello', 'helloworld'>);
+
+// Multiple occurrences of prefix (should only remove from start)
+expectType<'bar-bar-foo'>({} as RemovePrefix<'bar-bar-bar-foo', 'bar-'>);
+expectType<'foofoo'>({} as RemovePrefix<'foofoofoo', 'foo'>);
+
+// === Non-literals ===
+
+// Input: Non-literal, Prefix: Literal
+expectType<string>({} as RemovePrefix<`hover:${string}`, 'hover:'>);
+expectType<Capitalize<string>>({} as RemovePrefix<`on${Capitalize<string>}`, 'on'>);
+expectType<`${number}`>({} as RemovePrefix<`id-${number}`, 'id-'>);
+expectType<`${string}--`>({} as RemovePrefix<`--${string}--`, '--'>);
+expectType<`focus:${string}`>({} as RemovePrefix<`hover:focus:${string}`, 'hover:'>);
+expectType<`user_${string}`>({} as RemovePrefix<`user_${string}`, 'admin_'>);
+expectType<string>({} as RemovePrefix<string, 'on'>);
+expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, 'foo'>);
+
+// Input: Literal, Prefix: Non-literal
+expectType<string>({} as RemovePrefix<'on-click', `${string}-`>);
+expectType<string>({} as RemovePrefix<'hover:flex', string>);
+expectType<'handle-click'>({} as RemovePrefix<'handle-click', Uppercase<string>>);
+expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`>);
+
+// Input: Non-literal, Prefix: Non-literal
+expectType<string>({} as RemovePrefix<`hover:${string}`, `${string}:`>);
+expectType<string>({} as RemovePrefix<`${string}/${number}`, `${string}/`>);
+expectType<string>({} as RemovePrefix<string, string>);
+expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}:`>);
+expectType<`${number}:${number}`>({} as RemovePrefix<`${number}:${number}`, `-${string}`>);
+
+// Unions
+expectType<'click' | 'hover' | 'change'>({} as RemovePrefix<'on-click' | 'on-hover' | 'on-change', 'on-'>);
+expectType<'click' | 'hover' | 'handle-change'>({} as RemovePrefix<'on-click' | 'on-hover' | 'handle-change', 'on-'>);
+expectType<Uppercase<string> | `${number}`>({} as RemovePrefix<`id-${Uppercase<string>}` | `id-${number}`, 'id-'>);
+expectType<string>({} as RemovePrefix<`hover:${string}` | `focus:${string}`, `${string}:`>);
+
+expectType<'-change' | 'change'>({} as RemovePrefix<'on-change', 'on' | 'on-'>);
+expectType<'change' | 'on-change'>({} as RemovePrefix<'on-change', 'on-' | 'handle-'>);
+expectType<'on-change'>({} as RemovePrefix<'on-change', 'off-' | 'handle-'>);
+expectType<string>({} as RemovePrefix<'on-change', `${string}-` | 'on'>);
+
+expectType<'on:change' | 'onChange'>({} as RemovePrefix<'on:change' | 'onChange', `${string}-`>);
+expectType<'name' | 'get-name' | 'age' | 'set-age' | 'other'>(
+	{} as RemovePrefix<'get-name' | 'set-age' | 'other', 'get-' | 'set-'>,
+);
+expectType<string>({} as RemovePrefix<`id:${Uppercase<string>}` | `id/${number}`, `${string}:` | `${string}/`>);
+
+// Boundary types
+expectType<any>({} as RemovePrefix<any, 'foo'>);
+expectType<never>({} as RemovePrefix<never, 'foo'>);
+expectType<string>({} as RemovePrefix<'on-change', any>);
+expectType<'on-change'>({} as RemovePrefix<'on-change', never>);
+
+// === strict: false ===
+
+// No effect if `Prefix` is a literal
+expectType<'change'>({} as RemovePrefix<'on-change', 'on-', {strict: false}>);
+expectType<'change' | 'hover'>({} as RemovePrefix<'on-change' | 'on-hover', 'on-', {strict: false}>);
+expectType<Capitalize<string>>({} as RemovePrefix<`handle${Capitalize<string>}`, 'handle', {strict: false}>);
+
+expectType<'click'>({} as RemovePrefix<'on-click', `${string}-`, {strict: false}>);
+expectType<'over:flex'>({} as RemovePrefix<'hover:flex', string, {strict: false}>);
+expectType<`${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}/`, {strict: false}>);
+expectType<'change' | '-change'>({} as RemovePrefix<'on-change', `${string}-` | 'on', {strict: false}>);
+expectType<'on:change' | 'change'>({} as RemovePrefix<'on:change' | 'on-change', `${string}-`, {strict: false}>);
+expectType<Uppercase<string> | `id:${Uppercase<string>}` | `${number}` | `id/${number}`>(
+	{} as RemovePrefix<`id:${Uppercase<string>}` | `id/${number}`, `${string}:` | `${string}/`, {strict: false}>,
+);
+
+// Generic assignability test
+type Assignability<S extends string> = S;
+// Output of `RemovePrefix` should be assignable to `string`.
+type Test1<S extends string, Prefix extends string> = Assignability<RemovePrefix<S, Prefix>>;
+type Test2<S extends Uppercase<string>, Prefix extends '-' | '/' | '#'> = Assignability<RemovePrefix<S, Prefix>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Adds `RemovePrefix` type as mentioned in #1188.

Let me know if the naming feels off, here are a few alternatives:
- `StripLeading`
- `StripPrefix`
- `TrimPrefix`