### PR TITLE
`Split`: Fix behaviour with template strings ending with interpolated types

### DIFF
--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -78,7 +78,9 @@ type SplitHelper<
 			? S extends `${infer Head}${Delimiter}${infer Tail}`
 				? SplitHelper<Tail, Delimiter, Options, [...Accumulator, Head]>
 				: Delimiter extends ''
-					? Accumulator
+					? S extends ''
+						? Accumulator
+						: [...Accumulator, S]
 					: [...Accumulator, S]
 			// Otherwise, return `string[]`
 			: string[]

--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -40,7 +40,8 @@ expectType<['a', 'b', 'c'] | ['a,b,c'] | ['x', 'y', 'z'] | ['x:y:z']>({} as Spli
 // which, when split by `.`, would result in `['a', 'b', 'c', 'd']`, which wouldn't conform to the output type of `['a', 'b', string]`.
 expectType<['a', 'b', string]>({} as Split<`a.b.${string}`, '.', {strictLiteralChecks: false}>);
 
-// Ensure the last dynamic "string" is not droped when split by '' https://github.com/sindresorhus/type-fest/issues/1203
+// Ensure the last dynamic "string" is not dropped when split by `''`.
+// https://github.com/sindresorhus/type-fest/issues/1203
 expectType<['a', 'b', string]>({} as Split<`ab${string}`, '', {strictLiteralChecks: false}>);
 
 // -- strictLiteralChecks: true --

--- a/test-d/split.ts
+++ b/test-d/split.ts
@@ -40,6 +40,9 @@ expectType<['a', 'b', 'c'] | ['a,b,c'] | ['x', 'y', 'z'] | ['x:y:z']>({} as Spli
 // which, when split by `.`, would result in `['a', 'b', 'c', 'd']`, which wouldn't conform to the output type of `['a', 'b', string]`.
 expectType<['a', 'b', string]>({} as Split<`a.b.${string}`, '.', {strictLiteralChecks: false}>);
 
+// Ensure the last dynamic "string" is not droped when split by '' https://github.com/sindresorhus/type-fest/issues/1203
+expectType<['a', 'b', string]>({} as Split<`ab${string}`, '', {strictLiteralChecks: false}>);
+
 // -- strictLiteralChecks: true --
 expectType<string[]>({} as Split<string, ''>);
 expectType<string[]>({} as Split<Uppercase<string>, '-'>);


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/1203

Hoping I didn't miss any case