### PR TITLE
`MergeDeep` : fix producing `[never]` when merging empty tuples.

### DIFF
--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -79,11 +79,16 @@ Pick the rest type.
 
 @example
 ```
-type Rest1 = PickRestType<[]>; // => []
-type Rest2 = PickRestType<[string]>; // => []
-type Rest3 = PickRestType<[...number[]]>; // => number[]
-type Rest4 = PickRestType<[string, ...number[]]>; // => number[]
-type Rest5 = PickRestType<string[]>; // => string[]
+type Rest1 = PickRestType<[]>;
+//=> []
+type Rest2 = PickRestType<[string]>;
+//=> []
+type Rest3 = PickRestType<[...number[]]>;
+//=> number[]
+type Rest4 = PickRestType<[string, ...number[]]>;
+//=> number[]
+type Rest5 = PickRestType<string[]>;
+//=> string[]
 ```
 */
 type PickRestType<Type extends UnknownArrayOrTuple> = number extends Type['length']
@@ -104,12 +109,18 @@ Omit the rest type.
 
 @example
 ```
-type Tuple1 = OmitRestType<[]>; // => []
-type Tuple2 = OmitRestType<[string]>; // => [string]
-type Tuple3 = OmitRestType<[...number[]]>; // => []
-type Tuple4 = OmitRestType<[string, ...number[]]>; // => [string]
-type Tuple5 = OmitRestType<[string, boolean[], ...number[]]>; // => [string, boolean[]]
-type Tuple6 = OmitRestType<string[]>; // => []
+type Tuple1 = OmitRestType<[]>;
+//=> []
+type Tuple2 = OmitRestType<[string]>;
+//=> [string]
+type Tuple3 = OmitRestType<[...number[]]>;
+//=> []
+type Tuple4 = OmitRestType<[string, ...number[]]>;
+//=> [string]
+type Tuple5 = OmitRestType<[string, boolean[], ...number[]]>;
+//=> [string, boolean[]]
+type Tuple6 = OmitRestType<string[]>;
+//=> []
 ```
 */
 type OmitRestType<Type extends UnknownArrayOrTuple, Result extends UnknownArrayOrTuple = []> = number extends Type['length']
@@ -415,7 +426,7 @@ type Bar = {
 };
 
 type FooBar1 = MergeDeep<Foo, Bar>;
-// {
+// => {
 // 	life: number;
 // 	name: string;
 // 	items: number[];
@@ -423,7 +434,7 @@ type FooBar1 = MergeDeep<Foo, Bar>;
 // }
 
 type FooBar2 = MergeDeep<Foo, Bar, {arrayMergeMode: 'spread'}>;
-// {
+// => {
 // 	life: number;
 // 	name: string;
 // 	items: (string | number)[];
@@ -436,16 +447,20 @@ type FooBar2 = MergeDeep<Foo, Bar, {arrayMergeMode: 'spread'}>;
 import type {MergeDeep} from 'type-fest';
 
 // Merge two arrays
-type ArrayMerge = MergeDeep<string[], number[]>; // => (string | number)[]
+type ArrayMerge = MergeDeep<string[], number[]>;
+//=> (string | number)[]
 
 // Merge two tuples
-type TupleMerge = MergeDeep<[1, 2, 3], ['a', 'b']>; // => (1 | 2 | 3 | 'a' | 'b')[]
+type TupleMerge = MergeDeep<[1, 2, 3], ['a', 'b']>;
+//=> (1 | 2 | 3 | 'a' | 'b')[]
 
 // Merge an array into a tuple
-type TupleArrayMerge = MergeDeep<[1, 2, 3], string[]>; // => (string | 1 | 2 | 3)[]
+type TupleArrayMerge = MergeDeep<[1, 2, 3], string[]>;
+//=> (string | 1 | 2 | 3)[]
 
 // Merge a tuple into an array
