### PR TITLE
docs(readme): introduce Used by section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1034,6 +1034,12 @@ There are many advanced types most users don't know about.
 
 You can find some examples in the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/utility-types.html).
 
+## Used by
+
+[![Used by](https://api.usedby.dev/npm/type-fest?max=30&sort=stars)](https://github.com/sindresorhus/type-fest/network/dependents)
+
+Generated with [usedby.dev](https://usedby.dev/)
+
 ## Maintainers
 
 - [Sindre Sorhus](https://github.com/sindresorhus)


### PR DESCRIPTION
## Summary

This introduces a **Used by** section in the README to showcase the top users of `type-fest` and how many repositories rely on this package.

The image is generated with [usedby.dev](https://usedby.dev/) and refreshed every day.

I added the image low in the README not to disrupt the flow, but happy to move it higher if this makes sense!