### PR TITLE
`Paths`: Fix `leavesOnly` behavior with `never` leaves

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -213,13 +213,15 @@ type InternalPaths<T, Options extends Required<PathsOptions>, CurrentDepth exten
 			? ((Options['leavesOnly'] extends true
 				? Options['maxRecursionDepth'] extends CurrentDepth
 					? TransformedKey
-					: T[Key] extends infer Value // For distributing `T[Key]`
-						? (Value extends readonly [] | NonRecursiveType | Exclude<MapsSetsOrArrays, UnknownArray>
-							? TransformedKey
-							: IsNever<keyof Value> extends true // Check for empty object & `unknown`, because `keyof unknown` is `never`.
+					: IsNever<T[Key]> extends true
+						? TransformedKey
+						: T[Key] extends infer Value // For distributing `T[Key]`
+							? (Value extends readonly [] | NonRecursiveType | Exclude<MapsSetsOrArrays, UnknownArray>
 								? TransformedKey
-								: never)
-						: never // Should never happen
+								: IsNever<keyof Value> extends true // Check for empty object & `unknown`, because `keyof unknown` is `never`.
+									? TransformedKey
+									: never)
+							: never // Should never happen
 				: TransformedKey
 			) extends infer _TransformedKey
 				// If `depth` is provided, the condition becomes truthy only when it matches `CurrentDepth`.

--- a/test-d/paths.ts
+++ b/test-d/paths.ts
@@ -295,6 +295,9 @@ expectType<'a.b'>(unknownLeaves);
 declare const anyLeaves: Paths<{a: {b: any}}, {leavesOnly: true}>;
 expectType<'a.b'>(anyLeaves);
 
+declare const neverLeaves: Paths<{a: {b: never}}, {leavesOnly: true}>;
+expectType<'a.b'>(neverLeaves);
+
 // -- depth option --
 declare const zeroDepth: Paths<DeepObject, {depth: 0}>;
 expectType<'a'>(zeroDepth);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Fixes https://github.com/sindresorhus/type-fest/pull/1348#discussion_r2768319141.