### PR TITLE
`PartialDeep`: Fix behaviour with functions containing multiple call signatures

### DIFF
--- a/source/required-deep.d.ts
+++ b/source/required-deep.d.ts
@@ -1,4 +1,5 @@
 import type {BuiltIns, HasMultipleCallSignatures} from './internal/index.d.ts';
+import type {IsNever} from './is-never.d.ts';
 
 /**
 Create a type from another type with all keys and nested keys set to required.
@@ -58,7 +59,7 @@ export type RequiredDeep<T> = T extends BuiltIns
 							: T extends Promise<infer ValueType>
 								? Promise<RequiredDeep<ValueType>>
 								: T extends (...arguments_: any[]) => unknown
-									? {} extends RequiredObjectDeep<T>
+									? IsNever<keyof T> extends true
 										? T
 										: HasMultipleCallSignatures<T> extends true
 											? T

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -1,4 +1,4 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectType, expectAssignable, expectNotType} from 'tsd';
 import type {PartialDeep, Simplify} from '../index.d.ts';
 
 class ClassA {
@@ -128,3 +128,8 @@ expectType<{p1?: {p2?: string; p3?: [{p4?: number}?, string?]}}>({} as Simplify<
 
 expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]}, {allowUndefinedInNonTupleArrays: false}>>);
 expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]}, {allowUndefinedInNonTupleArrays: true}>>);
+
+// Properties within functions containing multiple call signatures are not made partial due to TS limitations, refer https://github.com/microsoft/TypeScript/issues/29732
+type FunctionWithProperties4 = {(a1: number): string; (a1: string, a2: number): number; p1: string};
+declare const functionWithProperties4: PartialDeep<FunctionWithProperties4>;
+expectNotType<{p1?: string}>({} as Simplify<typeof functionWithProperties4>);

--- a/test-d/partial-deep.ts
+++ b/test-d/partial-deep.ts
@@ -132,4 +132,6 @@ expectType<{p1?: string[]}>({} as Simplify<PartialDeep<{(): void; p1: string[]},
 // Properties within functions containing multiple call signatures are not made partial due to TS limitations, refer https://github.com/microsoft/TypeScript/issues/29732
 type FunctionWithProperties4 = {(a1: number): string; (a1: string, a2: number): number; p1: string};
 declare const functionWithProperties4: PartialDeep<FunctionWithProperties4>;
+expectType<string>(functionWithProperties4(1));
+expectType<number>(functionWithProperties4('foo', 1));
 expectNotType<{p1?: string}>({} as Simplify<typeof functionWithProperties4>);

--- a/test-d/required-deep.ts
+++ b/test-d/required-deep.ts
@@ -80,4 +80,6 @@ expectType<{p1: {p2: string; p3: [{p4: number}, string]}}>({} as Simplify<typeof
 // Properties within functions containing multiple call signatures are not made required due to TS limitations, refer https://github.com/microsoft/TypeScript/issues/29732
 type FunctionWithProperties4 = {(a1: number): string; (a1: string, a2: number): number; p1?: string};
 declare const functionWithProperties4: RequiredDeep<FunctionWithProperties4>;
+expectType<string>(functionWithProperties4(1));
+expectType<number>(functionWithProperties4('foo', 1));
 expectNotType<{p1: string}>({} as Simplify<typeof functionWithProperties4>);

--- a/test-d/required-deep.ts
+++ b/test-d/required-deep.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectNotType, expectType} from 'tsd';
 import type {RequiredDeep, Simplify} from '../index.d.ts';
 import type {BuiltIns} from '../source/internal/type.d.ts';
 
@@ -80,5 +80,4 @@ expectType<{p1: {p2: string; p3: [{p4: number}, string]}}>({} as Simplify<typeof
 // Properties within functions containing multiple call signatures are not made required due to TS limitations, refer https://github.com/microsoft/TypeScript/issues/29732
 type FunctionWithProperties4 = {(a1: number): string; (a1: string, a2: number): number; p1?: string};
 declare const functionWithProperties4: RequiredDeep<FunctionWithProperties4>;
-// @ts-expect-error
-expectType<{p1: string}>({} as Simplify<typeof functionWithProperties4>);
+expectNotType<{p1: string}>({} as Simplify<typeof functionWithProperties4>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR adds handling of multiple call signatures in `PartialDeep`, similar to `RequiredDeep`. 

Currently, if `PartialDeep` is instantiated with a function containing multiple call signatures and a property, the call signatures are _not_ preserved in the resultant type. This PR fixes this by simply bypassing such inputs, similar to how it's done in `RequiredDeep`.

Current behaviour:
```ts
type FunctionWithProperties = {(a1: number): string; (a1: string, a2: number): number; p1: string};
declare const functionWithProperties: PartialDeep<FunctionWithProperties>;

const r1 = functionWithProperties(1); // Errors
const r2 = functionWithProperties('a', 1);
//    ^? const r2: number

type JustProperties = Simplify<typeof functionWithProperties>; // `p1` is correctly optional
//   ^? type JustProperties = { p1?: string; }
```

Fixed behaviour:
```ts
type FunctionWithProperties = {(a1: number): string; (a1: string, a2: number): number; p1: string};
declare const functionWithProperties: PartialDeep<FunctionWithProperties>;

const r1 = functionWithProperties(1);
//    ^? const r1: string
const r2 = functionWithProperties('a', 1);
//    ^? const r2: number

type JustProperties = Simplify<typeof functionWithProperties>; // `p1` is NO longer optional, this is a limitation
//   ^? type JustProperties = { p1: string; }
```