### PR TITLE
Ensure `import-path` lint rule works on re-exports

### DIFF
--- a/lint-rules/import-path.js
+++ b/lint-rules/import-path.js
@@ -16,7 +16,12 @@ export const importPathRule = /** @type {const} */ ({
 	defaultOptions: [],
 	create(context) {
 		return {
-			ImportDeclaration(node) {
+			'ImportDeclaration, ExportNamedDeclaration, ExportAllDeclaration'(node) {
+				// Exit if not a re-export
+				if (!node.source) {
+					return;
+				}
+
 				const importPath = node.source.value;
 
 				// Skip if not relative path

--- a/xo.config.js
+++ b/xo.config.js
@@ -62,7 +62,7 @@ const xoConfig = [
 		},
 	},
 	{
-		files: ['source/**/*.d.ts', 'test-d/**/*.ts'],
+		files: ['source/**/*.d.ts', 'test-d/**/*.ts', 'index.d.ts'],
 		rules: {
 			'type-fest/import-path': 'error',
 		},


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR ensures `import-path` rule works on re-exports as well. This is required because even re-export sources could get autocompleted with `.js` extension.

https://github.com/user-attachments/assets/10a5c90a-dc31-45e1-b64a-dff603952575

In the video above, the re-export file extension changes from `.d.ts` to `.js` if "update imports" suggestion is applied.