### PR TITLE
`ConditionalKeys`: Fix behaviour with arrays and unions

### DIFF
--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -36,7 +36,7 @@ type NoMatchingKeys = ConditionalKeys<{a?: string}, string>;
 //=> never
 ```
 
-You can also extract array indicies whose value match the specified condition, as shown below:
+You can also extract array indices whose value match the specified condition, as shown below:
 ```
 import type {ConditionalKeys} from 'type-fest';
 

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -36,6 +36,17 @@ type NoMatchingKeys = ConditionalKeys<{a?: string}, string>;
 //=> never
 ```
 
+You can also extract array indicies whose value match the specified condition, as shown below:
+```
+import type {ConditionalKeys} from 'type-fest';
+
+type StringValueIndices = ConditionalKeys<[string, number, string], string>;
+//=> '0' | '2'
+
+type NumberValueIndices = ConditionalKeys<[string, number?, string?], number | undefined>;
+//=> '1'
+```
+
 @category Object
 */
 export type ConditionalKeys<Base, Condition> = (Base extends UnknownArray ? TupleToObject<Base> : Base) extends infer _Base // Remove non-numeric keys from arrays

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -10,25 +10,28 @@ Internally this is used for the `ConditionalPick` and `ConditionalExcept` types.
 ```
 import type {ConditionalKeys} from 'type-fest';
 
-interface Example {
+type Example = {
 	a: string;
 	b: string | number;
 	c?: string;
 	d: {};
-}
+};
 
 type StringKeysOnly = ConditionalKeys<Example, string>;
 //=> 'a'
 ```
 
-To support partial types, make sure your `Condition` is a union of undefined (for example, `string | undefined`) as demonstrated below.
+Note: To extract optional keys, make sure your `Condition` is a union of `undefined` (for example, `string | undefined`) as demonstrated below.
 
 @example
 ```
 import type {ConditionalKeys} from 'type-fest';
 
