### PR TITLE
add: `IndexOf`, `LastIndexOf` and `IndicesOf` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -158,6 +158,9 @@ export type {IsUppercase} from './source/is-uppercase.d.ts';
 export type {IsOptional} from './source/is-optional.d.ts';
 export type {IsNullable} from './source/is-nullable.d.ts';
 export type {TupleOf} from './source/tuple-of.d.ts';
+export type {IndexOf} from './source/index-of.d.ts';
+export type {LastIndexOf} from './source/last-index-of.d.ts';
+export type {IndicesOf} from './source/indices-of.d.ts';
 
 // Template literal types
 export type {CamelCase, CamelCaseOptions} from './source/camel-case.d.ts';

--- a/source/index-of.d.ts
+++ b/source/index-of.d.ts
@@ -7,62 +7,58 @@ import type {IsAnyOrNever} from './internal/type.d.ts';
 import type {LiteralUnion} from './literal-union.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
 
-export type IndexOfOptions = {
-    ignoreOptionalModifier?: boolean;
-    fromIndex?: number;
-}
-
-type DefaultIndexOfOptions = {
-    ignoreOptionalModifier: false;
-    fromIndex: 0;
-}
-
+/* eslint-disable type-fest/require-exported-types */
 export type Inc<T extends number[]> = [...T, 1];
 export type Neg<T extends number[]> = ReverseSign<T['length']>;
+export type IndexOfOptions = {
+	ignoreOptionalModifier?: boolean;
+	fromIndex?: number;
+};
+/* eslint-enable type-fest/require-exported-types */
+
+type DefaultIndexOfOptions = {
+	ignoreOptionalModifier: false;
+	fromIndex: 0;
+};
 
 export type IndexOf<
-    Array_ extends UnknownArray, Item,
-    Options extends IndexOfOptions = {},
+	Array_ extends UnknownArray, Item,
+	Options extends IndexOfOptions = {},
 > = IsAnyOrNever<Array_> extends true ? Array_
-    : _IndexOf<Array_, Item,
-        ApplyDefaultOptions<
-            IndexOfOptions,
-            DefaultIndexOfOptions,
-            Options
-        >
-    >;
+	: _IndexOf<Array_, Item,
+		ApplyDefaultOptions<
+			IndexOfOptions,
+			DefaultIndexOfOptions,
+			Options
+		>
+	>;
 
 type _IndexOf<
-    Array_ extends UnknownArray, Item,
-    Options extends Required<IndexOfOptions>,
-    F_Index extends number[] = [],
-    B_Index extends number[] = [1],
-    T_Index extends number[] = never,
+	Array_ extends UnknownArray, Item,
+	Options extends Required<IndexOfOptions>,
+	F_Index extends number[] = [],
+	B_Index extends number[] = [1],
+	T_Index extends number[] = never,
 > =
-    keyof Array_ & `${number}` extends never
-        // Backward search
+	keyof Array_ & `${number}` extends never
+		// Backward search
 		? Array_ extends readonly [...infer Rest, infer Last]
 			? IsEqual<Last, Item> extends true
-                ? _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, B_Index>
-                : _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+				? _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, B_Index>
+				: _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
 			: Array_ extends readonly [] ? Neg<T_Index>
-                : IsEqual<Array_[number], Item> extends false ? Neg<T_Index>
-                    : LiteralUnion<F_Index, number>
-        // Forward search
+				: IsEqual<Array_[number], Item> extends false ? Neg<T_Index>
+					: LiteralUnion<F_Index, number>
+		// Forward search
 		: Array_ extends readonly [(infer First)?, ...infer Rest]
 			? GreaterThanOrEqual<F_Index['length'], Options['fromIndex']> extends true
