### PR TITLE
Ignore temporary `.d.ts` files from `fixtures` in `xo.config.js`

### DIFF
--- a/xo.config.js
+++ b/xo.config.js
@@ -43,6 +43,9 @@ const xoConfig = [
 		},
 	},
 	{
+		ignores: ['lint-processors/fixtures/**/*.d.ts'],
+	},
+	{
 		files: 'source/**/*.d.ts',
 		rules: {
 			'no-restricted-imports': [


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Because the tests run in parallel, `test:xo` run might pick up `.d.ts` files from `fixtures` and try to lint them, which can cause failure because those files are temporary. And those files should anyways not be linted.

<img width="1678" height="303" alt="Screenshot 2026-01-07 at 7 43 56 PM" src="https://github.com/user-attachments/assets/6fad72de-80fa-4738-853f-07c9d9faaa12" />
