### PR TITLE
`Jsonify`: handle unknown as `JsonValue`

### DIFF
--- a/source/internal/keys.d.ts
+++ b/source/internal/keys.d.ts
@@ -1,5 +1,6 @@
 import type {IsAny} from '../is-any.d.ts';
 import type {IsLiteral} from '../is-literal.d.ts';
+import type {IsUnknown} from '../is-unknown.d.ts';
 import type {ToString} from './string.d.ts';
 
 // Returns `never` if the key or property is not jsonable without testing whether the property is required or optional otherwise return the key.
@@ -25,7 +26,7 @@ export type FilterDefinedKeys<T extends object> = Exclude<
 	{
 		[Key in keyof T]: IsAny<T[Key]> extends true
 			? Key
-			: undefined extends T[Key]
+			: IsUnknown<T[Key]> extends true ? Key : undefined extends T[Key]
 				? never
 				: T[Key] extends undefined
 					? never

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -369,3 +369,22 @@ expectType<typeof nestedObjectWithNameProperty>(
 // Regression test for https://github.com/sindresorhus/type-fest/issues/629
 declare const readonlyTuple: Jsonify<readonly [1, 2, 3]>;
 expectType<[1, 2, 3]>(readonlyTuple);
+
+// `unknown` values
+declare const unknownValue: Jsonify<unknown>;
+declare const unknownArray: Jsonify<unknown[]>;
+declare const unknownTuple: Jsonify<[unknown, unknown]>;
+declare const objectWithUnknownValue: Jsonify<{key: unknown}>;
+expectType<JsonValue>(unknownValue);
+expectAssignable<Jsonify<unknown>>('foo');
+expectAssignable<Jsonify<unknown>>(['foo']);
+expectNotAssignable<Jsonify<unknown>>(new Date());
+expectType<JsonValue[]>(unknownArray);
+expectAssignable<Jsonify<unknown[]>>(['foo']);
+expectNotAssignable<Jsonify<unknown[]>>([new Date()]);
+expectType<[JsonValue, JsonValue]>(unknownTuple);
+expectAssignable<Jsonify<[unknown, unknown]>>(['foo', 'foo']);
+expectNotAssignable<Jsonify<[unknown, unknown]>>([new Date(), new Date()]);
+expectType<{key: JsonValue}>(objectWithUnknownValue);
+expectAssignable<Jsonify<{key: unknown}>>({key: []});
+expectNotAssignable<Jsonify<{key: unknown}>>({key: new Date()});


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1195

Had a bit of struggles with the test

```ts
declare const tupleStringJson: Jsonify<string[] & ['some value']>;
expectType<['some value']>(tupleStringJson);
```

because

```ts
type JsonifyList<T extends UnknownArray> = T extends readonly [infer F, ...infer R]
```

infered `{F: 'some value', R: unknown[]}`, thus the dirty hack that is probably not ideal. Yet, it passes all the tests and it somewhat makes sense.

This problem looks like a known issue in TS tuples handling & intersection with arrays, but depending on the POV, it may be more of a feature than a bug.