-                ? IsEqual<First, Item> extends true
-                    ? F_Index['length'] | (
-                        Options['ignoreOptionalModifier'] extends true ? never
-                            : IsOptionalKeyOf<Array_, '0'> extends false ? never
-                                : _IndexOf<Rest, Item, Options, Inc<F_Index>>)
-                    : _IndexOf<Rest, Item, Options, Inc<F_Index>>
-                : _IndexOf<Rest, Item, Options, Inc<F_Index>>
+				? IsEqual<First, Item> extends true ? F_Index['length'] | (
+					Options['ignoreOptionalModifier'] extends true ? never
+						: IsOptionalKeyOf<Array_, '0'> extends false ? never
+							: _IndexOf<Rest, Item, Options, Inc<F_Index>>)
+					: _IndexOf<Rest, Item, Options, Inc<F_Index>>
+				: _IndexOf<Rest, Item, Options, Inc<F_Index>>
 
 			: never;
-
-
-type T = IndexOf<[1, 3, 0, 6/* , ...10[] */, 8, 10, 4, 2, 4], 4, {fromIndex: 0}>
-//    ^?
 
 export {};

--- a/source/index-of.d.ts
+++ b/source/index-of.d.ts
@@ -1,0 +1,68 @@
+import type {GreaterThanOrEqual} from './greater-than-or-equal.d.ts';
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
+import type {ReverseSign} from './internal/numeric.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+import type {IsAnyOrNever} from './internal/type.d.ts';
+import type {LiteralUnion} from './literal-union.d.ts';
+import type {IsEqual} from './is-equal.d.ts';
+
+export type IndexOfOptions = {
+    ignoreOptionalModifier?: boolean;
+    fromIndex?: number;
+}
+
+type DefaultIndexOfOptions = {
+    ignoreOptionalModifier: false;
+    fromIndex: 0;
+}
+
+export type Inc<T extends number[]> = [...T, 1];
+export type Neg<T extends number[]> = ReverseSign<T['length']>;
+
+export type IndexOf<
+    Array_ extends UnknownArray, Item,
+    Options extends IndexOfOptions = {},
+> = IsAnyOrNever<Array_> extends true ? Array_
+    : _IndexOf<Array_, Item,
+        ApplyDefaultOptions<
+            IndexOfOptions,
+            DefaultIndexOfOptions,
+            Options
+        >
+    >;
+
+type _IndexOf<
+    Array_ extends UnknownArray, Item,
+    Options extends Required<IndexOfOptions>,
+    F_Index extends number[] = [],
+    B_Index extends number[] = [1],
+    T_Index extends number[] = never,
+> =
+    keyof Array_ & `${number}` extends never
+        // Backward search
+		? Array_ extends readonly [...infer Rest, infer Last]
+			? IsEqual<Last, Item> extends true
+                ? _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, B_Index>
+                : _IndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+			: Array_ extends readonly [] ? Neg<T_Index>
+                : IsEqual<Array_[number], Item> extends false ? Neg<T_Index>
+                    : LiteralUnion<F_Index, number>
+        // Forward search
+		: Array_ extends readonly [(infer First)?, ...infer Rest]
+			? GreaterThanOrEqual<F_Index['length'], Options['fromIndex']> extends true
+                ? IsEqual<First, Item> extends true
+                    ? F_Index['length'] | (
+                        Options['ignoreOptionalModifier'] extends true ? never
+                            : IsOptionalKeyOf<Array_, '0'> extends false ? never
+                                : _IndexOf<Rest, Item, Options, Inc<F_Index>>)
+                    : _IndexOf<Rest, Item, Options, Inc<F_Index>>
+                : _IndexOf<Rest, Item, Options, Inc<F_Index>>
+
+			: never;
+
+
+type T = IndexOf<[1, 3, 0, 6/* , ...10[] */, 8, 10, 4, 2, 4], 4, {fromIndex: 0}>
+//    ^?
+
+export {};

