### PR TITLE
feat: improve `UnionMax`, `UnionMin`, `ReverseSign`, `Negative`, `ToNumber` and add `ToBigint`, `SplitFloat` and `SeperateNegatives` internal types

### DIFF
--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -161,10 +161,10 @@ type T3 = ReverseSign<-1n>;
 type T4 = ReverseSign<1n>;
 //=> -1n
 
-type T5 = ReverseSign<NegativeInfinity>
+type T5 = ReverseSign<NegativeInfinity>;
 //=> Infinity
 
-type T6 = ReverseSign<PositiveInfinity>
+type T6 = ReverseSign<PositiveInfinity>;
 //=> -Infinity
 ```
 */
@@ -241,13 +241,13 @@ type T7 = ToNumber<'-Infinity'>;
 */
 export type ToNumber<T extends Numeric | string | boolean> =
 	`${T}` extends `${infer F}${infer R}`
-		? F extends '0' ? ToNumber<R> // Prevent returning `number` when preseding `T` with 0, (e.g, '00123' -> 123)
+		? F extends '0' ? ToNumber<R> // Prevent returning `number` when preceding `T` with 0, (e.g, '00123' -> 123)
 			: `${T}` extends `${infer N extends number}` ? N // For number strings (e.g, '123' -> 123)
 				: `${T}` extends `${infer B extends number}n` ? B // For bigint strings (e.g, '123n' -> 123)
 					: `${T}` extends 'Infinity' ? PositiveInfinity
 						: `${T}` extends '-Infinity' ? NegativeInfinity
 							: T extends boolean ? {true: 1; false: 0}[`${T}`] // For boolean (e.g, true -> 1)
-								: never // Not a numeric convertable type
+								: never // Not a numeric convertible type
 		: string extends T ? never : 0; // `Number('')` returns `0`
 
 /**

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -80,7 +80,7 @@ type T6 = UnionMin<number>;
 */
 export type UnionMin<N extends number> =
 	IsAnyOrNever<N> extends true ? N // Handles `any/never`
-		: number extends N ? number // If `N` is the wide `number` type, we cannot infer a literal manimum
+		: number extends N ? number // If `N` is the wide `number` type, we cannot infer a literal minimum
 			: NegativeInfinity extends N ? NegativeInfinity // If `NegativeInfinity` is present, it dominates any finite number
 				: [N] extends [PositiveInfinity] ? PositiveInfinity // If `N` is exactly `PositiveInfinity`, return it directly
 					: SeparateNegatives<N> extends [infer Pos extends number, infer Neg extends number]

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -59,22 +59,22 @@ Note: Just supports numbers from 0 to 999.
 
 @example
 ```
-type T1 = UnionMax<1 | 2 | 3>;
+type T1 = UnionMin<1 | 2 | 3>;
 //=> 1
 
-type T2 = UnionMax<-1 | -2 | -3>
+type T2 = UnionMin<-1 | -2 | -3>;
 //=> -3
 
-type T3 = UnionMax<-1 | 0 | 1>
+type T3 = UnionMin<-1 | 0 | 1>;
 //=> -1
 
-type T4 = UnionMax<NegativeInfinity | -1 | 1>;
+type T4 = UnionMin<NegativeInfinity | -1 | 1>;
 //=> NegativeInfinity
 
-type T5 = UnionMax<-1 | 1 | PositiveInfinity>;
+type T5 = UnionMin<-1 | 1 | PositiveInfinity>;
 //=> -1
 
