### PR TITLE
remaster `Includes` type

### DIFF
--- a/source/includes.d.ts
+++ b/source/includes.d.ts
@@ -1,3 +1,5 @@
+import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
 
 /**
@@ -9,16 +11,39 @@ This can be useful if another type wants to make a decision based on whether the
 ```
 import type {Includes} from 'type-fest';
 
-type hasRed<array extends any[]> = Includes<array, 'red'>;
+type array = [1, 2, 3, ...4[], 5];
+
+type T1 = Includes<array, 1>;
+//=> true
+
+type T2 = Includes<array, 4>;
+//=> true
+
+type T3 = Includes<array, 0>;
+//=> false
+
+type T4 = Includes<[1, 2, 3?], 3>;
+//=> boolean
+
+type T5 = Includes<[1, 3, 3?], 3>;
+//=> true
 ```
 
 @category Array
 */
-export type Includes<Value extends readonly any[], Item> =
-	Value extends readonly [Value[0], ...infer rest]
-		? IsEqual<Value[0], Item> extends true
-			? true
-			: Includes<rest, Item>
-		: false;
+export type Includes<Array_ extends UnknownArray, Item> = {
+	[Key in keyof Array_]-?:
+	IsOptionalKeyOf<Array_, Key> extends true
+		? IsEqual<Array_[Key], Item | undefined> extends true
+			? 'boolean'
+			: 'false'
+		: IsEqual<Array_[Key], Item> extends true
+			? 'true'
+			: 'false'
+}[number] extends infer Result
+	? [Result] extends ['false'] ? false
+		: ['true'] extends [Result] ? true
+			: boolean
+	: never;
 
 export {};

--- a/test-d/includes.ts
+++ b/test-d/includes.ts
@@ -1,57 +1,66 @@
 import {expectType} from 'tsd';
-import type {Includes} from '../index.d.ts';
+import type {Includes} from '../source/includes.d.ts';
 
-const includesEmptyArray: Includes<[], 'abc'> = false;
-expectType<false>(includesEmptyArray);
+declare const boolean: boolean;
 
-const includesSingleItemArray: Includes<['colors'], 'colors'> = true;
-expectType<true>(includesSingleItemArray);
+// ---------- Basic definite cases ----------
+expectType<Includes<[1, 2, 3], 1>>(true);
+expectType<Includes<[1, 2, 3], 3>>(true);
+expectType<Includes<[1, 2, 3], 4>>(false);
 
-const readonlyArray = ['a', 'b', 'c'] as const;
-const includesReadonlyArray: Includes<typeof readonlyArray, 'a'> = true;
-expectType<true>(includesReadonlyArray);
+// ---------- Optional elements ----------
+expectType<Includes<[a: string, b?: number], string>>(true);
+expectType<Includes<[a: string, b?: number], number>>(boolean);
+expectType<Includes<[a: string, b?: number], undefined>>(false);
 
-const includesComplexMultiTypeArray: Includes<[
-	{
-		prop: 'value';
-		num: 5;
-		anotherArr: [1, '5', false];
-	},
-	true,
-	null,
-	'abcd',
-], 'abc'> = false;
-expectType<false>(includesComplexMultiTypeArray);
+// ---------- Explicit undefined ----------
+expectType<Includes<[a: string, b: undefined], undefined>>(true);
+expectType<Includes<[a: string, b: undefined], string>>(true);
+expectType<Includes<[a: string, b: undefined], number>>(false);
 
-const noExtendsProblem: Includes<[boolean], true> = false;
-expectType<false>(noExtendsProblem);
+// ---------- Empty tuple ----------
+expectType<Includes<[], any>>(false);
+expectType<Includes<[], never>>(false);
+expectType<Includes<[], undefined>>(false);
 
-const objectIncludes: Includes<[{}], {a: 1}> = false;
-expectType<false>(objectIncludes);
+// ---------- Homogeneous arrays ----------
+expectType<Includes<string[], string>>(true);
+expectType<Includes<string[], number>>(false);
+expectType<Includes<readonly number[], number>>(true);
+expectType<Includes<readonly number[], string>>(false);
 
-const objectIncludesPass: Includes<[{a: 1}], {a: 1}> = true;
-expectType<true>(objectIncludesPass);
+// ---------- Nested ----------
+expectType<Includes<[[1, 2], [3, 4]], [1, 2]>>(true);
+expectType<Includes<[[1, 2], [3, 4]], [2, 3]>>(false);
+expectType<Includes<[{a: 1; b: 2}, {a: 3; b: 4}], {a: 1; b: 2}>>(true);
+expectType<Includes<[{a: 1; b: 2}, {c: 3; d: 4}], {c: 3; d: 4}>>(true);
 
-const nullIncludesUndefined: Includes<[null], undefined> = false;
-expectType<false>(nullIncludesUndefined);
+// ---------- Optional + required mix ----------
+expectType<Includes<[1, 3, 3?], 3>>(true);
+expectType<Includes<[1, 2?, 3?], 1>>(true);
+expectType<Includes<[1, 2?, 3?], 2>>(boolean);
+expectType<Includes<[1, 2?, 3?], 3>>(boolean);
 
-const nullIncludesNullPass: Includes<[null], null> = true;
-expectType<true>(nullIncludesNullPass);
+// ---------- Unions ----------
+expectType<Includes<[1 | 2, 3], 1>>(false);
+expectType<Includes<[1 | 2, 3], 1 | 2>>(true);
+expectType<Includes<[1, 3] | [2, 3], 1>>(true);
 
-// Verify that incorrect usage of `Includes` produces an error.
+// ---------- Literal cases ----------
+declare const sym: unique symbol;
+expectType<Includes<[typeof sym], typeof sym>>(true);
+expectType<Includes<[typeof sym], symbol>>(false);
 
-// Missing all generic parameters.
-// @ts-expect-error
-type A0 = Includes;
+// ---------- Mixed optional ----------
+expectType<Includes<[1?, 2?], 1>>(boolean);
+expectType<Includes<[1?, 2?], 2>>(boolean);
+expectType<Includes<[1?, 2?], 3>>(false);
+expectType<Includes<[undefined?], undefined>>(boolean);
+expectType<Includes<[undefined], undefined>>(true);
+expectType<Includes<[undefined?], number>>(false);
 
-// Missing `Item` generic parameter.
-// @ts-expect-error
-type A1 = Includes<['my', 'array', 'has', 'stuff']>;
-
-// Value generic parameter is a string not an array.
-// @ts-expect-error
-type A2 = Includes<'why a string?', 5>;
-
-// Value generic parameter is an object not an array.
-// @ts-expect-error
-type A3 = Includes<{key: 'value'}, 7>;
+// ---------- Edge cases ----------
+expectType<Includes<[never], any>>(false);
+expectType<Includes<[never], never>>(true);
+expectType<Includes<any, any>>(boolean);
+expectType<Includes<never, never>>(false);


### PR DESCRIPTION

- Fully supports optional elements (?) → returns `boolean` if the match is optional.
- Correctly handles required undefined separately from optional (?).

Feature | Old (Recursive) | New (Mapped)
-- | -- | --
Optional element support | ❌ | ✅
Required undefined distinction | ❌ | ✅
Result precision | true/false | true/false/boolean
Edge case coverage | limited | complete
