### PR TITLE
Export `*Options` types from source files

### DIFF
--- a/source/all-extend.d.ts
+++ b/source/all-extend.d.ts
@@ -10,7 +10,7 @@ import type {UnknownArray} from './unknown-array.d.ts';
 /**
 @see {@link AllExtend}
 */
-type AllExtendOptions = {
+export type AllExtendOptions = {
 	/**
 	Consider `never` elements to match the target type only if the target type itself is `never` (or `any`).
 

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -30,7 +30,7 @@ type Filtered = Filter<'bar', 'foo'>;
 */
 type Filter<KeyType, ExcludeType> = IsEqual<KeyType, ExcludeType> extends true ? never : (KeyType extends ExcludeType ? never : KeyType);
 
-type ExceptOptions = {
+export type ExceptOptions = {
 	/**
 	Disallow assigning non-specified properties.
 

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -5,7 +5,7 @@ import type {Split} from './split.d.ts';
 import type {KeyAsString} from './key-as-string.d.ts';
 import type {DigitCharacter} from './characters.d.ts';
 
-type GetOptions = {
+export type GetOptions = {
 	/**
 	Include `undefined` in the return type when accessing properties.
 

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -6,7 +6,7 @@ import type {Or} from './or.d.ts';
 /**
 @see {@link RemovePrefix}
 */
-type RemovePrefixOptions = {
+export type RemovePrefixOptions = {
 	/**
 	When enabled, instantiations with non-literal prefixes (e.g., `string`, `Uppercase<string>`, `` `on${string}` ``) simply return `string`, since their precise structure cannot be statically determined.
 

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -1,6 +1,6 @@
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 
-type ReplaceOptions = {
+export type ReplaceOptions = {
 	all?: boolean;
 };
 

--- a/source/set-field-type.d.ts
+++ b/source/set-field-type.d.ts
@@ -1,7 +1,7 @@
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {Simplify} from './simplify.d.ts';
 
-type SetFieldTypeOptions = {
+export type SetFieldTypeOptions = {
 	/**
 	Preserve optional and readonly modifiers for properties being updated.
 

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -8,7 +8,7 @@ Split options.
 
 @see {@link Split}
 */
-type SplitOptions = {
+export type SplitOptions = {
 	/**
 	When enabled, instantiations with non-literal string types (e.g., `string`, `Uppercase<string>`, `on${string}`) simply return back `string[]` without performing any splitting, as the exact structure cannot be statically determined.
 


### PR DESCRIPTION
Export `*Options` types from source files that are re-exported from index.d.ts.

- Fixes #1240