-type StringKeysAndUndefined = ConditionalKeys<Example, string | undefined>;
-//=> 'a' | 'c'
+type StringKeysAndUndefined = ConditionalKeys<{a?: string}, string | undefined>;
+//=> 'a'
+
+type NoMatchingKeys = ConditionalKeys<{a?: string}, string>;
+//=> never
 ```
 
 @category Object

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -17,3 +17,82 @@ expectType<'a' | 'c'>(exampleConditionalKeysWithUndefined);
 
 declare const exampleConditionalKeysTargetingNever: ConditionalKeys<Example, never>;
 expectType<'e'>(exampleConditionalKeysTargetingNever);
+
+// Readonly modifiers
+expectType<'a' | 'c'>({} as ConditionalKeys<{readonly a: string; readonly b: number; c: Uppercase<string>}, string>);
+expectType<never>({} as ConditionalKeys<{readonly a?: string; readonly b: number}, string>);
+expectType<'a'>({} as ConditionalKeys<{readonly a?: string; readonly b?: number}, string | undefined>);
+
+// Optional modifiers
+expectType<'b'>({} as ConditionalKeys<{a?: string; b: string}, string>);
+expectType<never>({} as ConditionalKeys<{a?: string; b?: string}, string>);
+expectType<never>({} as ConditionalKeys<{a?: string; b: string}, undefined>);
+expectType<'a' | 'b'>({} as ConditionalKeys<{a?: string; b: string}, string | undefined>);
+expectType<'a' | 'b'>({} as ConditionalKeys<{readonly a?: string; readonly b: string}, string | undefined>);
+
+// Union in property values
+expectType<never>({} as ConditionalKeys<{a: boolean | number}, boolean>);
+expectType<'a' | 'b' | 'c'>({} as ConditionalKeys<{a: boolean | number; b: boolean; c: number}, boolean | number>);
+expectType<'b'>({} as ConditionalKeys<{a?: boolean | number; readonly b: boolean | number}, boolean | number>);
+expectType<'a' | 'b'>(
+	{} as ConditionalKeys<{a?: boolean | number; readonly b?: boolean; c: bigint | number}, boolean | number | undefined>,
+);
+
+// `never` as condition
+expectType<never>({} as ConditionalKeys<{a: string; b: number}, never>);
+expectType<never>({} as ConditionalKeys<{readonly a?: string; readonly b?: number}, never>);
+expectType<'a' | 'b'>({} as ConditionalKeys<{a: never; b: never}, never>);
+expectType<'a' | 'b'>({} as ConditionalKeys<{a: never; b: never}, any>);
+expectType<never>({} as ConditionalKeys<{a?: never; b?: never}, never>);
+expectType<'a' | 'b'>({} as ConditionalKeys<{a?: never; b?: never}, undefined>);
+
+// Unions
+expectType<never>({} as ConditionalKeys<{a: string} | {b: number}, string | number>);
+expectType<never>({} as ConditionalKeys<{a: string} | {b: number}, string>);
+expectType<never>({} as ConditionalKeys<{a: string} | {b: number}, number>);
+expectType<never>({} as ConditionalKeys<{a: string} | {a: number}, number>);
+expectType<'a'>({} as ConditionalKeys<{a: string} | {a: number}, string | number>);
+expectType<'a' | 'b'>(
+	{} as ConditionalKeys<{a: string; b: bigint} | {a: number; b: string; c: boolean}, string | number | bigint>,
+);
+expectType<'a'>({} as ConditionalKeys<{a: string} | {a: Lowercase<string>; b: Uppercase<string>}, string>);
+expectType<never>({} as ConditionalKeys<{length: number} | [number], number>);
+
+// `any`/`unknown` as condition
+expectType<'a' | 'b' | 'c' | 'd' | 'e'>(
+	{} as ConditionalKeys<{a?: string; b: string | number; readonly c: boolean; readonly d?: bigint; e: never}, any>,
+);
+expectType<'a' | 'b' | 'c' | 'd'>(
+	{} as ConditionalKeys<{a?: string; b: string | number; readonly c: boolean; readonly d?: bigint; e: never}, unknown>,
+);
+
+// Index signatures
+expectType<string | number>({} as ConditionalKeys<{[x: string]: boolean}, boolean>);
+expectType<string | number>({} as ConditionalKeys<{[x: string]: string; a: string}, string>);
+expectType<Uppercase<string> | 'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: string; a: string}, string>);
+expectType<number | 'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: string; [x: number]: number; a: number}, number>);
+
+// Arrays and tuples
+expectType<'0' | '2'>({} as ConditionalKeys<[string, number, string], string>);
+expectType<'0' | '1'>({} as ConditionalKeys<[string, string, string | number], string>);
+expectType<'0' | '1' | '2'>({} as ConditionalKeys<[string, number, string], any>);
+expectType<'0'>({} as ConditionalKeys<[string, string?, string?], string>);
+expectType<'0' | '1' | '2'>({} as ConditionalKeys<[string, string?, string?], string | undefined>);
+expectType<never>({} as ConditionalKeys<[string, number, ...boolean[]], boolean>);
+expectType<'0'>({} as ConditionalKeys<[string, number?, ...boolean[]], string | number | boolean>);
+expectType<'1'>({} as ConditionalKeys<[string?, number?, ...boolean[]], number | undefined>);
+expectType<'0' | '1' | number>({} as ConditionalKeys<[string, number, ...boolean[]], string | number | boolean>);
+expectType<'0'>({} as ConditionalKeys<[bigint, ...number[], bigint], bigint>);
+expectType<never>({} as ConditionalKeys<[...boolean[], string, string], string>);
+expectType<number>({} as ConditionalKeys<[...string[], string, string], string>);
+expectType<number>({} as ConditionalKeys<string[], string>);
+expectType<never>({} as ConditionalKeys<string[], number>);
+
+// Primitives
+expectType<'length'>({} as ConditionalKeys<string, number>);
+expectType<'valueOf'>({} as ConditionalKeys<number, () => number>);
+
+// Boundary cases
+expectType<never>({} as ConditionalKeys<{}, boolean>);
+expectType<PropertyKey>({} as ConditionalKeys<any, boolean>);
+expectType<never>({} as ConditionalKeys<never, boolean>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR:

- Fixes behaviour with arrays:
  ```ts
  type Current1 = ConditionalKeys<[string, number, string], string>;
  //   ^? type Current1 = 3 | "0" | "2" | (() => ArrayIterator<"0" | "2">) | { [x: number]: boolean | undefine…
  
  type Current2 = ConditionalKeys<string[], string>;
  //   ^? type Current2 = number | (() => ArrayIterator<number>) | { [x: number]: boolean | undefined; length?…
  
  type Current3 = ConditionalKeys<[string, number, ...string[]], string | number>;
  //   ^? type Current3 = number | "0" | "1" | (() => ArrayIterator<number | "0" | "1">) | { [x: number]: bool…
  
  type Updated1 = ConditionalKeys<[string, number, string], string>;
  //   ^? type Updated1 = "0" | "2"
  
  type Updated2 = ConditionalKeys<string[], string>;
  //   ^? type Updated2 = number
  
  type Updated3 = ConditionalKeys<[string, number, ...string[]], string | number>;
  //   ^? type Updated3 = number | "0" | "1"
  ```
  So, now for arrays we _only_ return back numeric keys.

- Fixes one edge case with unions:

  Currently, `ConditionalKeys` only returns _common matching_ keys when instantiated with unions, for example, `ConditionalKeys<{a: string} | {b: string}, string>` returns `never` and _not_ `'a' | 'b'`. Considering this behaviour is fine, `ConditionalKeys<{a: string} | {a: number}, string>` should return `never` and not `'a'`, because the common key `'a'` should match the condition across all union members.
  
  ```ts
  type Current = ConditionalKeys<{a: string} | {a: number}, string>;
  //   ^? type Current = "a"
  
  type Updated = ConditionalKeys<{a: string} | {a: number}, string>;
  //   ^? type Updated = never
  ```
  Maybe we can simply return _all_ matching keys across union members instead of just common matching keys. But IMO, it's fine to return back just the common keys.
  
<br>  

Here are some other minor behaviour changes:
- Fixes behaviour with primitives:
  ```ts
  type Current1 = ConditionalKeys<string, number>;
  //   ^? type Current1 = string | number | (() => StringIterator<string>) | (() => string) | ((pos: number) =…
  
  type Current2 = ConditionalKeys<number, () => number>;
  //   ^? type Current2 = ((radix?: number) => string) | (() => number) | ((fractionDigits?: number) => string…
  
  type Updated1 = ConditionalKeys<string, number>;
  //   ^? type Updated1 = "length"
  
  type Updated2 = ConditionalKeys<number, () => number>;
  //   ^? type Updated2 = "valueOf"
  ```
  Currently, we always return back all the keys of the primitive, so `ConditionalKeys<SomePrimitive>` returns `keyof SomePrimitive`. This happens because homomorphic mapped types, when instantiated with primitives, return them back as is.
  
- Keys with `never` value can now also be extracted using `any` as the condition.
   ```ts
   type Current = ConditionalKeys<{a: never; b: never}, any>;
   //   ^? type Current = never
   
   type Updated = ConditionalKeys<{a: never; b: never}, any>;
   //   ^? type Updated = 'a' | 'b'
   ```
   
- `string` indexors now return `string | number` instead of just `string`.
   ```ts
   type Current = ConditionalKeys<{[x: string]: boolean}, boolean>;
   //   ^? type Current = string
   
   type Updated = ConditionalKeys<{[x: string]: boolean}, boolean>;
   //   ^? type Updated = string | number
   ```
   
- `any` as input returns `PropertyKey` instead of `string`.
   ```ts
   type Current = ConditionalKeys<any, number>;
   //   ^? type Current = string
   
   type Updated = ConditionalKeys<any, number>;
   //   ^? type Updated = PropertyKey
   ```
   