### PR TITLE
Fix incorrect ignore of temporary `.d.ts` files from fixtures in `xo.config.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"scripts": {
 		"test:tsc": "node --max-old-space-size=6144 ./node_modules/.bin/tsc",
 		"test:tsd": "node --max-old-space-size=6144 ./node_modules/.bin/tsd",
-		"test:xo": "node --max-old-space-size=6144 ./node_modules/.bin/xo",
+		"test:xo": "node --max-old-space-size=6144 ./node_modules/.bin/xo --ignores=lint-processors/fixtures/**/*.d.ts",
 		"test:linter": "node --test",
 		"test": "run-p test:*"
 	},

--- a/xo.config.js
+++ b/xo.config.js
@@ -43,9 +43,6 @@ const xoConfig = [
 		},
 	},
 	{
-		ignores: ['lint-processors/fixtures/**/*.d.ts'],
-	},
-	{
 		files: 'source/**/*.d.ts',
 		rules: {
 			'no-restricted-imports': [


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

The fix made in #1326 didn't quite fix the issue.

I looked into the XO codebase and realised that using `ignores` inside `xo.config.js` isn't what we want over here. From what I understand, files ignored this way are still linted, they just do not have any matching rules applied. That is not sufficient in this case because these files are ephemeral, which makes the linting process flaky.

This PR removes `ignores` from `xo.config.js` and moves the configuration to a CLI flag instead. This ensures the temporary files are not linted at all. Refer https://github.com/xojs/xo/blob/ceadd8d1cbbeac894ecf56936ab8e509ae5e432b/lib/xo.ts#L341.