-type T6 = UnionMax<number>;
+type T6 = UnionMin<number>;
 //=> number
 ```
 */
@@ -107,10 +107,10 @@ Note: Just supports numbers from 0 to 999.
 type T1 = UnionMax<1 | 2 | 3>;
 //=> 3
 
-type T2 = UnionMax<-1 | -2 | -3>
+type T2 = UnionMax<-1 | -2 | -3>;
 //=> -1
 
-type T3 = UnionMax<-1 | 0 | 1>
+type T3 = UnionMax<-1 | 0 | 1>;
 //=> 1
 
 type T4 = UnionMax<NegativeInfinity | -1 | 1>;
@@ -188,13 +188,13 @@ Split a union of positive and negative number into a tuple in the form of `[Nega
 
 @example
 ```
-type T1 = SeparateNegatives<-1 | 2 | 4 | -5>
+type T1 = SeparateNegatives<-1 | 2 | 4 | -5>;
 //=> [4 | 2, -1 | -5]
 
-type T2 = SeparateNegatives<PositiveInfinity | NegativeInfinity | 0 | -1>
+type T2 = SeparateNegatives<PositiveInfinity | NegativeInfinity | 0 | -1>;
 //=> [0 | PositiveInfinity, NegativeInfinity | -1]
 
-type T3 = SeparateNegatives<1 | 4>
+type T3 = SeparateNegatives<1 | 4>;
 //=> [4 | 1, never]
 ```
 */

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -1,8 +1,11 @@
-import type {IsNever} from '../is-never.d.ts';
-import type {Finite, NegativeInfinity, PositiveInfinity} from '../numeric.d.ts';
+import type {Negative, NegativeInfinity, PositiveInfinity} from '../numeric.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
-import type {StringToNumber} from './string.d.ts';
+import type {IsNever} from '../is-never.d.ts';
 import type {IsAnyOrNever} from './type.d.ts';
+
+export type Numeric = number | bigint;
+
+export type Zero = 0 | 0n;
 
 /**
 Returns the absolute value of a given value.
@@ -19,7 +22,7 @@ NumberAbsolute<NegativeInfinity>
 //=> PositiveInfinity
 ```
 */
-export type NumberAbsolute<N extends number> = `${N}` extends `-${infer StringPositiveN}` ? StringToNumber<StringPositiveN> : N;
+export type NumberAbsolute<N extends number> = `${N}` extends `-${infer StringPositiveN}` ? ToNumber<StringPositiveN> : N;
 
 /**
 Check whether the given type is a number or a number string.
@@ -71,18 +74,20 @@ type D = UnionMin<never>;
 */
 export type UnionMin<N extends number> =
 	IsAnyOrNever<N> extends true ? N
-		: number extends N ? number
-			: NegativeInfinity extends N ? NegativeInfinity
-				: [N] extends [PositiveInfinity] ? PositiveInfinity
-					: InternalUnionMin<Finite<N>>;
+		: NegativeInfinity extends N ? NegativeInfinity
+			: SeparateNegatives<N> extends [infer Pos extends number, infer Neg extends number]
+				? IsNever<Neg> extends true
+					? _UnionMin<Pos>
+					: ReverseSign<_UnionMax<ReverseSign<Neg>>>
+				: never;
 
 /**
 The actual implementation of `UnionMin`. It's private because it has some arguments that don't need to be exposed.
 */
-type InternalUnionMin<N extends number, T extends UnknownArray = []> =
+type _UnionMin<N extends number, T extends UnknownArray = []> =
 	T['length'] extends N
 		? T['length']
-		: InternalUnionMin<N, [...T, unknown]>;
+		: _UnionMin<N, [...T, unknown]>;
 
 /**
 Returns the maximum number in the given union of numbers.
@@ -106,45 +111,151 @@ type D = UnionMax<never>;
 */
 export type UnionMax<N extends number> =
 	IsAnyOrNever<N> extends true ? N
-		: number extends N ? number
-			: PositiveInfinity extends N ? PositiveInfinity
-				: [N] extends [NegativeInfinity] ? NegativeInfinity
-					: InternalUnionMax<Finite<N>>;
+		: PositiveInfinity extends N ? PositiveInfinity
+			: SeparateNegatives<N> extends [infer Pos extends number, infer Neg extends number]
+				? IsNever<Pos> extends true
+					? ReverseSign<_UnionMin<ReverseSign<Neg>>>
+					: _UnionMax<Pos>
+				: never;
 
 /**
 The actual implementation of `UnionMax`. It's private because it has some arguments that don't need to be exposed.
 */
-type InternalUnionMax<N extends number, T extends UnknownArray = []> =
+type _UnionMax<N extends number, T extends UnknownArray = []> =
 	IsNever<N> extends true
 		? T['length']
 		: T['length'] extends N
-			? InternalUnionMax<Exclude<N, T['length']>, T>
-			: InternalUnionMax<N, [...T, unknown]>;
+			? _UnionMax<Exclude<N, T['length']>, T>
+			: _UnionMax<N, [...T, unknown]>;
 
 /**
 Returns the number with reversed sign.
 
 @example
 ```
-ReverseSign<-1>;
+type T1 = ReverseSign<-1>;
 //=> 1
 
-ReverseSign<1>;
+type T2 = ReverseSign<1>;
 //=> -1
 
-ReverseSign<NegativeInfinity>
-//=> PositiveInfinity
+type T3 = ReverseSign<-1n>;
+//=> 1n
 
-ReverseSign<PositiveInfinity>
-//=> NegativeInfinity
+type T4 = ReverseSign<1n>;
+//=> -1n
+
+type T5 = ReverseSign<NegativeInfinity>
+//=> Infinity
+
+type T6 = ReverseSign<PositiveInfinity>
+//=> -Infinity
 ```
 */
-export type ReverseSign<N extends number> =
+export type ReverseSign<N extends Numeric> =
 	// Handle edge cases
-	N extends 0 ? 0 : N extends PositiveInfinity ? NegativeInfinity : N extends NegativeInfinity ? PositiveInfinity :
-	// Handle negative numbers
-	`${N}` extends `-${infer P extends number}` ? P
-		// Handle positive numbers
-		: `-${N}` extends `${infer R extends number}` ? R : never;
+	N extends Zero ? N
+		: N extends PositiveInfinity ? NegativeInfinity
+			: N extends NegativeInfinity ? PositiveInfinity
+				: (
+					`${N}` extends `-${infer P}` ? P // Handle negative numbers
+						: `-${N}` extends `${infer R}` ? R // Handle positive numbers
+							: never
+				) extends infer Result extends string
+					? N extends bigint
+						? ToBigint<Result>
+						: ToNumber<Result>
+					: never;
+
+/**
+Split a union of positive and negative number into a tuple in the form of `[Negatives, Positives]`
+
+@example
+```
+type T1 = SeparateNegatives<-1 | 2 | 4 | -5>
+//=> [4 | 2, -1 | -5]
+
+type T2 = SeparateNegatives<PositiveInfinity | NegativeInfinity | 0 | -1>
+//=> [0 | PositiveInfinity, NegativeInfinity | -1]
+```
+*/
+export type SeparateNegatives<N extends Numeric> =
+	IsAnyOrNever<N> extends true ? N
+		: Negative<N> extends infer Negatives
+			? [Exclude<N, Negatives>, Negatives]
+			: never;
+
+export type SplitFloat<N extends Numeric> =
+	`${N}` extends `${infer Int extends number}.${infer Dec}`
+		? [Int, Dec]
+		: [N, '0'];
+
+/**
+Converts a numeric type to a number.
+
+@example
+```
+type T1 = ToNumber<'1234'>;
+//=> 1234
+
+type T2 = ToNumber<-1234n>;
+//=> -1234
+
+type T3 = ToNumber<'1234.56'>;
+//=> 1234.56
+
+type T4 = ToNumber<true>;
+//=> 1
+
+type T5 = ToNumber<false>;
+//=> 0
+
+type T6 = ToNumber<'Infinity'>;
+//=> Infinity
+
+type T7 = ToNumber<'-Infinity'>;
+//=> -Infinity
+```
+
+@category String
+@category Numeric
+@category Template literal
+*/
+
+export type ToNumber<T extends Numeric | string | boolean> =
+	`${T}` extends `${infer F}${infer R}`
+		? F extends '0' ? ToNumber<R> // Prevent returning number when preseding `T` with 0, (e.g, '00123')
+			: `${T}` extends `${infer N extends number}` ? N
+				: `${T}` extends `${infer B extends bigint}n` ? ToNumber<B>
+					: `${T}` extends 'Infinity' ? PositiveInfinity
+						: `${T}` extends '-Infinity' ? NegativeInfinity
+							: T extends boolean ? {true: 1; false: 0}[`${T}`]
+								: never
+		: never;
+
+/**
+Converts a numeric type to a bigint.
+
+@example
+```
+type T1 = ToBigint<'1234'>;
+//=> 1234n
+
+type T2 = ToBigint<-1234n>;
+//=> -1234n
+
+type T3 = ToBigint<'1234.56'>;
+//=> 1234n
+
+type T4 = ToBigint<true>;
+//=> 1n
+
+type T5 = ToBigint<false>;
+//=> 0n
+```
+*/
+// TODO: push `Round` type branch for review, and replace here.
+export type ToBigint<N extends Numeric | string | boolean> =
+	`${SplitFloat<ToNumber<N>>[0]}` extends `${infer B extends bigint}` ? B : never;
 
 export {};

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -184,7 +184,7 @@ export type ReverseSign<N extends Numeric> =
 					: never;
 
 /**
-Split a union of positive and negative number into a tuple in the form of `[Negatives, Positives]`
+Split a union of positive and negative number into a tuple in the form of `[Positives, Negatives]`
 
 @example
 ```

--- a/source/internal/string.d.ts
+++ b/source/internal/string.d.ts
@@ -1,5 +1,4 @@
 import type {TupleOf} from '../tuple-of.d.ts';
-import type {NegativeInfinity, PositiveInfinity} from '../numeric.d.ts';
 import type {Trim} from '../trim.d.ts';
 import type {Whitespace} from './characters.d.ts';
 
@@ -9,42 +8,6 @@ Return a string representation of the given string or number.
 Note: This type is not the return type of the `.toString()` function.
 */
 export type ToString<T> = T extends string | number ? `${T}` : never;
-
-/**
-Converts a numeric string to a number.
-
-@example
-```
-type PositiveInt = StringToNumber<'1234'>;
-//=> 1234
-
-type NegativeInt = StringToNumber<'-1234'>;
-//=> -1234
-
-type PositiveFloat = StringToNumber<'1234.56'>;
-//=> 1234.56
-
-type NegativeFloat = StringToNumber<'-1234.56'>;
-//=> -1234.56
-
-type PositiveInfinity = StringToNumber<'Infinity'>;
-//=> Infinity
-
-type NegativeInfinity = StringToNumber<'-Infinity'>;
-//=> -Infinity
-```
-
-@category String
-@category Numeric
-@category Template literal
-*/
-export type StringToNumber<S extends string> = S extends `${infer N extends number}`
-	? N
-	: S extends 'Infinity'
-		? PositiveInfinity
-		: S extends '-Infinity'
-			? NegativeInfinity
-			: never;
 
 /**
 Returns a boolean for whether the given string `S` starts with the given string `SearchString`.

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,5 +1,5 @@
 import type {Primitive} from './primitive.d.ts';
-import type {_Numeric} from './numeric.d.ts';
+import type {Numeric} from './internal/numeric.d.ts';
 import type {CollapseLiterals, IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
@@ -173,7 +173,7 @@ endsWith('abc123', end);
 @category Type Guard
 @category Utilities
 */
-export type IsNumericLiteral<T> = LiteralChecks<T, _Numeric>;
+export type IsNumericLiteral<T> = LiteralChecks<T, Numeric>;
 
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -1,9 +1,6 @@
-import type {IsFloat} from './is-float.d.ts';
+import type {Numeric, Zero} from './internal/numeric.d.ts';
 import type {IsInteger} from './is-integer.d.ts';
-
-export type _Numeric = number | bigint;
-
-type Zero = 0 | 0n;
+import type {IsFloat} from './is-float.d.ts';
 
 /**
 Matches the hidden `Infinity` type.
@@ -146,7 +143,11 @@ Use-case: Validating and documenting parameters.
 
 @category Numeric
 */
-export type Negative<T extends _Numeric> = T extends Zero ? never : `${T}` extends `-${string}` ? T : never;
+export type Negative<N extends Numeric> =
+	N extends Zero ? never
+		: N extends NegativeInfinity ? N
+			: `${N}` extends `-${number}` ? N
+				: never;
 
 /**
 A negative (`-∞ < x < 0`) `number` that is an integer.
@@ -180,7 +181,7 @@ declare function setLength<T extends number>(length: NonNegative<T>): void;
 
 @category Numeric
 */
-export type NonNegative<T extends _Numeric> = T extends Zero ? T : Negative<T> extends never ? T : never;
+export type NonNegative<T extends Numeric> = T extends Zero ? T : Negative<T> extends never ? T : never;
 
 /**
 A non-negative (`0 <= x < ∞`) `number` that is an integer.
@@ -219,6 +220,6 @@ type ShouldBeTrue = IsNegative<-1>;
 
 @category Numeric
 */
-export type IsNegative<T extends _Numeric> = T extends Negative<T> ? true : false;
+export type IsNegative<T extends Numeric> = T extends Negative<T> ? true : false;
 
 export {};

--- a/source/set-non-nullable-deep.d.ts
+++ b/source/set-non-nullable-deep.d.ts
@@ -1,4 +1,4 @@
-import type {NonRecursiveType, StringToNumber} from './internal/index.d.ts';
+import type {NonRecursiveType, ToNumber} from './internal/index.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {SetNonNullable} from './set-non-nullable.d.ts';
 import type {Simplify} from './simplify.d.ts';
@@ -80,6 +80,6 @@ type SetNonNullableDeepSinglePath<BaseType, KeyPath> =
 					? SetNonNullableDeepSinglePath<BaseType[Key], RestPath>
 					: BaseType[Key];
 			}
