### PR TITLE
`Paths`: Fix behavior with tuples containing optional elements with a rest element

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -1,4 +1,4 @@
-import type {StaticPartOfArray, VariablePartOfArray, NonRecursiveType, ToString, IsNumberLike, ApplyDefaultOptions} from './internal/index.d.ts';
+import type {NonRecursiveType, ToString, IsNumberLike, ApplyDefaultOptions} from './internal/index.d.ts';
 import type {IsAny} from './is-any.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 import type {GreaterThan} from './greater-than.d.ts';
@@ -196,14 +196,9 @@ type _Paths<T, Options extends Required<PathsOptions>, CurrentDepth extends numb
 		? never
 		: IsAny<T> extends true
 			? never
-			: T extends UnknownArray
-				? number extends T['length']
-					// We need to handle the fixed and non-fixed index part of the array separately.
-					? InternalPaths<StaticPartOfArray<T>, Options, CurrentDepth> | InternalPaths<Array<VariablePartOfArray<T>[number]>, Options, CurrentDepth>
-					: InternalPaths<T, Options, CurrentDepth>
-				: T extends object
-					? InternalPaths<T, Options, CurrentDepth>
-					: never;
+			: T extends object
+				? InternalPaths<T, Options, CurrentDepth>
+				: never;
 
 type InternalPaths<T, Options extends Required<PathsOptions>, CurrentDepth extends number> =
 	Options['maxRecursionDepth'] extends infer MaxDepth extends number

--- a/test-d/paths.ts
+++ b/test-d/paths.ts
@@ -92,6 +92,12 @@ expectType<number | `${number}` | '0.a' | `${number}.b`>(trailingSpreadTuple);
 declare const trailingSpreadTuple1: Paths<[{a: string}, {b: number}, ...Array<{c: number}>]>;
 expectType<number | `${number}` | '0.a' | '1.b' | `${number}.c`>(trailingSpreadTuple1);
 
+declare const optionalElementsWithTrailingSpreadTuple: Paths<{foo: [{a: string}, ({b: number})?, ...Array<{c: number}>]}>;
+expectType<'foo' | `foo.${number}` | 'foo.0.a' | 'foo.1.b' | `foo.${number}.c`>(optionalElementsWithTrailingSpreadTuple);
+
+declare const optionalElementsWithTrailingSpreadTuple1: Paths<[({a: string})?, ({b: number})?, ...Array<{c: number}>]>;
+expectType<number | `${number}` | '0.a' | '1.b' | `${number}.c`>(optionalElementsWithTrailingSpreadTuple1);
+
 declare const leadingSpreadTuple: Paths<[...Array<{a: string}>, {b: number}]>;
 expectType<number | `${number}` | `${number}.b` | `${number}.a`>(leadingSpreadTuple);
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently `Paths` fails when instantiated with tuple containing optional elements with a rest element. For example, `Paths<[({a: 1})?, ...string[]]>` currently returns `` number | `${number}` | `${number}.a` ``, but should instead return `` number | `${number}` | '0.a' ``. This fails because the `StaticPartOfArray` and `VariablePartOfArray` utilities don't work properly with such tuples.

This PR fixes this issue by simply removing the array branch, arrays don't require any special handling.