### PR TITLE
Add function parameter constraint examples to numeric comparison types

### DIFF
--- a/source/greater-than-or-equal.d.ts
+++ b/source/greater-than-or-equal.d.ts
@@ -40,11 +40,14 @@ import type {GreaterThanOrEqual} from 'type-fest';
 // Use `GreaterThanOrEqual` to constrain a function parameter to non-negative numbers.
 declare function setNonNegative<N extends number>(value: GreaterThanOrEqual<N, 0> extends true ? N : never): void;
 
-setNonNegative(0);
-setNonNegative(1);
+setNonNegative(0); // ✅ Allowed
+setNonNegative(1); // ✅ Allowed
 
 // @ts-expect-error
 setNonNegative(-1);
+
+// @ts-expect-error
+setNonNegative(-2);
 ```
 */
 export type GreaterThanOrEqual<A extends number, B extends number> = number extends A | B

--- a/source/greater-than.d.ts
+++ b/source/greater-than.d.ts
@@ -44,13 +44,14 @@ import type {GreaterThan} from 'type-fest';
 // Use `GreaterThan` to constrain a function parameter to positive numbers.
 declare function setPositive<N extends number>(value: GreaterThan<N, 0> extends true ? N : never): void;
 
-setPositive(1);
-
-// @ts-expect-error
-setPositive(-1);
+setPositive(1); // ✅ Allowed
+setPositive(2); // ✅ Allowed
 
 // @ts-expect-error
 setPositive(0);
+
+// @ts-expect-error
+setPositive(-1);
 ```
 */
 export type GreaterThan<A extends number, B extends number> =

--- a/source/less-than-or-equal.d.ts
+++ b/source/less-than-or-equal.d.ts
@@ -40,11 +40,14 @@ import type {LessThanOrEqual} from 'type-fest';
 // Use `LessThanOrEqual` to constrain a function parameter to non-positive numbers.
 declare function setNonPositive<N extends number>(value: LessThanOrEqual<N, 0> extends true ? N : never): void;
 
-setNonPositive(-1);
-setNonPositive(0);
+setNonPositive(0); // ✅ Allowed
+setNonPositive(-1); // ✅ Allowed
 
 // @ts-expect-error
 setNonPositive(1);
+
+// @ts-expect-error
+setNonPositive(2);
 ```
 */
 export type LessThanOrEqual<A extends number, B extends number> =

--- a/source/less-than.d.ts
+++ b/source/less-than.d.ts
@@ -40,7 +40,8 @@ import type {LessThan} from 'type-fest';
 // Use `LessThan` to constrain a function parameter to negative numbers.
 declare function setNegative<N extends number>(value: LessThan<N, 0> extends true ? N : never): void;
 
-setNegative(-1);
+setNegative(-1); // ✅ Allowed
+setNegative(-2); // ✅ Allowed
 
 // @ts-expect-error
 setNegative(0);


### PR DESCRIPTION
Closes #957

Adds a second `@example` block to `GreaterThan` showing how to use it as a function parameter constraint.

Users attempting to use `GreaterThan<N, 0>` directly as a parameter type get `never` because the generic is unresolved. The added example demonstrates the correct pattern using a conditional type:

```ts
declare function setPositive<N extends number>(value: GreaterThan<N, 0> extends true ? N : never): void;
```