-type ArrayTupleMerge = MergeDeep<number[], ['a', 'b']>; // => (number | 'b' | 'a')[]
+type ArrayTupleMerge = MergeDeep<number[], ['a', 'b']>;
+//=> (number | 'b' | 'a')[]
 ```
 
 @example

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -71,7 +71,7 @@ type MergeDeepRecord<
 > = DoMergeDeepRecord<OmitIndexSignature<Destination>, OmitIndexSignature<Source>, Options>
 	& Merge<PickIndexSignature<Destination>, PickIndexSignature<Source>>;
 
-// helper to avoid computing ArrayTail twice.
+// Helper to avoid computing ArrayTail twice.
 type PickRestTypeHelper<Tail extends UnknownArrayOrTuple, Type> = Tail extends [] ? Type : PickRestType<Tail>;
 
 /**

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -238,9 +238,13 @@ type DoMergeArrayOrTuple<
 	Destination extends UnknownArrayOrTuple,
 	Source extends UnknownArrayOrTuple,
 	Options extends MergeDeepInternalOptions,
-> = ShouldSpread<Options> extends true
-	? Array<Exclude<Destination, undefined>[number] | Exclude<Source, undefined>[number]>
-	: Source; // 'replace'
+> = [Destination, Source] extends [readonly [], readonly []]
+	? Source extends []
+		? []
+		: readonly []
+	: ShouldSpread<Options> extends true
+		? Array<Exclude<Destination, undefined>[number] | Exclude<Source, undefined>[number]>
+		: Source; // 'replace'
 
 /**
 Merge two arrays recursively.

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -71,7 +71,7 @@ type MergeDeepRecord<
 > = DoMergeDeepRecord<OmitIndexSignature<Destination>, OmitIndexSignature<Source>, Options>
 	& Merge<PickIndexSignature<Destination>, PickIndexSignature<Source>>;
 
-// Helper to avoid computing ArrayTail twice.
+// helper to avoid computing ArrayTail twice.
 type PickRestTypeHelper<Tail extends UnknownArrayOrTuple, Type> = Tail extends [] ? Type : PickRestType<Tail>;
 
 /**
@@ -270,18 +270,24 @@ Merge two array/tuple recursively by selecting one of the four strategies accord
 - tuple/array
 - array/tuple
 - array/array
+
+Each cases are considered that the one or both are empty.
 */
 type MergeDeepArrayOrTupleRecursive<
 	Destination extends UnknownArrayOrTuple,
 	Source extends UnknownArrayOrTuple,
 	Options extends MergeDeepInternalOptions,
-> = IsBothExtends<NonEmptyTuple, Destination, Source> extends true
-	? MergeDeepTupleAndTupleRecursive<Destination, Source, Options>
-	: Destination extends NonEmptyTuple
-		? MergeDeepTupleAndArrayRecursive<Destination, Source, Options>
-		: Source extends NonEmptyTuple
-			? MergeDeepArrayAndTupleRecursive<Destination, Source, Options>
-			: MergeDeepArrayRecursive<Destination, Source, Options>;
+> = Destination extends []
+	? Source
+	: Source extends []
+		? Destination
+		: IsBothExtends<NonEmptyTuple, Destination, Source> extends true
+			? MergeDeepTupleAndTupleRecursive<Destination, Source, Options>
+			: Destination extends NonEmptyTuple
+				? MergeDeepTupleAndArrayRecursive<Destination, Source, Options>
+				: Source extends NonEmptyTuple
+					? MergeDeepArrayAndTupleRecursive<Destination, Source, Options>
+					: MergeDeepArrayRecursive<Destination, Source, Options>;
 
 /**
 Merge two array/tuple according to {@link MergeDeepOptions.recurseIntoArrays recurseIntoArrays} option.

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {MergeDeep, MergeDeepOptions} from '../index.d.ts';
+import type {MergeDeep, MergeDeepOptions, IsEqual} from '../index.d.ts';
 
 // Test helper.
 declare function mergeDeep<
@@ -325,3 +325,51 @@ type OptionalWithUndefined = {a: string | undefined; b?: number; c?: boolean | u
 
 expectType<OptionalWithUndefined>({} as MergeDeep<NotOptional, OptionalWithUndefined>);
 expectType<NotOptional>({} as MergeDeep<OptionalWithUndefined, NotOptional>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+type EmptyFoo = {foo: []};
+type NotEmptyTupleFoo = {foo: [0, 1]};
+type NotEmptyArrayFoo = {foo: number[]};
+expectType<true>({} as IsEqual<NotEmptyTupleFoo, MergeDeep<EmptyFoo, NotEmptyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyTupleFoo, MergeDeep<NotEmptyTupleFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyArrayFoo, MergeDeep<EmptyFoo, NotEmptyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyArrayFoo, MergeDeep<NotEmptyArrayFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+type EmptyReadonlyFoo = {readonly foo: []};
+type NotEmptyReadonlyFoo = {readonly foo: [0, 1]};
+expectType<true>({} as IsEqual<NotEmptyReadonlyFoo, MergeDeep<EmptyReadonlyFoo, NotEmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyReadonlyFoo, MergeDeep<NotEmptyReadonlyFoo, EmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+type EmptyOptionalFoo = {foo?: []};
+type NotEmptyOptionalTupleFoo = {foo?: [0, 1]};
+type NotEmptyOptionalArrayFoo = {foo?: number[]};
+expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<NotEmptyOptionalTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalArrayFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalArrayFoo, MergeDeep<NotEmptyOptionalArrayFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+type EmptyOptionalReadonlyFoo = {readonly foo?: []};
+type NotEmptyOptionalReadonlyTupleFoo = {readonly foo?: [0, 1]};
+type NotEmptyOptionalReadonlyArrayFoo = {readonly foo?: number[]};
+expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyArrayFoo, MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyArrayFoo, MergeDeep<NotEmptyOptionalReadonlyArrayFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<EmptyOptionalFoo, MergeDeep<EmptyOptionalReadonlyFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<EmptyOptionalReadonlyFoo, MergeDeep<EmptyOptionalFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1200
+type EmptyFooRecursive = {foo: [0, string, {bar: []}]};
+type NotEmptyTupleFooRecursive = {foo: [0, number, {bar: [0, 1]}]};
+type NotEmptyArrayFooRecursive = {foo: [0, number, {bar: number[]}]};
+expectType<true>({} as IsEqual<NotEmptyTupleFooRecursive, MergeDeep<EmptyFooRecursive, NotEmptyTupleFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<{foo: [0, string, {bar: [0, 1]}]}, MergeDeep<NotEmptyTupleFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<NotEmptyArrayFooRecursive, MergeDeep<EmptyFooRecursive, NotEmptyArrayFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<true>({} as IsEqual<{foo: [0, string, {bar: number[]}]}, MergeDeep<NotEmptyArrayFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {MergeDeep, MergeDeepOptions, IsEqual} from '../index.d.ts';
+import type {MergeDeep, MergeDeepOptions} from '../index.d.ts';
 
 // Test helper.
 declare function mergeDeep<

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -334,6 +334,10 @@ expectType<NotEmptyTupleFoo>({} as MergeDeep<EmptyFoo, NotEmptyTupleFoo, {recurs
 expectType<NotEmptyTupleFoo>({} as MergeDeep<NotEmptyTupleFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 expectType<NotEmptyArrayFoo>({} as MergeDeep<EmptyFoo, NotEmptyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 expectType<NotEmptyArrayFoo>({} as MergeDeep<NotEmptyArrayFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyTupleFoo>({} as MergeDeep<EmptyFoo, NotEmptyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);
+expectType<NotEmptyTupleFoo>({} as MergeDeep<NotEmptyTupleFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);
+expectType<NotEmptyArrayFoo>({} as MergeDeep<EmptyFoo, NotEmptyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);
+expectType<NotEmptyArrayFoo>({} as MergeDeep<NotEmptyArrayFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
 type EmptyReadonlyFoo = {readonly foo: []};
@@ -376,3 +380,9 @@ expectType<NotEmptyTupleFooRecursive>({} as MergeDeep<EmptyFooRecursive, NotEmpt
 expectType<{foo: [0, string, {bar: [0, 1]}]}>({} as MergeDeep<NotEmptyTupleFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 expectType<NotEmptyArrayFooRecursive>({} as MergeDeep<EmptyFooRecursive, NotEmptyArrayFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 expectType<{foo: [0, string, {bar: number[]}]}>({} as MergeDeep<NotEmptyArrayFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+
+// Tuple and array recursion behavior with primitive values
+expectType<[string, string, ...string[]]>({} as MergeDeep<[1, 2], string[], {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<[string, string, ...string[]]>({} as MergeDeep<[1, 2], string[], {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);
+expectType<[1, 2, ...string[]]>({} as MergeDeep<string[], [1, 2], {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<[1, 2, ...string[]]>({} as MergeDeep<string[], [1, 2], {recurseIntoArrays: true; arrayMergeMode: 'spread'}>);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -15,10 +15,10 @@ expectType<{}>(mergeDeep({}, {} as const));
 expectType<{}>(mergeDeep({} as const, {} as const));
 
 // Test valid signatures for arrays/tuples.
-expectType<true>({} as IsEqual<[], MergeDeep<[], []>>);
-expectType<true>({} as IsEqual<[], MergeDeep<readonly [], []>>);
-expectType<true>({} as IsEqual<readonly [], MergeDeep<[], readonly []>>);
-expectType<true>({} as IsEqual<readonly [], MergeDeep<readonly [], readonly []>>);
+expectType<[]>(mergeDeep([], []));
+expectType<[]>(mergeDeep([] as const, []));
+expectType<readonly []>(mergeDeep([], [] as const));
+expectType<readonly []>(mergeDeep([] as const, [] as const));
 
 // Test invalid signatures.
 expectType<never>(mergeDeep({}, []));
@@ -330,46 +330,49 @@ expectType<NotOptional>({} as MergeDeep<OptionalWithUndefined, NotOptional>);
 type EmptyFoo = {foo: []};
 type NotEmptyTupleFoo = {foo: [0, 1]};
 type NotEmptyArrayFoo = {foo: number[]};
-expectType<true>({} as IsEqual<NotEmptyTupleFoo, MergeDeep<EmptyFoo, NotEmptyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyTupleFoo, MergeDeep<NotEmptyTupleFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyArrayFoo, MergeDeep<EmptyFoo, NotEmptyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyArrayFoo, MergeDeep<NotEmptyArrayFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<NotEmptyTupleFoo>({} as MergeDeep<EmptyFoo, NotEmptyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyTupleFoo>({} as MergeDeep<NotEmptyTupleFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyArrayFoo>({} as MergeDeep<EmptyFoo, NotEmptyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyArrayFoo>({} as MergeDeep<NotEmptyArrayFoo, EmptyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
 type EmptyReadonlyFoo = {readonly foo: []};
-type NotEmptyReadonlyFoo = {readonly foo: [0, 1]};
-expectType<true>({} as IsEqual<NotEmptyReadonlyFoo, MergeDeep<EmptyReadonlyFoo, NotEmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyReadonlyFoo, MergeDeep<NotEmptyReadonlyFoo, EmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+type NotEmptyReadonlyTupleFoo = {readonly foo: [0, 1]};
+type NotEmptyReadonlyArrayFoo = {readonly foo: number[]};
+expectType<NotEmptyReadonlyTupleFoo>({} as MergeDeep<EmptyReadonlyFoo, NotEmptyReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyReadonlyTupleFoo>({} as MergeDeep<NotEmptyReadonlyTupleFoo, EmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyReadonlyArrayFoo>({} as MergeDeep<EmptyReadonlyFoo, NotEmptyReadonlyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyReadonlyArrayFoo>({} as MergeDeep<NotEmptyReadonlyArrayFoo, EmptyReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
 type EmptyOptionalFoo = {foo?: []};
 type NotEmptyOptionalTupleFoo = {foo?: [0, 1]};
 type NotEmptyOptionalArrayFoo = {foo?: number[]};
-expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<NotEmptyOptionalTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalArrayFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalArrayFoo, MergeDeep<NotEmptyOptionalArrayFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<NotEmptyOptionalTupleFoo>({} as MergeDeep<EmptyOptionalFoo, NotEmptyOptionalTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalTupleFoo>({} as MergeDeep<NotEmptyOptionalTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalArrayFoo>({} as MergeDeep<EmptyOptionalFoo, NotEmptyOptionalArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalArrayFoo>({} as MergeDeep<NotEmptyOptionalArrayFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
 type EmptyOptionalReadonlyFoo = {readonly foo?: []};
 type NotEmptyOptionalReadonlyTupleFoo = {readonly foo?: [0, 1]};
 type NotEmptyOptionalReadonlyArrayFoo = {readonly foo?: number[]};
-expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyArrayFoo, MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyArrayFoo, MergeDeep<NotEmptyOptionalReadonlyArrayFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<NotEmptyOptionalReadonlyTupleFoo>({} as MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalReadonlyTupleFoo>({} as MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalReadonlyArrayFoo>({} as MergeDeep<EmptyOptionalReadonlyFoo, NotEmptyOptionalReadonlyArrayFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalReadonlyArrayFoo>({} as MergeDeep<NotEmptyOptionalReadonlyArrayFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
-expectType<true>({} as IsEqual<NotEmptyOptionalReadonlyTupleFoo, MergeDeep<EmptyOptionalFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyOptionalTupleFoo, MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<EmptyOptionalFoo, MergeDeep<EmptyOptionalReadonlyFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<EmptyOptionalReadonlyFoo, MergeDeep<EmptyOptionalFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<NotEmptyOptionalReadonlyTupleFoo>({} as MergeDeep<EmptyOptionalFoo, NotEmptyOptionalReadonlyTupleFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyOptionalTupleFoo>({} as MergeDeep<NotEmptyOptionalReadonlyTupleFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<EmptyOptionalFoo>({} as MergeDeep<EmptyOptionalReadonlyFoo, EmptyOptionalFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<EmptyOptionalReadonlyFoo>({} as MergeDeep<EmptyOptionalFoo, EmptyOptionalReadonlyFoo, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
 
 // Test for https://github.com/sindresorhus/type-fest/issues/1200
 type EmptyFooRecursive = {foo: [0, string, {bar: []}]};
 type NotEmptyTupleFooRecursive = {foo: [0, number, {bar: [0, 1]}]};
 type NotEmptyArrayFooRecursive = {foo: [0, number, {bar: number[]}]};
-expectType<true>({} as IsEqual<NotEmptyTupleFooRecursive, MergeDeep<EmptyFooRecursive, NotEmptyTupleFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<{foo: [0, string, {bar: [0, 1]}]}, MergeDeep<NotEmptyTupleFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<NotEmptyArrayFooRecursive, MergeDeep<EmptyFooRecursive, NotEmptyArrayFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
-expectType<true>({} as IsEqual<{foo: [0, string, {bar: number[]}]}, MergeDeep<NotEmptyArrayFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>>);
+expectType<NotEmptyTupleFooRecursive>({} as MergeDeep<EmptyFooRecursive, NotEmptyTupleFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<{foo: [0, string, {bar: [0, 1]}]}>({} as MergeDeep<NotEmptyTupleFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<NotEmptyArrayFooRecursive>({} as MergeDeep<EmptyFooRecursive, NotEmptyArrayFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);
+expectType<{foo: [0, string, {bar: number[]}]}>({} as MergeDeep<NotEmptyArrayFooRecursive, EmptyFooRecursive, {recurseIntoArrays: true; arrayMergeMode: 'replace'}>);

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -56,7 +56,7 @@ expectType<Array<string | 42>>(mergeDeep(['life'], [42] as const, {arrayMergeMod
 expectType<Array<'life' | 42>>(mergeDeep(['life'] as const, [42] as const, {arrayMergeMode: 'replace'}));
 
 // Should merge tuples with union
-expectType<Array<number | string | boolean>>(mergeDeep(['life', true], [42], {arrayMergeMode: 'spread'}));
+expectType<Array<number | string | true>>(mergeDeep(['life', true], [42], {arrayMergeMode: 'spread'}));
 expectType<Array<number | string | true>>(mergeDeep(['life'], [42, true], {arrayMergeMode: 'spread'}));
 
 // Should not deep merge classes

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -15,10 +15,10 @@ expectType<{}>(mergeDeep({}, {} as const));
 expectType<{}>(mergeDeep({} as const, {} as const));
 
 // Test valid signatures for arrays/tuples.
-expectType<never[]>(mergeDeep([], []));
-expectType<never[]>(mergeDeep([] as const, []));
-expectType<never[]>(mergeDeep([], [] as const));
-expectType<never[]>(mergeDeep([] as const, [] as const));
+expectType<true>({} as IsEqual<[], MergeDeep<[], []>>);
+expectType<true>({} as IsEqual<[], MergeDeep<readonly [], []>>);
+expectType<true>({} as IsEqual<readonly [], MergeDeep<[], readonly []>>);
+expectType<true>({} as IsEqual<readonly [], MergeDeep<readonly [], readonly []>>);
 
 // Test invalid signatures.
 expectType<never>(mergeDeep({}, []));


### PR DESCRIPTION
Close #1200

## Test case
I use `IsEqual` because this passes uncorrectly on editor (it rejects correctly with `npm test` though).

```typescript
expectType<{f: [0]}>({} as {f: [never]})
```

I think this might be related to [this tsd issue](https://github.com/tsdjs/tsd/issues/229)

## Undefined behavior

```typescript
type A = MergeDeep<[1, 2], string[], {recurseIntoArrays: true, arrayMergeMode: 'replace'}>
// [string, string, ...string[]]
type B = MergeDeep<[1, 2], string[], {recurseIntoArrays: true, arrayMergeMode: 'spread'}> 
// [string, string, ...string[]]
type C = MergeDeep<string[], [1, 2], {recurseIntoArrays: true, arrayMergeMode: 'replace'}> 
// [1, 2, ...string[]]
type D = MergeDeep<string[], [1, 2], {recurseIntoArrays: true, arrayMergeMode: 'spread'}> 
// [1, 2, ...string[]]
```

This is how it behaves in this PR, but is this according to the spec?
I couldn't find any test cases that verify this, even in the original codebase.

I think this might be somewhat related to [this test case](https://github.com/sindresorhus/type-fest/blob/3ec94d2ff3e01130f550be2c89c04152faaa67ee/test-d/merge-deep.ts#L266), though I'm not certain.

```typescript
// Should merge array into tuple with object entries
type FooNumberTuple = [Foo[], number[]];
type BarArray2D = Bar[][];

declare const fooNumberTupleBarArray2DSpread: MergeDeep<FooNumberTuple, BarArray2D, {arrayMergeMode: 'spread'; recurseIntoArrays: true}>;
expectType<[FooBarSpread[], Array<number | Bar>, ...BarArray2D]>(fooNumberTupleBarArray2DSpread);

declare const fooNumberTupleBarArray2DReplace: MergeDeep<FooNumberTuple, BarArray2D, {arrayMergeMode: 'replace'; recurseIntoArrays: true}>;
expectType<[FooBarReplace[], Bar[], ...BarArray2D]>(fooNumberTupleBarArray2DReplace);
```

I'll add A to D test cases if they satisfy the spec.