--- a/source/indices-of.d.ts
+++ b/source/indices-of.d.ts
@@ -6,64 +6,61 @@ import type {Inc, Neg} from './index-of.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
 
 type IndicesOfOptions = {
-    ignoreOptionalModifier?: boolean;
-    // fromIndex?: number;
-}
+	ignoreOptionalModifier?: boolean;
+	// FromIndex?: number;
+};
 
 type DefaultIndicesOfOptions = {
-    ignoreOptionalModifier: false;
-    // fromIndex: 0;
-}
+	ignoreOptionalModifier: false;
+	// FromIndex: 0;
+};
 
 export type IndicesOf<
-    Array_ extends UnknownArray, Item,
-    Options extends IndicesOfOptions = {},
+	Array_ extends UnknownArray, Item,
+	Options extends IndicesOfOptions = {},
 > = IsAnyOrNever<Array_> extends true ? Array_
-    : _IndicesOf<Array_, Item,
-        ApplyDefaultOptions<
-            IndicesOfOptions,
-            DefaultIndicesOfOptions,
-            Options
-        >
-    >;
+	: _IndicesOf<Array_, Item,
+		ApplyDefaultOptions<
+			IndicesOfOptions,
+			DefaultIndicesOfOptions,
+			Options
+		>
+	>;
 
 type _IndicesOf<
-    Array_ extends UnknownArray, Item,
-    Options extends Required<IndicesOfOptions>,
-    F_Index extends number[] = [],
-    F_Indices extends (number | undefined)[] = [],
-    B_Index extends number[] = [1],
-    B_Indices extends (number | undefined)[] = [],
-    T_Index extends number = F_Index['length'],
+	Array_ extends UnknownArray, Item,
+	Options extends Required<IndicesOfOptions>,
+	F_Index extends number[] = [],
+	F_Indices extends Array<number | undefined> = [],
+	B_Index extends number[] = [1],
+	B_Indices extends Array<number | undefined> = [],
+	T_Index extends number = F_Index['length'],
 > =
-    keyof Array_ & `${number}` extends never
+	keyof Array_ & `${number}` extends never
 
-        ? Array_ extends readonly [...infer Rest, infer Last]
-            ? IsEqual<Last, Item> extends true
-                ? _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, [Neg<B_Index>, ...B_Indices]>
-                : _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, B_Indices>
+		? Array_ extends readonly [...infer Rest, infer Last]
+			? IsEqual<Last, Item> extends true
+				? _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, [Neg<B_Index>, ...B_Indices]>
+				: _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, B_Indices>
 
-            : [
-                ...F_Indices,
-                ...Array_ extends readonly [] ? []
-                    : IsEqual<Array_[number], Item> extends false ? []
-                        : [Array_[number] | (number & {})],
-                ...B_Indices,
-            ]
+			: [
+				...F_Indices,
+				...Array_ extends readonly [] ? []
+					: IsEqual<Array_[number], Item> extends false ? []
+						: [Array_[number] | (number & {})],
+				...B_Indices,
+			]
 
-        : Array_ extends readonly [(infer First)?, ...infer Rest]
-            ? IsEqual<First, Item> extends true
-                ? _IndicesOf<Rest, Item, Options, Inc<F_Index>, [
-                    ...F_Indices,
-                    ...Options['ignoreOptionalModifier'] extends true ? [T_Index]
-                        : IsOptionalKeyOf<Array_, '0'> extends false ? [T_Index]
-                            : [T_Index?]
-                ]>
-                : _IndicesOf<Rest, Item, Options, Inc<F_Index>, F_Indices>
+		: Array_ extends readonly [(infer First)?, ...infer Rest]
+			? IsEqual<First, Item> extends true
+				? _IndicesOf<Rest, Item, Options, Inc<F_Index>, [
+					...F_Indices,
+					...Options['ignoreOptionalModifier'] extends true ? [T_Index]
+						: IsOptionalKeyOf<Array_, '0'> extends false ? [T_Index]
+							: [T_Index?],
+				]>
+				: _IndicesOf<Rest, Item, Options, Inc<F_Index>, F_Indices>
 
