### PR TITLE
Add lint rule to catch cases of missing exports in index.d.ts

### DIFF
--- a/lint-rules/require-exported-types.js
+++ b/lint-rules/require-exported-types.js
@@ -1,0 +1,160 @@
+import path from 'node:path';
+import fs from 'node:fs';
+
+/**
+Cache for index exports to avoid repeated lookups
+*/
+const indexCache = new Map();
+
+export const requireExportedTypesRule = /** @type {const} */ ({
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description: 'Enforce that exported types are also exported from index.d.ts',
+			category: 'Best Practices',
+			recommended: true,
+		},
+		messages: {
+			missingExport: 'Type `{{typeName}}` is exported from this file but not from index.d.ts. Add it to index.d.ts or use `// eslint-disable-next-line type-fest/require-exported-types` to ignore.',
+			noTypeInfo: 'Rule requires TypeScript type information. Configure `parserOptions.project` in your ESLint config.',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					indexFile: {
+						type: 'string',
+						description: 'Path to the index file (default: "index.d.ts")',
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+	},
+	defaultOptions: [],
+	create(context) {
+		// Only run on TypeScript declaration files in source directory
+		const filename = context.filename ?? context.getFilename?.() ?? '';
+		if (!filename.includes('/source/') || !filename.endsWith('.d.ts')) {
+			return {};
+		}
+
+		// Skip internal files
+		if (filename.includes('/internal/')) {
+			return {};
+		}
+
+		const options = context.options?.[0] ?? {};
+		const indexFileName = options.indexFile ?? 'index.d.ts';
+
+		// Get TypeScript type-aware services
+		const parserServices = context.sourceCode?.parserServices;
+
+		// Type information is required for this rule
+		if (!parserServices?.program || !parserServices?.esTreeNodeToTSNodeMap) {
+			// Report once per file that type information is required
+			return {
+				'Program'(node) {
+					context.report({
+						node,
+						messageId: 'noTypeInfo',
+					});
+				},
+			};
+		}
+
+		const {program} = parserServices;
+		const checker = program.getTypeChecker();
+
+		// Find project root
+		let projectRoot = path.dirname(filename);
+		while (projectRoot !== path.dirname(projectRoot)) {
+			if (fs.existsSync(path.join(projectRoot, 'package.json'))) {
+				break;
+			}
+
+			projectRoot = path.dirname(projectRoot);
+		}
+
+		const indexPath = path.join(projectRoot, indexFileName);
+
+		// Get or cache index exports
+		let indexExports;
+		const cacheKey = `index:${indexPath}`;
+
+		if (indexCache.has(cacheKey)) {
+			indexExports = indexCache.get(cacheKey);
+		} else {
+			indexExports = new Set();
+
+			// Get the source file for index.d.ts
+			const indexSourceFile = program.getSourceFile(indexPath);
+			if (indexSourceFile) {
+				const indexSymbol = checker.getSymbolAtLocation(indexSourceFile);
+				if (indexSymbol) {
+					const exports = checker.getExportsOfModule(indexSymbol);
+					for (const exportSymbol of exports) {
+						indexExports.add(exportSymbol.name);
+					}
+				}
+			}
+
+			indexCache.set(cacheKey, indexExports);
+		}
+
+		// State to track processed nodes
+		const processed = new Set();
+
+		// Helper function to check exported type/interface
+		const checkExportedType = node => {
+			const typeName = node.id.name;
+
+			// Skip types starting with underscore (internal/private convention)
+			if (typeName.startsWith('_')) {
+				return;
+			}
+
+			// Skip if inside declare namespace
+			const ancestors = context.sourceCode.getAncestors(node);
+			const isInsideDeclareNamespace = ancestors.some(ancestor =>
+				ancestor.type === 'TSModuleDeclaration' && ancestor.declare === true,
+			);
+
+			if (isInsideDeclareNamespace) {
+				return;
+			}
+
+			// Skip if already processed
+			if (processed.has(typeName)) {
+				return;
+			}
+
+			processed.add(typeName);
+
+			// Report if not exported from index
+			if (!indexExports.has(typeName)) {
+				context.report({
+					node,
+					messageId: 'missingExport',
+					data: {typeName},
+				});
+			}
+		};
+
+		return {
+			// Handle: export type Foo = ...
+			'ExportNamedDeclaration > TSTypeAliasDeclaration': checkExportedType,
+
+			// Handle: export interface Foo { ... }
+			'ExportNamedDeclaration > TSInterfaceDeclaration': checkExportedType,
+
+			// Clean up cache periodically
+			'Program:exit'() {
+				// Clear cache if it gets too large
+				if (indexCache.size > 100) {
+					indexCache.clear();
+				}
+			},
+		};
+	},
+});

