### PR TITLE
`ConditionalPickDeep`: Fix returning `{}` instead of `never` when no keys match

### DIFF
--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -105,7 +105,7 @@ export type ConditionalPickDeep<
 	ApplyDefaultOptions<ConditionalPickDeepOptions, DefaultConditionalPickDeepOptions, Options>
 >>;
 
-type _NeverIfEmpty<Type> = [keyof Type] extends [never] ? never : Type;
+type _NeverIfEmpty<Type> = Type extends EmptyObject ? never : Type;
 
 type _ConditionalPickDeep<
 	Type,

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -108,6 +108,10 @@ expectType<never>(emptyEqualityPick);
 declare const noMatchingKeys: ConditionalPickDeep<{a: string; b: number}, boolean>;
 expectType<never>(noMatchingKeys);
 
+// Union with no common properties
+declare const unionNoCommon: ConditionalPickDeep<{a: string} | {b: string}, string>;
+expectType<{a: string} | {b: string}>(unionNoCommon);
+
 declare const stringOrBooleanPick: ConditionalPickDeep<Example, string | boolean>;
 expectType<{
 	literal: 'foo';


### PR DESCRIPTION
Fixes #1358

## Summary
- When no keys match the given `Condition` at any depth, `ConditionalPickDeep` previously returned `{}` (empty object type). This allowed any properties to be assigned without type errors.
- Added a `_NeverIfEmpty` helper that checks if the result has no keys and returns `never` in that case. This is applied only at the top level to avoid interfering with the internal recursive `EmptyObject` exclusion logic.
- Updated JSDoc twoslash comment and test cases accordingly.

## Note
This is the deep variant of the same issue fixed in #1359 for `ConditionalPick`.