-			: Simplify<SetNonNullable<BaseType, (KeyPath | StringToNumber<KeyPath & string>) & keyof BaseType>>;
+			: Simplify<SetNonNullable<BaseType, (KeyPath | ToNumber<KeyPath & string>) & keyof BaseType>>;
 
 export {};

--- a/source/set-required-deep.d.ts
+++ b/source/set-required-deep.d.ts
@@ -1,5 +1,5 @@
 import type {IsAny} from './is-any.d.ts';
-import type {NonRecursiveType, StringToNumber} from './internal/index.d.ts';
+import type {NonRecursiveType, ToNumber} from './internal/index.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {SetRequired} from './set-required.d.ts';
 import type {SimplifyDeep} from './simplify-deep.d.ts';
@@ -65,6 +65,6 @@ type SetRequiredDeepSinglePath<BaseType, KeyPath> = BaseType extends NonRecursiv
 				? SetRequiredDeepSinglePath<BaseType[Key], RestPath>
 				: BaseType[Key];
 		}
-		: SetRequired<BaseType, (KeyPath | StringToNumber<KeyPath & string>) & keyof BaseType>;
+		: SetRequired<BaseType, (KeyPath | ToNumber<KeyPath & string>) & keyof BaseType>;
 
 export {};

--- a/test-d/internal/separate-negatives.ts
+++ b/test-d/internal/separate-negatives.ts
@@ -1,0 +1,38 @@
+import {expectType} from 'tsd';
+import type {SeparateNegatives} from '../../source/internal/numeric.d.ts';
+import type {NegativeInfinity, PositiveInfinity} from '../../source/numeric.d.ts';
+
+//  Basic single number cases
+expectType<SeparateNegatives<1>>({} as [1, never]);
+expectType<SeparateNegatives<-1>>({} as [never, -1]);
+expectType<SeparateNegatives<0>>({} as [0, never]);
+expectType<SeparateNegatives<number>>({} as [number, never]);
+
+//  Simple unions
+expectType<SeparateNegatives<1 | -1>>({} as [1, -1]);
+expectType<SeparateNegatives<1 | 2 | -3>>({} as [1 | 2, -3]);
+expectType<SeparateNegatives<0 | -1 | 2>>({} as [0 | 2, -1]);
+expectType<SeparateNegatives<-1 | -2 | -3>>({} as [never, -1 | -2 | -3]);
+expectType<SeparateNegatives<-1 | -2 | -3 | 4>>({} as [4, -1 | -2 | -3]);
+expectType<SeparateNegatives<(1 | 2) | (-3 | -4)>>({} as [1 | 2, -3 | -4]);
+
+//  Mixed with infinity types
+expectType<SeparateNegatives<PositiveInfinity>>({} as [PositiveInfinity, never]);
+expectType<SeparateNegatives<NegativeInfinity>>({} as [never, NegativeInfinity]);
+expectType<SeparateNegatives<PositiveInfinity | NegativeInfinity>>({} as [
+	PositiveInfinity,
+	NegativeInfinity,
+]);
+expectType<SeparateNegatives<0 | PositiveInfinity | NegativeInfinity | 5 | -3>>({} as [
+	0 | PositiveInfinity | 5,
+	NegativeInfinity | -3,
+]);
+expectType<SeparateNegatives<-1 | NegativeInfinity | 0 | 2 | PositiveInfinity>>({} as [
+	0 | 2 | PositiveInfinity,
+	-1 | NegativeInfinity,
+]);
+
+//  Edge cases and literal union
+expectType<SeparateNegatives<never>>({} as never);
+expectType<SeparateNegatives<any>>({} as any);
+expectType<SeparateNegatives<1 | 2 | -3 | (number & {})>>({} as [1 | 2 | (number & {}), -3]);