--- a/lint-rules/require-exported-types.js
+++ b/lint-rules/require-exported-types.js
@@ -105,7 +105,7 @@ export const requireExportedTypesRule = /** @type {const} */ ({
 			// Skip if inside declare namespace
 			const ancestors = context.sourceCode.getAncestors(node);
 			const isInsideDeclareNamespace = ancestors.some(ancestor =>
-				ancestor.type === 'TSModuleDeclaration' && ancestor.declare === true,
+				ancestor.type === 'TSModuleDeclaration' && ancestor.declare,
 			);
 
 			if (isInsideDeclareNamespace) {

--- a/lint-rules/require-exported-types.js
+++ b/lint-rules/require-exported-types.js
@@ -31,7 +31,7 @@ export const requireExportedTypesRule = /** @type {const} */ ({
 	create(context) {
 		// Only run on TypeScript declaration files in source directory
 		// Convert to forward slashes for consistent path checking across platforms
-		const filename = (context.filename ?? context.getFilename?.() ?? '').replaceAll('\\', '/');
+		const filename = context.filename.replaceAll('\\', '/');
 		if (!filename.includes('/source/') || !filename.endsWith('.d.ts')) {
 			return {};
 		}

--- a/lint-rules/require-exported-types.js
+++ b/lint-rules/require-exported-types.js
@@ -45,7 +45,7 @@ export const requireExportedTypesRule = /** @type {const} */ ({
 		const indexFileName = options.indexFile ?? 'index.d.ts';
 
 		// Get TypeScript type-aware services
-		const parserServices = context.sourceCode.parserServices;
+		const {parserServices} = context.sourceCode;
 
 		// Type information is required for this rule
 		if (!parserServices?.program || !parserServices?.esTreeNodeToTSNodeMap) {

--- a/lint-rules/require-exported-types.js
+++ b/lint-rules/require-exported-types.js
@@ -45,7 +45,7 @@ export const requireExportedTypesRule = /** @type {const} */ ({
 		const indexFileName = options.indexFile ?? 'index.d.ts';
 
 		// Get TypeScript type-aware services
-		const parserServices = context.sourceCode?.parserServices;
+		const parserServices = context.sourceCode.parserServices;
 
 		// Type information is required for this rule
 		if (!parserServices?.program || !parserServices?.esTreeNodeToTSNodeMap) {

--- a/lint-rules/require-exported-types.test.js
+++ b/lint-rules/require-exported-types.test.js
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+/**
+ * Test suite for the require-exported-types ESLint rule
+ *
+ * Run with: node --test lint-rules/require-exported-types.test.mjs
+ */
+
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import {requireExportedTypesRule} from './require-exported-types.js';
+
+describe('require-exported-types ESLint rule', () => {
+	describe('rule structure and metadata', () => {
+		test('has correct structure', () => {
+			assert.ok(requireExportedTypesRule.meta);
+			assert.equal(requireExportedTypesRule.meta.type, 'suggestion');
+			assert.ok(requireExportedTypesRule.meta.docs);
+			assert.ok(requireExportedTypesRule.meta.messages);
+			assert.ok(requireExportedTypesRule.create);
+			assert.equal(typeof requireExportedTypesRule.create, 'function');
+		});
+
+		test('has correct meta.docs', () => {
+			const {docs} = requireExportedTypesRule.meta;
+			assert.equal(docs.description, 'Enforce that exported types are also exported from index.d.ts');
+			assert.equal(docs.category, 'Best Practices');
+			assert.equal(docs.recommended, true);
+		});
+
+		test('has correct messages', () => {
+			const {messages} = requireExportedTypesRule.meta;
+			assert.ok(messages.missingExport.includes('Type `{{typeName}}`'));
+			assert.ok(messages.missingExport.includes('index.d.ts'));
+			assert.ok(messages.noTypeInfo.includes('TypeScript type information'));
+		});
+
+		test('has correct schema', () => {
+			const {schema} = requireExportedTypesRule.meta;
+			assert.ok(Array.isArray(schema));
+			assert.equal(schema.length, 1);
+			assert.equal(schema[0].type, 'object');
+			assert.ok(schema[0].properties.indexFile);
+			assert.equal(schema[0].properties.indexFile.type, 'string');
+		});
+	});
+
+	describe('file filtering', () => {
+		test('skips non-.d.ts files', () => {
+			const context = {
+				filename: '/project/source/foo.ts',
+				sourceCode: {parserServices: {}},
+				options: [],
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			assert.deepEqual(handlers, {});
+		});
+
+		test('skips files outside source directory', () => {
+			const context = {
+				filename: '/project/test/foo.d.ts',
+				sourceCode: {parserServices: {}},
+				options: [],
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			assert.deepEqual(handlers, {});
+		});
+
+		test('skips internal files', () => {
+			const context = {
+				filename: '/project/source/internal/foo.d.ts',
+				sourceCode: {parserServices: {}},
+				options: [],
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			assert.deepEqual(handlers, {});
+		});
+
+		test('processes source/*.d.ts files', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+				},
+				options: [],
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			assert.ok(handlers['ExportNamedDeclaration > TSTypeAliasDeclaration']);
+			assert.ok(handlers['ExportNamedDeclaration > TSInterfaceDeclaration']);
+			assert.ok(handlers['Program:exit']);
+		});
+	});
+
+	describe('TypeScript type information', () => {
+		test('requires type information', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {parserServices: {}}, // No type info
+				options: [],
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			assert.ok(handlers.Program);
+			assert.equal(typeof handlers.Program, 'function');
+		});
+
+		test('reports noTypeInfo message when type info is missing', () => {
+			let reportedError = null;
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {parserServices: {}},
+				options: [],
+				report(error) {
+					reportedError = error;
+				},
+			};
+			const handlers = requireExportedTypesRule.create(context);
+			handlers.Program({type: 'Program'}); // eslint-disable-line new-cap
+			assert.equal(reportedError.messageId, 'noTypeInfo');
+		});
+	});
+
+	describe('underscore prefix handling', () => {
+		test('skips types starting with underscore', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: '_InternalType'}});
+			assert.equal(errors.length, 0);
+		});
+
+		test('reports types not starting with underscore', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: 'PublicType'}});
+			assert.equal(errors.length, 1);
+			assert.equal(errors[0].data.typeName, 'PublicType');
+			assert.equal(errors[0].messageId, 'missingExport');
+		});
+
+		test('skips interfaces starting with underscore', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const interfaceHandler = handlers['ExportNamedDeclaration > TSInterfaceDeclaration'];
+
+			interfaceHandler({id: {name: '_InternalInterface'}});
+			assert.equal(errors.length, 0);
+		});
+
+		test('reports interfaces not starting with underscore', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const interfaceHandler = handlers['ExportNamedDeclaration > TSInterfaceDeclaration'];
+
+			interfaceHandler({id: {name: 'PublicInterface'}});
+			assert.equal(errors.length, 1);
+			assert.equal(errors[0].data.typeName, 'PublicInterface');
+		});
+	});
+
+	describe('declare namespace handling', () => {
+		test('skips types inside declare namespace', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [
+						{type: 'TSModuleDeclaration', declare: true},
+					],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: 'TypeInNamespace'}});
+			assert.equal(errors.length, 0);
+		});
+
+		test('reports types outside declare namespace', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [
+						{type: 'TSModuleDeclaration', declare: false}, // Not a declare namespace
+					],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: 'TypeOutsideNamespace'}});
+			assert.equal(errors.length, 1);
+			assert.equal(errors[0].data.typeName, 'TypeOutsideNamespace');
+		});
+
+		test('handles nested declare namespaces', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [
+						{type: 'TSModuleDeclaration', declare: false},
+						{type: 'TSModuleDeclaration', declare: true}, // At least one is declare
+					],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: 'NestedType'}});
+			assert.equal(errors.length, 0); // Should be skipped
+		});
+	});
+
+	describe('deduplication', () => {
+		test('processes each type only once', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			const node = {id: {name: 'DuplicateType'}};
+			typeHandler(node);
+			typeHandler(node);
+			typeHandler(node);
+
+			assert.equal(errors.length, 1);
+		});
+
+		test('processes each interface only once', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const interfaceHandler = handlers['ExportNamedDeclaration > TSInterfaceDeclaration'];
+
+			const node = {id: {name: 'DuplicateInterface'}};
+			interfaceHandler(node);
+			interfaceHandler(node);
+
+			assert.equal(errors.length, 1);
+		});
+	});
+
+	describe('options', () => {
+		test('accepts custom index file option', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+				},
+				options: [{indexFile: 'custom-index.d.ts'}],
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			assert.ok(handlers['ExportNamedDeclaration > TSTypeAliasDeclaration']);
+			// The rule should use custom-index.d.ts instead of index.d.ts
+		});
+
+		test('uses default index.d.ts when no option provided', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+				},
+				options: [],
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			assert.ok(handlers['ExportNamedDeclaration > TSTypeAliasDeclaration']);
+		});
+	});
+
+	describe('cache management', () => {
+		test('has cache cleanup handler', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+				},
+				options: [],
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			assert.ok(handlers['Program:exit']);
+			assert.equal(typeof handlers['Program:exit'], 'function');
+		});
+
+		test('cache cleanup does not throw', () => {
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+				},
+				options: [],
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const exitHandler = handlers['Program:exit'];
+
+			assert.doesNotThrow(() => exitHandler());
+		});
+	});
+
+	describe('error reporting', () => {
+		test('includes type name in error data', () => {
+			const errors = [];
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler({id: {name: 'TestType'}});
+			assert.equal(errors[0].messageId, 'missingExport');
+			assert.equal(errors[0].data.typeName, 'TestType');
+		});
+
+		test('reports correct node location', () => {
+			const errors = [];
+			const testNode = {id: {name: 'LocationTest'}};
+			const context = {
+				filename: '/project/source/foo.d.ts',
+				sourceCode: {
+					parserServices: {
+						program: {
+							getTypeChecker: () => ({getSymbolAtLocation: () => null}),
+							getSourceFile: () => null,
+						},
+						esTreeNodeToTSNodeMap: new Map(),
+					},
+					getAncestors: () => [],
+				},
+				options: [],
+				report: error => errors.push(error),
+			};
+
+			const handlers = requireExportedTypesRule.create(context);
+			const typeHandler = handlers['ExportNamedDeclaration > TSTypeAliasDeclaration'];
+
+			typeHandler(testNode);
+			assert.equal(errors[0].node, testNode);
+		});
+	});
+});