-            : never;
-
-type T = IndicesOf<[1, 2, 4, 6, ...4[], 8, 4, 2, 4], 4, {ignoreOptionalModifier: true}>
-//    ^?
+			: never;
 
 export {};

--- a/source/indices-of.d.ts
+++ b/source/indices-of.d.ts
@@ -1,0 +1,69 @@
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+import type {IsAnyOrNever} from './internal/type.d.ts';
+import type {Inc, Neg} from './index-of.d.ts';
+import type {IsEqual} from './is-equal.d.ts';
+
+type IndicesOfOptions = {
+    ignoreOptionalModifier?: boolean;
+    // fromIndex?: number;
+}
+
+type DefaultIndicesOfOptions = {
+    ignoreOptionalModifier: false;
+    // fromIndex: 0;
+}
+
+export type IndicesOf<
+    Array_ extends UnknownArray, Item,
+    Options extends IndicesOfOptions = {},
+> = IsAnyOrNever<Array_> extends true ? Array_
+    : _IndicesOf<Array_, Item,
+        ApplyDefaultOptions<
+            IndicesOfOptions,
+            DefaultIndicesOfOptions,
+            Options
+        >
+    >;
+
+type _IndicesOf<
+    Array_ extends UnknownArray, Item,
+    Options extends Required<IndicesOfOptions>,
+    F_Index extends number[] = [],
+    F_Indices extends (number | undefined)[] = [],
+    B_Index extends number[] = [1],
+    B_Indices extends (number | undefined)[] = [],
+    T_Index extends number = F_Index['length'],
+> =
+    keyof Array_ & `${number}` extends never
+
+        ? Array_ extends readonly [...infer Rest, infer Last]
+            ? IsEqual<Last, Item> extends true
+                ? _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, [Neg<B_Index>, ...B_Indices]>
+                : _IndicesOf<Rest, Item, Options, F_Index, F_Indices, Inc<B_Index>, B_Indices>
+
+            : [
+                ...F_Indices,
+                ...Array_ extends readonly [] ? []
+                    : IsEqual<Array_[number], Item> extends false ? []
+                        : [Array_[number] | (number & {})],
+                ...B_Indices,
+            ]
+
+        : Array_ extends readonly [(infer First)?, ...infer Rest]
+            ? IsEqual<First, Item> extends true
+                ? _IndicesOf<Rest, Item, Options, Inc<F_Index>, [
+                    ...F_Indices,
+                    ...Options['ignoreOptionalModifier'] extends true ? [T_Index]
+                        : IsOptionalKeyOf<Array_, '0'> extends false ? [T_Index]
+                            : [T_Index?]
+                ]>
+                : _IndicesOf<Rest, Item, Options, Inc<F_Index>, F_Indices>
+
+            : never;
+
+type T = IndicesOf<[1, 2, 4, 6, ...4[], 8, 4, 2, 4], 4, {ignoreOptionalModifier: true}>
+//    ^?
+
+export {};