--- a/test-d/internal/union-max.ts
+++ b/test-d/internal/union-max.ts
@@ -2,23 +2,35 @@ import {expectType} from 'tsd';
 import type {UnionMax} from '../../source/internal/numeric.d.ts';
 import type {NegativeInfinity, PositiveInfinity} from '../../index.d.ts';
 
+//  Basic positive numbers
 expectType<UnionMax<1 | 3 | 2>>(3);
 expectType<UnionMax<10 | 5 | 2>>(10);
 expectType<UnionMax<0 | 5 | 2 | 1>>(5);
 expectType<UnionMax<1 | 2 | 5 | 3 | 7 | 9 | 0>>(9);
 
-// TODO: push `negative-union-max-min` branch
-// Negatives are not supported yet (infinite).
-// expectType<UnionMax<-1 | -3 | -2>>(-1);
-// expectType<UnionMax<0 | -5 | -2>>(0);
+//  Negative numbers
+expectType<UnionMax<0 | -5 | -2>>(0);
+expectType<UnionMax<-1 | -3 | -2>>(-1);
+expectType<UnionMax<-10 | -5 | -7>>(-5);
 
-// Edge cases
+//  Mixed positive and negative
+expectType<UnionMax<-10 | 0>>(0);
+expectType<UnionMax<-1 | 2 | -5>>(2);
+expectType<UnionMax<-3 | -2 | 1 | 5>>(5);
+expectType<UnionMax<-1 | -2 | 1 | 2>>(2);
+
+//  Infinity cases
+expectType<UnionMax<PositiveInfinity>>({} as PositiveInfinity);
+expectType<UnionMax<NegativeInfinity>>({} as NegativeInfinity);
+expectType<UnionMax<1 | PositiveInfinity>>({} as PositiveInfinity);
+expectType<UnionMax<1 | NegativeInfinity>>(1);
+expectType<UnionMax<NegativeInfinity | PositiveInfinity>>({} as PositiveInfinity);
+expectType<UnionMax<-100 | 100 | PositiveInfinity>>({} as PositiveInfinity);
+expectType<UnionMax<-100 | 100 | NegativeInfinity>>(100);
+
+//  Edge cases
 expectType<UnionMax<any>>({} as any);
 expectType<UnionMax<never>>({} as never);
 expectType<UnionMax<number>>({} as number);
 expectType<UnionMax<(number & {})>>({} as number);
 expectType<UnionMax<(number & {}) | 1 | 5>>({} as number);