--- a/lint-rules/require-exported-types.test.js
+++ b/lint-rules/require-exported-types.test.js
@@ -92,7 +92,6 @@ describe('require-exported-types ESLint rule', () => {
 			const handlers = requireExportedTypesRule.create(context);
 			assert.ok(handlers['ExportNamedDeclaration > TSTypeAliasDeclaration']);
 			assert.ok(handlers['ExportNamedDeclaration > TSInterfaceDeclaration']);
-			assert.ok(handlers['Program:exit']);
 		});
 	});
 
@@ -411,49 +410,6 @@ describe('require-exported-types ESLint rule', () => {
 
 			const handlers = requireExportedTypesRule.create(context);
 			assert.ok(handlers['ExportNamedDeclaration > TSTypeAliasDeclaration']);
-		});
-	});
-
-	describe('cache management', () => {
-		test('has cache cleanup handler', () => {
-			const context = {
-				filename: '/project/source/foo.d.ts',
-				sourceCode: {
-					parserServices: {
-						program: {
-							getTypeChecker: () => ({}),
-							getSourceFile: () => null,
-						},
-						esTreeNodeToTSNodeMap: new Map(),
-					},
-				},
-				options: [],
-			};
-
-			const handlers = requireExportedTypesRule.create(context);
-			assert.ok(handlers['Program:exit']);
-			assert.equal(typeof handlers['Program:exit'], 'function');
-		});
-
-		test('cache cleanup does not throw', () => {
-			const context = {
-				filename: '/project/source/foo.d.ts',
-				sourceCode: {
-					parserServices: {
-						program: {
-							getTypeChecker: () => ({}),
-							getSourceFile: () => null,
-						},
-						esTreeNodeToTSNodeMap: new Map(),
-					},
-				},
-				options: [],
-			};
-
-			const handlers = requireExportedTypesRule.create(context);
-			const exitHandler = handlers['Program:exit'];
-
-			assert.doesNotThrow(() => exitHandler());
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"test:tsc": "tsc",
 		"test:tsd": "tsd",
 		"test:xo": "xo",
+		"test:linter": "node --test",
 		"test": "run-p test:*"
 	},
 	"files": [

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -15,7 +15,7 @@ export type CamelCaseOptions = {
 	preserveConsecutiveUppercase?: boolean;
 };
 
-export type DefaultCamelCaseOptions = {
+export type _DefaultCamelCaseOptions = {
 	preserveConsecutiveUppercase: false;
 };
 
@@ -84,6 +84,6 @@ export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extend
 		? Type
 		: Uncapitalize<CamelCaseFromArray<
 			Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type>,
-			ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>
+			ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
 		>>
 	: Type;

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case.d.ts';
+import type {CamelCase, CamelCaseOptions, _DefaultCamelCaseOptions} from './camel-case.d.ts';
 import type {ApplyDefaultOptions, NonRecursiveType} from './internal/index.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
@@ -57,7 +57,7 @@ const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{fooBAR: {fooBARBiz
 export type CamelCasedPropertiesDeep<
 	Value,
 	Options extends CamelCaseOptions = {},
-> = _CamelCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+> = _CamelCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>>;
 
 type _CamelCasedPropertiesDeep<
 	Value,

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case.d.ts';
+import type {CamelCase, CamelCaseOptions, _DefaultCamelCaseOptions} from './camel-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 
 /**
@@ -38,6 +38,6 @@ export type CamelCasedProperties<Value, Options extends CamelCaseOptions = {}> =
 		? Value
 		: {
 			[K in keyof Value as
-			CamelCase<K, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>
+			CamelCase<K, ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>>
 			]: Value[K];
 		};

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -2,9 +2,9 @@ import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal
 import type {IsStringLiteral} from './is-literal.d.ts';
 import type {Merge} from './merge.d.ts';
 import type {RemovePrefix} from './remove-prefix.d.ts';
-import type {DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
+import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
 
-export type DefaultDelimiterCaseOptions = Merge<DefaultWordsOptions, {splitOnNumbers: false}>;
+export type _DefaultDelimiterCaseOptions = Merge<_DefaultWordsOptions, {splitOnNumbers: false}>;
 
 /**
 Convert an array of words to delimiter case starting with a delimiter with input capitalization.
@@ -69,7 +69,7 @@ export type DelimiterCase<
 	? IsStringLiteral<Value> extends false
 		? Value
 		: Lowercase<RemovePrefix<DelimiterCaseFromArray<
-			Words<Value, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>,
+			Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
 			Delimiter
 		>, string, {strict: false}>>
 	: Value;

--- a/source/delimiter-cased-properties-deep.d.ts
+++ b/source/delimiter-cased-properties-deep.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
 import type {ApplyDefaultOptions, NonRecursiveType} from './internal/index.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -61,7 +61,7 @@ export type DelimiterCasedPropertiesDeep<
 	Value,
 	Delimiter extends string,
 	Options extends WordsOptions = {},
-> = _DelimiterCasedPropertiesDeep<Value, Delimiter, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = _DelimiterCasedPropertiesDeep<Value, Delimiter, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;
 
 type _DelimiterCasedPropertiesDeep<
 	Value,

--- a/source/delimiter-cased-properties.d.ts
+++ b/source/delimiter-cased-properties.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
 
@@ -42,5 +42,5 @@ export type DelimiterCasedProperties<
 	: Value extends Array<infer U>
 		? Value
 		: {[K in keyof Value as
-			DelimiterCase<K, Delimiter, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>
+			DelimiterCase<K, Delimiter, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>
 			]: Value[K]};

--- a/source/entries.d.ts
+++ b/source/entries.d.ts
@@ -1,9 +1,9 @@
-import type {ArrayEntry, MapEntry, ObjectEntry, SetEntry} from './entry.d.ts';
+import type {_ArrayEntry, _MapEntry, _ObjectEntry, _SetEntry} from './entry.d.ts';
 
-type ArrayEntries<BaseType extends readonly unknown[]> = Array<ArrayEntry<BaseType>>;
-type MapEntries<BaseType> = Array<MapEntry<BaseType>>;
-type ObjectEntries<BaseType> = Array<ObjectEntry<BaseType>>;
-type SetEntries<BaseType extends Set<unknown>> = Array<SetEntry<BaseType>>;
+type ArrayEntries<BaseType extends readonly unknown[]> = Array<_ArrayEntry<BaseType>>;
+type MapEntries<BaseType> = Array<_MapEntry<BaseType>>;
+type ObjectEntries<BaseType> = Array<_ObjectEntry<BaseType>>;
+type SetEntries<BaseType extends Set<unknown>> = Array<_SetEntry<BaseType>>;
 
 /**
 Many collections have an `entries` method which returns an array of a given object's own enumerable string-keyed property [key, value] pairs. The `Entries` type will return the type of that collection's entries.

--- a/source/entry.d.ts
+++ b/source/entry.d.ts
@@ -1,10 +1,10 @@
 type MapKey<BaseType> = BaseType extends Map<infer KeyType, unknown> ? KeyType : never;
 type MapValue<BaseType> = BaseType extends Map<unknown, infer ValueType> ? ValueType : never;
 
-export type ArrayEntry<BaseType extends readonly unknown[]> = [number, BaseType[number]];
-export type MapEntry<BaseType> = [MapKey<BaseType>, MapValue<BaseType>];
-export type ObjectEntry<BaseType> = [keyof BaseType, BaseType[keyof BaseType]];
-export type SetEntry<BaseType> = BaseType extends Set<infer ItemType> ? [ItemType, ItemType] : never;
+export type _ArrayEntry<BaseType extends readonly unknown[]> = [number, BaseType[number]];
+export type _MapEntry<BaseType> = [MapKey<BaseType>, MapValue<BaseType>];
+export type _ObjectEntry<BaseType> = [keyof BaseType, BaseType[keyof BaseType]];
+export type _SetEntry<BaseType> = BaseType extends Set<infer ItemType> ? [ItemType, ItemType] : never;
 
 /**
 Many collections have an `entries` method which returns an array of a given object's own enumerable string-keyed property [key, value] pairs. The `Entry` type will return the type of that collection's entry.
@@ -58,8 +58,8 @@ const setEntryNumber: Entry<typeof setExample> = [1, 1];
 @category Set
 */
 export type Entry<BaseType> =
-	BaseType extends Map<unknown, unknown> ? MapEntry<BaseType>
-		: BaseType extends Set<unknown> ? SetEntry<BaseType>
-			: BaseType extends readonly unknown[] ? ArrayEntry<BaseType>
-				: BaseType extends object ? ObjectEntry<BaseType>
+	BaseType extends Map<unknown, unknown> ? _MapEntry<BaseType>
+		: BaseType extends Set<unknown> ? _SetEntry<BaseType>
+			: BaseType extends readonly unknown[] ? _ArrayEntry<BaseType>
+				: BaseType extends object ? _ObjectEntry<BaseType>
 					: never;

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -1,5 +1,5 @@
 import type {ApplyDefaultOptions, ToString} from './internal/index.d.ts';
-import type {LiteralStringUnion} from './literal-union.d.ts';
+import type {_LiteralStringUnion} from './literal-union.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {Split} from './split.d.ts';
 import type {KeyAsString} from './key-as-string.d.ts';
@@ -210,7 +210,7 @@ export type Get<
 	BaseType,
 	Path extends
 	| readonly string[]
-	| LiteralStringUnion<ToString<Paths<BaseType, {bracketNotation: false; maxRecursionDepth: 2}> | Paths<BaseType, {bracketNotation: true; maxRecursionDepth: 2}>>>,
+	| _LiteralStringUnion<ToString<Paths<BaseType, {bracketNotation: false; maxRecursionDepth: 2}> | Paths<BaseType, {bracketNotation: true; maxRecursionDepth: 2}>>>,
 	Options extends GetOptions = {},
 > =
 	GetWithPath<

--- a/source/globals/observable-like.d.ts
+++ b/source/globals/observable-like.d.ts
@@ -16,6 +16,7 @@ As well, some guidance on making an `Observable` to not include `closed` propert
 
 @category Observable
 */
+// eslint-disable-next-line type-fest/require-exported-types
 export type Unsubscribable = {
 	unsubscribe(): void;
 };
@@ -38,6 +39,7 @@ type OnComplete = () => void;
 /**
 @category Observable
 */
+// eslint-disable-next-line type-fest/require-exported-types
 export type Observer<ValueType> = {
 	next: OnNext<ValueType>;
 	error: OnError;
@@ -67,6 +69,7 @@ But `Observable` implementations have evolved to preferring case 2 and some impl
 
 @category Observable
 */
+// eslint-disable-next-line type-fest/require-exported-types
 export type ObservableLike<ValueType = unknown> = {
 	subscribe(observer?: Partial<Observer<ValueType>>): Unsubscribable;
 	[Symbol.observable](): ObservableLike<ValueType>;

--- a/source/internal/enforce-optional.d.ts
+++ b/source/internal/enforce-optional.d.ts
@@ -1,4 +1,4 @@
-import type {Simplify} from './simplify.d.ts';
+import type {Simplify} from '../simplify.d.ts';
 
 // Returns `never` if the key is optional otherwise return the key type.
 type RequiredFilter<Type, Key extends keyof Type> = undefined extends Type[Key]

--- a/source/internal/index.d.ts
+++ b/source/internal/index.d.ts
@@ -6,3 +6,4 @@ export type * from './object.d.ts';
 export type * from './string.d.ts';
 export type * from './tuple.d.ts';
 export type * from './type.d.ts';
+export type * from './enforce-optional.d.ts';

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,5 +1,5 @@
 import type {Primitive} from './primitive.d.ts';
-import type {Numeric} from './numeric.d.ts';
+import type {_Numeric} from './numeric.d.ts';
 import type {CollapseLiterals, IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
@@ -173,7 +173,7 @@ endsWith('abc123', end);
 @category Type Guard
 @category Utilities
 */
-export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
+export type IsNumericLiteral<T> = LiteralChecks<T, _Numeric>;
 
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
 
@@ -41,4 +41,4 @@ const rawCliOptions: KebabCasedProperties<CliOptions> = {
 export type KebabCase<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCase<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCase<Value, '-', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -60,4 +60,4 @@ const splitOnNumbers: KebabCasedPropertiesDeep<{line1: { line2: [{ line3: string
 export type KebabCasedPropertiesDeep<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCasedPropertiesDeep<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCasedPropertiesDeep<Value, '-', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
 import type {DelimiterCasedProperties} from './delimiter-cased-properties.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -37,4 +37,4 @@ const splitOnNumbers: KebabCasedProperties<{line1: string}, {splitOnNumbers: tru
 export type KebabCasedProperties<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCasedProperties<Value, '-', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCasedProperties<Value, '-', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/literal-union.d.ts
+++ b/source/literal-union.d.ts
@@ -1,6 +1,6 @@
 import type {Primitive} from './primitive.d.ts';
 
-export type LiteralStringUnion<T> = LiteralUnion<T, string>;
+export type _LiteralStringUnion<T> = LiteralUnion<T, string>;
 
 /**
 Allows creating a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union.

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -6,11 +6,11 @@ import type {
 	FirstArrayElement,
 	IsBothExtends,
 	UnknownArrayOrTuple,
+	EnforceOptional,
 } from './internal/index.d.ts';
 import type {NonEmptyTuple} from './non-empty-tuple.d.ts';
 import type {ArrayTail as _ArrayTail} from './array-tail.d.ts';
 import type {UnknownRecord} from './unknown-record.d.ts';
-import type {EnforceOptional} from './enforce-optional.d.ts';
 import type {SimplifyDeep} from './simplify-deep.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -1,9 +1,9 @@
 import type {IsFloat} from './is-float.d.ts';
 import type {IsInteger} from './is-integer.d.ts';
 
-export type Numeric = number | bigint;
+export type _Numeric = number | bigint;
 
-export type Zero = 0 | 0n;
+type Zero = 0 | 0n;
 
 /**
 Matches the hidden `Infinity` type.
@@ -146,7 +146,7 @@ Use-case: Validating and documenting parameters.
 
 @category Numeric
 */
-export type Negative<T extends Numeric> = T extends Zero ? never : `${T}` extends `-${string}` ? T : never;
+export type Negative<T extends _Numeric> = T extends Zero ? never : `${T}` extends `-${string}` ? T : never;
 
 /**
 A negative (`-∞ < x < 0`) `number` that is an integer.
@@ -180,7 +180,7 @@ declare function setLength<T extends number>(length: NonNegative<T>): void;
 
 @category Numeric
 */
-export type NonNegative<T extends Numeric> = T extends Zero ? T : Negative<T> extends never ? T : never;
+export type NonNegative<T extends _Numeric> = T extends Zero ? T : Negative<T> extends never ? T : never;
 
 /**
 A non-negative (`0 <= x < ∞`) `number` that is an integer.
@@ -219,4 +219,4 @@ type ShouldBeTrue = IsNegative<-1>;
 
 @category Numeric
 */
-export type IsNegative<T extends Numeric> = T extends Negative<T> ? true : false;
+export type IsNegative<T extends _Numeric> = T extends Negative<T> ? true : false;

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCase, CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case.d.ts';
+import type {CamelCase, CamelCaseOptions, _DefaultCamelCaseOptions} from './camel-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 
 /**
@@ -42,7 +42,7 @@ const dbResult: PascalCasedProperties<RawOptions> = {
 @category Template literal
 */
 export type PascalCase<Value, Options extends CamelCaseOptions = {}> =
-	_PascalCase<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+	_PascalCase<Value, ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>>;
 
 type _PascalCase<Value, Options extends Required<CamelCaseOptions>> = CamelCase<Value, Options> extends string
 	? Capitalize<CamelCase<Value, Options>>

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case.d.ts';
+import type {CamelCaseOptions, _DefaultCamelCaseOptions} from './camel-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {PascalCase} from './pascal-case.d.ts';
 
@@ -55,7 +55,7 @@ const preserveConsecutiveUppercase: PascalCasedPropertiesDeep<{fooBAR: {fooBARBi
 @category Object
 */
 export type PascalCasedPropertiesDeep<Value, Options extends CamelCaseOptions = {}> =
-	_PascalCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>;
+	_PascalCasedPropertiesDeep<Value, ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>>;
 
 type _PascalCasedPropertiesDeep<Value, Options extends Required<CamelCaseOptions>> = Value extends Function | Date | RegExp
 	? Value

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -1,4 +1,4 @@
-import type {CamelCaseOptions, DefaultCamelCaseOptions} from './camel-case.d.ts';
+import type {CamelCaseOptions, _DefaultCamelCaseOptions} from './camel-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {PascalCase} from './pascal-case.d.ts';
 
@@ -37,4 +37,4 @@ export type PascalCasedProperties<Value, Options extends CamelCaseOptions = {}> 
 	? Value
 	: Value extends Array<infer U>
 		? Value
-		: {[K in keyof Value as PascalCase<K, ApplyDefaultOptions<CamelCaseOptions, DefaultCamelCaseOptions, Options>>]: Value[K]};
+		: {[K in keyof Value as PascalCase<K, ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>>]: Value[K]};

--- a/source/screaming-snake-case.d.ts
+++ b/source/screaming-snake-case.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {SnakeCase} from './snake-case.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -24,5 +24,5 @@ export type ScreamingSnakeCase<
 	Value,
 	Options extends WordsOptions = {},
 > = Value extends string
-	? Uppercase<SnakeCase<Value, ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>>
+	? Uppercase<SnakeCase<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>>
 	: Value;

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions, DelimiterCase} from './delimiter-case.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
 
@@ -42,4 +42,4 @@ const dbResult: SnakeCasedProperties<ModelProps> = {
 export type SnakeCase<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCase<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCase<Value, '_', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
 import type {DelimiterCasedPropertiesDeep} from './delimiter-cased-properties-deep.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -60,4 +60,4 @@ const splitOnNumbers: SnakeCasedPropertiesDeep<{line1: { line2: [{ line3: string
 export type SnakeCasedPropertiesDeep<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCasedPropertiesDeep<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCasedPropertiesDeep<Value, '_', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -1,4 +1,4 @@
-import type {DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
+import type {_DefaultDelimiterCaseOptions} from './delimiter-case.d.ts';
 import type {DelimiterCasedProperties} from './delimiter-cased-properties.d.ts';
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {WordsOptions} from './words.d.ts';
@@ -37,4 +37,4 @@ const splitOnNumbers: SnakeCasedProperties<{line1: string}, {splitOnNumbers: tru
 export type SnakeCasedProperties<
 	Value,
 	Options extends WordsOptions = {},
-> = DelimiterCasedProperties<Value, '_', ApplyDefaultOptions<WordsOptions, DefaultDelimiterCaseOptions, Options>>;
+> = DelimiterCasedProperties<Value, '_', ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>;

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -1,5 +1,6 @@
 import type tag from 'tagged-tag';
 
+// eslint-disable-next-line type-fest/require-exported-types
 export type TagContainer<Token> = {
 	readonly [tag]: Token;
 };

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -38,7 +38,7 @@ export type WordsOptions = {
 	splitOnNumbers?: boolean;
 };
 
-export type DefaultWordsOptions = {
+export type _DefaultWordsOptions = {
 	splitOnNumbers: true;
 };
 
@@ -76,7 +76,7 @@ type Words5 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 @category Template literal
 */
 export type Words<Sentence extends string, Options extends WordsOptions = {}> =
-	WordsImplementation<Sentence, ApplyDefaultOptions<WordsOptions, DefaultWordsOptions, Options>>;
+	WordsImplementation<Sentence, ApplyDefaultOptions<WordsOptions, _DefaultWordsOptions, Options>>;
 
 type WordsImplementation<
 	Sentence extends string,

--- a/test-d/internal/enforce-optional.ts
+++ b/test-d/internal/enforce-optional.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {EnforceOptional} from '../source/enforce-optional.d.ts';
+import type {EnforceOptional} from '../../source/internal/index.d.ts';
 
 type Foo = {
 	a: string;

--- a/xo.config.js
+++ b/xo.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 import {importPathRule} from './lint-rules/import-path.js';
 import {sourceFilesExtensionRule} from './lint-rules/source-files-extension.js';
+import {requireExportedTypesRule} from './lint-rules/require-exported-types.js';
 
 /** @type {import('xo').FlatXoConfig} */
 const xoConfig = [
@@ -53,6 +54,7 @@ const xoConfig = [
 				rules: {
 					'import-path': importPathRule,
 					'source-files-extension': sourceFilesExtensionRule,
+					'require-exported-types': requireExportedTypesRule,
 				},
 			},
 		},
@@ -67,6 +69,13 @@ const xoConfig = [
 		files: 'source/**/*',
 		rules: {
 			'type-fest/source-files-extension': 'error',
+		},
+	},
+	{
+		files: 'source/**/*.d.ts',
+		ignores: ['source/internal/**/*.d.ts'],
+		rules: {
+			'type-fest/require-exported-types': 'error',
 		},
 	},
 ];


### PR DESCRIPTION
To prevent https://github.com/sindresorhus/type-fest/commit/4f9c248b5729e1d1d2735dae5ec7922d1c70ba3a in the future.

For types that we export from one file and is internally in othre files, we just prefix with underscore to make it immediately clear it's an internal type.