--- a/source/last-index-of.d.ts
+++ b/source/last-index-of.d.ts
@@ -1,0 +1,80 @@
+import type {GreaterThanOrEqual} from './greater-than-or-equal.d.ts';
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
+import type {Inc, Neg, IndexOfOptions} from './index-of.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+import type {IsAnyOrNever} from './internal/type.d.ts';
+import type {LiteralUnion} from './literal-union.d.ts';
+import type {GreaterThan} from './greater-than.d.ts';
+import type {IsEqual} from './is-equal.d.ts';
+
+type DefaultLastIndexOfOptions = {
+    ignoreOptionalModifier: false;
+    fromIndex: 0;
+}
+
+type IsLastOptional<T extends UnknownArray> =
+    T extends [...infer Rest, (infer _)?]
+        ? [...Rest] extends T
+            ? true
+            : false
+        : false;
+
+export type LastIndexOf<
+    Array_ extends UnknownArray, Item,
+    Options extends IndexOfOptions = {},
+> = IsAnyOrNever<Array_> extends true ? Array_
+    : _LastIndexOf<Array_, Item,
+        ApplyDefaultOptions<
+            IndexOfOptions,
+            DefaultLastIndexOfOptions,
+            Options
+        >
+    >;
+
+type _LastIndexOf<
+    Array_ extends UnknownArray, Item,
+    Options extends Required<IndexOfOptions>,
+    F_Index extends number[] = [],
+    B_Index extends number[] = [1],
+    T_Index extends number = never,
+> =
+    number extends Array_['length']
+        ? keyof Array_ & `${number}` extends never
+
+            ? Array_ extends readonly [...infer Rest, infer Last]
+                ? GreaterThan<B_Index['length'], Options['fromIndex']> extends true
+                    ? IsEqual<Last, Item> extends true ? Neg<B_Index>
+                        : _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+                    : _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+
+                : Array_ extends readonly [] ? T_Index
+                    : IsEqual<Array_[number], Item> extends false ? T_Index
+                        : LiteralUnion<F_Index['length'], number>
+
+            : Array_ extends readonly [(infer First)?, ...infer Rest]
+                ? IsEqual<First, Item> extends true
+                    ? _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index,
+                        F_Index['length'] | (
+                            Options['ignoreOptionalModifier'] extends true ? never
+                                : IsOptionalKeyOf<Array_, '0'> extends false ? never
+                                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>)>
+                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>
+                : never
+
+        : Array_ extends readonly [...infer Rest, (infer Last)?]
+            ? GreaterThanOrEqual<F_Index['length'], Options['fromIndex']> extends true
+                ? IsEqual<Last, Item> extends true
+                    ? Required<Rest>['length'] | (
+                        Options['ignoreOptionalModifier'] extends true ? never
+                            : IsLastOptional<Array_> extends false ? never
+                                : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>)
+                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
+                : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
+            : never
+
+
+type T = LastIndexOf<[1, 3, 6, 6, ...10[], 8, 10, 4, 2, 4, 6], 4, {fromIndex: 0, ignoreOptionalModifier: false}>
+//    ^?
+
+export {};

--- a/source/last-index-of.d.ts
+++ b/source/last-index-of.d.ts
@@ -9,72 +9,66 @@ import type {GreaterThan} from './greater-than.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
 
 type DefaultLastIndexOfOptions = {
-    ignoreOptionalModifier: false;
-    fromIndex: 0;
-}
+	ignoreOptionalModifier: false;
+	fromIndex: 0;
+};
 
 type IsLastOptional<T extends UnknownArray> =
-    T extends [...infer Rest, (infer _)?]
-        ? [...Rest] extends T
-            ? true
-            : false
-        : false;
+	T extends [...infer Rest, (infer _)?]
+		? [...Rest] extends T
+			? true
+			: false
+		: false;
 
 export type LastIndexOf<
-    Array_ extends UnknownArray, Item,
-    Options extends IndexOfOptions = {},
+	Array_ extends UnknownArray, Item,
+	Options extends IndexOfOptions = {},
 > = IsAnyOrNever<Array_> extends true ? Array_
-    : _LastIndexOf<Array_, Item,
-        ApplyDefaultOptions<
-            IndexOfOptions,
-            DefaultLastIndexOfOptions,
-            Options
-        >
-    >;
+	: _LastIndexOf<Array_, Item,
+		ApplyDefaultOptions<
+			IndexOfOptions,
+			DefaultLastIndexOfOptions,
+			Options
+		>
+	>;
 
 type _LastIndexOf<
-    Array_ extends UnknownArray, Item,
-    Options extends Required<IndexOfOptions>,
-    F_Index extends number[] = [],
-    B_Index extends number[] = [1],
-    T_Index extends number = never,
+	Array_ extends UnknownArray, Item,
+	Options extends Required<IndexOfOptions>,
+	F_Index extends number[] = [],
+	B_Index extends number[] = [1],
+	T_Index extends number = never,
 > =