-expectType<UnionMax<PositiveInfinity>>({} as PositiveInfinity);
-expectType<UnionMax<NegativeInfinity>>({} as NegativeInfinity);
-expectType<UnionMax<1 | PositiveInfinity>>({} as PositiveInfinity);
-expectType<UnionMax<1 | NegativeInfinity>>({} as 1);

--- a/test-d/internal/union-min.ts
+++ b/test-d/internal/union-min.ts
@@ -2,23 +2,35 @@ import {expectType} from 'tsd';
 import type {UnionMin} from '../../source/internal/numeric.d.ts';
 import type {NegativeInfinity, PositiveInfinity} from '../../index.d.ts';
 
+//  Basic positive numbers
 expectType<UnionMin<1 | 3 | 2>>(1);
 expectType<UnionMin<10 | 5 | 2>>(2);
 expectType<UnionMin<0 | 5 | 2 | 1>>(0);
 expectType<UnionMin<1 | 2 | 5 | 3 | 7 | 9 | 0>>(0);
 
-// TODO: push `negative-union-max-min` branch
-// Negatives are not supported yet (skipped)
-// expectType<UnionMin<-1 | -3 | -2>>(-3);
-// expectType<UnionMin<0 | -5 | -2>>(-5);
+//  Negative numbers
+expectType<UnionMin<0 | -5 | -2>>(-5);
+expectType<UnionMin<-1 | -3 | -2>>(-3);
+expectType<UnionMin<-10 | -5 | -7>>(-10);
 
