### PR TITLE
`ReadonlyTuple`: Deprecate in favour of `TupleOf`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,7 @@ Click the type names for complete docs.
 - `HomomorphicOmit` - See [`Except`](source/except.d.ts)
 - `IfAny`, `IfNever`, `If*` - See [`If`](source/if.d.ts)
 - `MaybePromise` - See [`Promisable`](source/promisable.d.ts)
+- `ReadonlyTuple` - See [`TupleOf`](source/tuple-of.d.ts)
 
 ## Tips
 

--- a/source/readonly-tuple.d.ts
+++ b/source/readonly-tuple.d.ts
@@ -1,13 +1,4 @@
-/**
-Creates a read-only tuple of type `Element` and with the length of `Length`.
-
-@private
-@see `ReadonlyTuple` which is safer because it tests if `Length` is a specific finite number.
-*/
-type BuildTupleHelper<Element, Length extends number, Rest extends Element[]> =
-	Rest['length'] extends Length ?
-		readonly [...Rest] : // Terminate with readonly array (aka tuple)
-		BuildTupleHelper<Element, Length, [Element, ...Rest]>;
+import type {TupleOf} from './tuple-of.d.ts';
 
 /**
 Create a type that represents a read-only tuple of the given type and length.
@@ -32,12 +23,10 @@ guestFencingTeam.push('Sam');
 //=> error TS2339: Property 'push' does not exist on type 'FencingTeam'
 ```
 
+@deprecated This type will be removed in the next major version. Use the built-in `Readonly` type in combination with the {@link TupleOf} type instead, like `Readonly<TupleOf<Length, Element>>`.
+
 @category Utilities
 */
-export type ReadonlyTuple<Element, Length extends number> =
-	number extends Length
-		// Because `Length extends number` and `number extends Length`, then `Length` is not a specific finite number.
-		? readonly Element[] // It's not fixed length.
-		: BuildTupleHelper<Element, Length, []>; // Otherwise it is a fixed length tuple.
+export type ReadonlyTuple<Element, Length extends number> = Readonly<TupleOf<Length, Element>>;
 
 export {};

--- a/source/tuple-of.d.ts
+++ b/source/tuple-of.d.ts
@@ -61,6 +61,8 @@ type EmptyTuple = TupleOf<-3, string>;
 //=> []
 ```
 
+Note: If you need a readonly tuple, simply wrap this type with `Readonly`, for example, to create `readonly [number, number, number]` use `Readonly<TupleOf<3, number>>`.
+
 @category Array
 */
 export type TupleOf<Length extends number, Fill = unknown> = IfNotAnyOrNever<Length,


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Now that we have [`TupleOf`](https://github.com/sindresorhus/type-fest/pull/1250) exposed, I don't think we need a separate `ReadonlyTuple` type because it simply wraps the result of `TupleOf` in `Readonly`.

This PR also refactors the implementation of `ReadonlyTuple` to use `TupleOf`, which in turn fixes the following bug wherein the type wasn't distributing over the `Length` argument.
```ts
type Current = ReadonlyTuple<string, 3 | 4>;
//=> readonly [string, string, string]

type Fixed = ReadonlyTuple<string, 3 | 4>;
//=> readonly [string, string, string] | readonly [string, string, string, string]
```