-    number extends Array_['length']
-        ? keyof Array_ & `${number}` extends never
+	number extends Array_['length']
+		? keyof Array_ & `${number}` extends never
 
-            ? Array_ extends readonly [...infer Rest, infer Last]
-                ? GreaterThan<B_Index['length'], Options['fromIndex']> extends true
-                    ? IsEqual<Last, Item> extends true ? Neg<B_Index>
-                        : _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
-                    : _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+			? Array_ extends readonly [...infer Rest, infer Last]
+				? GreaterThan<B_Index['length'], Options['fromIndex']> extends true
+					? IsEqual<Last, Item> extends true ? Neg<B_Index>
+						: _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
+					: _LastIndexOf<Rest, Item, Options, F_Index, Inc<B_Index>, T_Index>
 
-                : Array_ extends readonly [] ? T_Index
-                    : IsEqual<Array_[number], Item> extends false ? T_Index
-                        : LiteralUnion<F_Index['length'], number>
+				: Array_ extends readonly [] ? T_Index
+					: IsEqual<Array_[number], Item> extends false ? T_Index
+						: LiteralUnion<F_Index['length'], number>
 
-            : Array_ extends readonly [(infer First)?, ...infer Rest]
-                ? IsEqual<First, Item> extends true
-                    ? _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index,
-                        F_Index['length'] | (
-                            Options['ignoreOptionalModifier'] extends true ? never
-                                : IsOptionalKeyOf<Array_, '0'> extends false ? never
-                                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>)>
-                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>
-                : never
+			: Array_ extends readonly [(infer First)?, ...infer Rest]
+				? IsEqual<First, Item> extends true
+					? _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, F_Index['length'] | (
+						Options['ignoreOptionalModifier'] extends true ? never
+							: IsOptionalKeyOf<Array_, '0'> extends false ? never
+								: _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>)>
+					: _LastIndexOf<Rest, Item, Options, Inc<F_Index>, B_Index, T_Index>
+				: never
 
-        : Array_ extends readonly [...infer Rest, (infer Last)?]
-            ? GreaterThanOrEqual<F_Index['length'], Options['fromIndex']> extends true
-                ? IsEqual<Last, Item> extends true
-                    ? Required<Rest>['length'] | (
-                        Options['ignoreOptionalModifier'] extends true ? never
-                            : IsLastOptional<Array_> extends false ? never
-                                : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>)
-                    : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
-                : _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
-            : never
-
-
-type T = LastIndexOf<[1, 3, 6, 6, ...10[], 8, 10, 4, 2, 4, 6], 4, {fromIndex: 0, ignoreOptionalModifier: false}>
-//    ^?
+		: Array_ extends readonly [...infer Rest, (infer Last)?]
+			? GreaterThanOrEqual<F_Index['length'], Options['fromIndex']> extends true
+				? IsEqual<Last, Item> extends true ? Required<Rest>['length'] | (
+					Options['ignoreOptionalModifier'] extends true ? never
+						: IsLastOptional<Array_> extends false ? never
+							: _LastIndexOf<Rest, Item, Options, Inc<F_Index>>)
+					: _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
+				: _LastIndexOf<Rest, Item, Options, Inc<F_Index>>
+			: never;
 
 export {};


### PR DESCRIPTION
this is a remake of the #1155

- **`IndexOf`** Returns the index of the first occurrence of a value in an array, or `never` if it is not present.
- **`LastIndexOf`** Returns the index of the last occurrence of a value in an array, or `never` if it is not present.
- **`IndicesOf`** Return an array of indexes of all the occurrences of a value in an array, or `[]` if it is not present.

this version added support for arrays (rest elements) so it returns a negative index if the match is behind the rest element, which will come perfect with the next plan of introducing `ArrayAt` type.