-// Edge cases
+//  Mixed positive and negative
+expectType<UnionMin<-10 | 0>>(-10);
+expectType<UnionMin<-1 | 2 | -5>>(-5);
+expectType<UnionMin<-3 | -2 | 1 | 5>>(-3);
+expectType<UnionMin<-1 | -2 | 1 | 2>>(-2);
+
+//  Infinity cases
+expectType<UnionMin<PositiveInfinity>>({} as PositiveInfinity);
+expectType<UnionMin<NegativeInfinity>>({} as NegativeInfinity);
+expectType<UnionMin<1 | PositiveInfinity>>(1);
+expectType<UnionMin<1 | NegativeInfinity>>({} as NegativeInfinity);
+expectType<UnionMin<NegativeInfinity | PositiveInfinity>>({} as NegativeInfinity);
+expectType<UnionMin<-100 | 100 | PositiveInfinity>>(-100);
+expectType<UnionMin<-100 | 100 | NegativeInfinity>>({} as NegativeInfinity);
+
+//  Edge cases
 expectType<UnionMin<any>>({} as any);
 expectType<UnionMin<never>>({} as never);
 expectType<UnionMin<number>>({} as number);
 expectType<UnionMin<(number & {})>>({} as number);
 expectType<UnionMin<(number & {}) | 1 | 5>>({} as number);
-expectType<UnionMin<PositiveInfinity>>({} as PositiveInfinity);
-expectType<UnionMin<NegativeInfinity>>({} as NegativeInfinity);
-expectType<UnionMin<1 | PositiveInfinity>>({} as 1);
-expectType<UnionMin<1 | NegativeInfinity>>({} as NegativeInfinity);


### PR DESCRIPTION
Changes:

- add negative numbers support for `UnionMax` and `UnionMin`.
- add `SeperateNegatives` internal type to split a number union to `[positives, negatives]`.
- add `bigint` support for `ReverseSign`.
- fix `Negative` type returning `never` for `NegativeInfinity`.
- rename and improve `StringToNumber -> ToNumber`  to include `bigint` and `boolean` similare to `Number(T)`.
- add `ToBigint` internal type to transforme supported types to `bigint`.
- add `SplitFloat` internal type to use as a simple `Round` type at the moment.