### PR TITLE
`TaggedUnion`: Fix incorrect JSDoc example (#1211)

### DIFF
--- a/source/tagged-union.d.ts
+++ b/source/tagged-union.d.ts
@@ -7,7 +7,7 @@ Use-case: A shorter way to declare tagged unions with multiple members.
 ```
 import type {TaggedUnion} from 'type-fest';
 
-type Tagged<Fields extends Record<string, unknown> = TaggedUnion<'type', Fields>
+type Tagged<Fields extends Record<string, Record<string, unknown>>> = TaggedUnion<'type', Fields>
 
 // The TaggedUnion utility reduces the amount of boilerplate needed to create a tagged union with multiple members, making the code more concise.
 type EventMessage = Tagged<{


### PR DESCRIPTION
Fixes the TaggedUnion example.

See the issues here: [TS Playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBDAnmApnA3nAKgQwOZ4oAmAqgHbARlwC+cAZlBCHAORKoC09KAzjKwDcAKGEB6MXADyUYHmBkcAGzjBecEGt4K8cHHAB8e+DAAWaFGSLCOaXAWIBGADwAxYCiVF1KAB4xLbzgAJRQAY2giZ35ZMjwAGjgAVzIAazIIAHcyIwBebHxCUgoqZ3ZkFFZE909vA3FJOCbmlta29o6EZAg4cyg0AD04UQlsbtV1emBfYjgAIySTUzU4fmAlFSIIPjJ2OEzoVJsKgociACY3Dy8ff0D1UIioKJidRJT0rJy806LySjIZVsVTgNRu9Qa2GW6hWZjQT36YXgADcUFBtFRjqhfsQrrVbgErA9wpFojBYgkQiTnmSKe80hlsgZmXB8vY-iVAeVUCCwXVRLY4ABRVFkGAAWT4vHwaDZhVx6GEAEgpKgyEK7lBFEoSFAlAAuDDKpVJPWG15xERKpXAIiGshJEBzNFWpVKHBxJIy83knRWmhWrAQAhKFAAIRwYVSYcWMCoADU1MA5utgEhDYrrcik3NQ4a5hAIKGPf6rQAFU1hUw4Xjh2NUMv9Xi1u1G61gWRhFD2x3OqCumCgbtwAAiOACpeVADkcNm8OOAQBlGDjlAAYWrcWIGeNijnC6oAH4fRTJzQDCJhBEyPw9IaRZYJVKZayjS1bIbWDP94OqMvVxuHpFFUwgtHucgHmQhoAEQAJICOoBxQKkOjQcINCiMA9AABQ4AAdIKuREWw34Qb+ZD-gEgFbkQrAAJRvs0168EWKB4Uowa4Xh4HzuRdHoUAA)

Example of the fixed version: [TS Playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBDAnmApnA3nAKgQwOZ4oAmAqgHbARlwA0cAkgM4CiAjgK44A2dAyqGC7AAZogC+cYVAgg4AciSoAtMJSMYcgNwAobYrS4CxADwAxYCi5FGcFAA8YKMtbgAlFAGNoRY+qjAyPDp3LygfPwCguHYyAGsyCAB3MgA+NLgAXmx8QlIKKmMFZBQ5OnNLaxTdAHpq7AALAxzickpqdhhgISQ4KGJ2DzUERrgcEAgY+AhhOAAjCC6UKEEcRzgyFGJiBAg4Dz7VtBwEZqJo-OpE4Bh6uBB2Lk7BNBAUEFmlxjoQHFjI4bQXiIL2ggKoHmAjBQADo9MU4MwAG5OGAAWTUjHwaCyhlyxnQ2gAkAB5VBkZgOJZkbgkKBcABcGCJhPYdMZEUCOkJhOAREZZHY7yWXMJXBwgU4hHZMH8nKJYi5WAgBC4KAAQjgPLE1R0YFQAGqQ4CzLrXRCMgncxFG2aqxnzCCq8VchVEgAKrI89RwUJ1MD1ZDdfUYUL5TO5YH8g35go+UBFnVejIAIocXVyAHI4a14VZtXgwQ4AYW9gWIFuZ1JzeaoAH5pbK8OntGIUjptLU4AAJJZoSEAuCY14IeH7FCHM5XG4TeA3fsdU1IWH6BHIshojFYgBMmSJAB9w4T9Iy5KSnBTHFBqVxaVwtMzWQzBzLIiLeTGhfHmWKJViG6-5X3DBj3kJUVXVTVtV1A0bUXRAtDga1GGNO05ggR1xzIMQgPQEC5A9KAvR9dVoMDYNQwQyNgGjdZY2FBBQBQFNDmwwkD1w4oTyzatOioAti1LXIEKrYBc14sh62fRtXQ7OoM02M49UHAQhFEOZPBwdgoTgaY4ACS8oQ8cTGDhVBbA4bhMgYFgLK4Yx+HAVTEGMJEUXREMsRSOhXPXdzMUILcqk7OAQoAPVrIA)