### PR TITLE
`UnionToIntersection`: Fix incorrect test case

### DIFF
--- a/source/union-to-intersection.d.ts
+++ b/source/union-to-intersection.d.ts
@@ -56,7 +56,7 @@ export type UnionToIntersection<Union> = (
 		// Infer the `Intersection` type since TypeScript represents the positional
 		// arguments of unions of functions as an intersection of the union.
 ) extends ((mergedIntersection: infer Intersection) => void)
-	// The `& Union` is to allow indexing by the resulting type
+	// The `& Union` is to ensure result of `UnionToIntersection<A | B>` is always assignable to `A | B`
 	? Intersection & Union
 	: never;
 

--- a/test-d/union-to-intersection.ts
+++ b/test-d/union-to-intersection.ts
@@ -8,7 +8,5 @@ expectAssignable<{a: string; b: number}>(intersection1);
 declare const intersection2: UnionToIntersection<{a: string} | {b: number} | {a: () => void}>;
 expectAssignable<{a: string | (() => void); b: number}>(intersection2);
 
-// It's possible to index by the resulting type.
-type ObjectsUnion = {a: string; z: string} | {b: string; z: string} | {c: string; z: string};
-declare const value: ObjectsUnion[UnionToIntersection<keyof ObjectsUnion>];
-expectType<string>(value);
+type Assignability<T, U, _K extends T | U> = never;
+type TestAssignability<T, U> = Assignability<T, U, UnionToIntersection<T | U>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

The `& Union` bit in `UnionToIntersection` was added in #682, but the test case added along with it was incorrect.
https://github.com/sindresorhus/type-fest/blob/3bd9de60d5384543c82c3de2a1461bdecc0da876/source/union-to-intersection.d.ts#L60

The test actually does nothing, as already pointed out in https://github.com/sindresorhus/type-fest/pull/682#issuecomment-1893613302.
https://github.com/sindresorhus/type-fest/blob/3bd9de60d5384543c82c3de2a1461bdecc0da876/test-d/union-to-intersection.ts#L11-L14

This PR adds a generic assignability test that correctly verifies the `& Union` change as it only passes when the change is present. The updated test case basically verifies that `UnionToIntersection<T | U | ...>` is assignable to `T | U | ...`. 

Thanks to @Beraliv for pointing this out in https://github.com/ts-essentials/ts-essentials/issues/451#issuecomment-3370576872.
