### PR TITLE
chore: deduplicate test fixture identifiers

### DIFF
--- a/test-d/override-properties.ts
+++ b/test-d/override-properties.ts
@@ -11,10 +11,10 @@ const fixture: OverrideProperties<Foo, {b: number}> = {a: 1, b: 2};
 expectType<{a: number; b: number}>(fixture);
 
 // @ts-expect-error
-type Bar = OverrideProperties<Foo, {c: number}>;
+type Bar1 = OverrideProperties<Foo, {c: number}>;
 
 // @ts-expect-error
-type Bar = OverrideProperties<Foo, {b: number; c: number}>;
+type Bar2 = OverrideProperties<Foo, {b: number; c: number}>;
 
 // Test for https://github.com/sindresorhus/type-fest/issues/858
 { // eslint-disable-line no-lone-blocks


### PR DESCRIPTION
This changes deduplicates test fixture identifiers.

Currently both fixtures are named `Bar`, hence `// @ts-expect-error` is suppressing two errors: "Duplicate identifier 'Bar'. ts(2300)" and the one which is expected.

This means that the test will keep passing even if the expected errors will not be there anymore. This is how `// @ts-expect-error` works. To try that out, add the following (the usage of `OverrideProperties` has no error, but `// @ts-expect-error` is still satisfied):

```ts
// @ts-expect-error
type Bar = OverrideProperties<{ a: string }, { a: number }>;
```

The problem was introduced while migrating away from `tsd`s `expectError()`, see here: https://github.com/sindresorhus/type-fest/blame/fa1c3f3cf49c4d5aae9da47c04320d1934cb2f9b/test-d/override-properties.ts

---

To avoid similar issues in the future, a solution could be to use a tool that checks messages suppressed by `// @ts-expect-error`. But that is another discussion.