### PR TITLE
Add 'overrides' property to package.json types

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -212,7 +212,7 @@ export namespace PackageJson {
 	Recursive map describing selective dependency version overrides supported by npm.
 	*/
 	type DependencyOverrides = {
-		[packageName: string]: string | DependencyOverrides;
+		[packageName: string]: string | undefined | DependencyOverrides;
 	};
 
 	/**

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -40,6 +40,8 @@ expectType<PackageJson.WorkspaceConfig | string[] | undefined>(packageJson.works
 expectAssignable<PackageJson['overrides']>({foo: '1.0.0'});
 expectAssignable<PackageJson['overrides']>({foo: {'.': '1.0.0', bar: '1.0.0'}});
 expectAssignable<PackageJson['overrides']>({baz: {bar: {foo: '1.0.0'}}});
+expectAssignable<PackageJson['overrides']>({foo: undefined});
+expectAssignable<PackageJson['overrides']>({foo: {bar: undefined}});
 expectAssignable<PackageJson.DevEngineDependency>({
 	name: 'unicorn',
 	version: '>= 1.0.0',


### PR DESCRIPTION
Add 'overrides' property to package.json type definition.

Per https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides