### PR TITLE
`OmitDeep`: Fix to preserve original fixed-tuple (instead of `never`) if index is out-of-bounds

### DIFF
--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -176,6 +176,8 @@ type TupleNumberOutOfIndex = IsValidIndex<[0, 1, 2], 9>;
 //=> false
 type TupleStringOutOfIndex = IsValidIndex<[0, 1, 2], '9'>;
 //=> false
+type TupleNumberOutOfIndexMinus = IsValidIndex<[0, 1, 2], -1>;
+//=> false
 type TupleNumber = IsValidIndex<[0, 1, 2], number>;
 //=> false
 type ArrayNumberIndex = IsValidIndex<readonly number[], 0>;
@@ -194,7 +196,9 @@ type IsValidIndex<A extends UnknownArray, Index extends string | number> =
 			? true
 			: number extends numberString
 				? false
-				: LessThan<numberString, A['length']>
+				: true extends LessThan<numberString, A['length']>
+					? LessThan<-1, numberString>
+					: false
 		: false;
 
 export {};

--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -8,6 +8,8 @@ import type {SimplifyDeep} from './simplify-deep.d.ts';
 import type {Simplify} from './simplify.d.ts';
 import type {UnionToTuple} from './union-to-tuple.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
+import type {LessThan} from './less-than.d.ts';
+import type {IsTuple} from './is-tuple.d.ts';
 
 /**
 Omit properties from a deeply-nested object.
@@ -131,7 +133,10 @@ It replaces the item to `unknown` at the given index.
 @example
 ```
 type A = OmitDeepArrayWithOnePath<[10, 20, 30, 40], 2>;
-//=> type A = [10, 20, unknown, 40];
+//=> [10, 20, unknown, 40];
+
+type B = OmitDeepArrayWithOnePath<[10, 20, 30, 40], 6>;
+//=> [10, 20, 30, 40];
 ```
 */
 type OmitDeepArrayWithOnePath<ArrayType extends UnknownArray, P extends string | number> =
@@ -141,14 +146,55 @@ type OmitDeepArrayWithOnePath<ArrayType extends UnknownArray, P extends string |
 		? number extends ArrayIndex
 			? Array<OmitDeepWithOnePath<NonNullable<ArrayType[number]>, SubPath>>
 			// If `ArrayIndex` is a number literal
-			: ArraySplice<ArrayType, ArrayIndex, 1, [OmitDeepWithOnePath<NonNullable<ArrayType[ArrayIndex]>, SubPath>]>
+			: [true, false] extends [IsTuple<ArrayType>, IsValidIndex<ArrayType, ArrayIndex>]
+				? ArrayType
+				: ArraySplice<ArrayType, ArrayIndex, 1, [OmitDeepWithOnePath<NonNullable<ArrayType[ArrayIndex]>, SubPath>]>
 		// If the path is equal to `number`
 		: P extends `${infer ArrayIndex extends number}`
 			// If `ArrayIndex` is `number`
 			? number extends ArrayIndex
 				? []
 				// If `ArrayIndex` is a number literal
-				: ArraySplice<ArrayType, ArrayIndex, 1, [unknown]>
+				: [true, false] extends [IsTuple<ArrayType>, IsValidIndex<ArrayType, ArrayIndex>]
+					? ArrayType
+					: ArraySplice<ArrayType, ArrayIndex, 1, [unknown]>
 			: ArrayType;
+
+/**
+`IsValidIndex` returns `true` if `Index` (either as a number or its string representation) is a valid index for the given `Array` or `Tuple`.
+
+If the first argument is a plain `Array`, it accepts `number`.
+if it is a `Tuple`, it only accepts specific numeric indices within its bounds.
+
+@example
+```
+type TupleNumberIndex = IsValidIndex<[0, 1, 2], '2'>;
+//=> true
+type TupleStringIndex = IsValidIndex<[0, 1, 2], 2>;
+//=> true
+type TupleNumberOutOfIndex = IsValidIndex<[0, 1, 2], 9>;
+//=> false
+type TupleStringOutOfIndex = IsValidIndex<[0, 1, 2], '9'>;
+//=> false
+type TupleNumber = IsValidIndex<[0, 1, 2], number>;
+//=> false
+type ArrayNumberIndex = IsValidIndex<readonly number[], 0>;
+//=> true
+type ArrayStringIndex = IsValidIndex<readonly number[], '0'>;
+//=> true
+type ArrayNumber = IsValidIndex<readonly number[], number>;
+//=> true
+type NotFixedTuple = IsValidIndex<['0', ...number[]], 0>;
+//=> true
+```
+*/
+type IsValidIndex<A extends UnknownArray, Index extends string | number> =
+	`${Index}` extends `${infer numberString extends number}`
+		? false extends IsTuple<A>
+			? true
+			: number extends numberString
+				? false
+				: LessThan<numberString, A['length']>
+		: false;
 
 export {};

--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -145,7 +145,7 @@ type OmitDeepArrayWithOnePath<ArrayType extends UnknownArray, P extends string |
 		// If `ArrayIndex` is equal to `number`
 		? number extends ArrayIndex
 			? Array<OmitDeepWithOnePath<NonNullable<ArrayType[number]>, SubPath>>
-			// If `ArrayIndex` is a number literal
+			// If `ArrayIndex` is a number literal and out-of-bounds, returns the original type.
 			: [true, false] extends [IsTuple<ArrayType>, IsValidIndex<ArrayType, ArrayIndex>]
 				? ArrayType
 				: ArraySplice<ArrayType, ArrayIndex, 1, [OmitDeepWithOnePath<NonNullable<ArrayType[ArrayIndex]>, SubPath>]>
@@ -154,7 +154,7 @@ type OmitDeepArrayWithOnePath<ArrayType extends UnknownArray, P extends string |
 			// If `ArrayIndex` is `number`
 			? number extends ArrayIndex
 				? []
-				// If `ArrayIndex` is a number literal
+				// If `ArrayIndex` is a number literal and out-of-bounds, returns the original type.
 				: [true, false] extends [IsTuple<ArrayType>, IsValidIndex<ArrayType, ArrayIndex>]
 					? ArrayType
 					: ArraySplice<ArrayType, ArrayIndex, 1, [unknown]>

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {OmitDeep} from '../index.d.ts';
+import type {OmitDeep, IsEqual} from '../index.d.ts';
 
 declare class ClassA {
 	a: string;
@@ -141,3 +141,10 @@ expectType<{array: Array<{c: string}>}>(arrayWithMultiplePaths);
 
 declare const tupleWithMultiplePaths: OmitDeep<{tuple: [{a: string; b: number; c: string}]}, 'tuple.0.a' | 'tuple.0.b'>;
 expectType<{tuple: [{c: string}]}>(tupleWithMultiplePaths);
+
+// Returns the original type unchanged if the specified path does not exist.
+type TupleInObject = {obj: {a: [0, 1]; b: {bb: {bbb: 10}}; c: boolean}};
+expectType<TupleInObject>({} as OmitDeep<TupleInObject, 'obj.b.bb.zzz' | `obj.a.${2}` | 'c.c'>);
+
+type ObjectInTuple = {obj: {a: [0, 1, {bb: {bbb: 10}}]; c: [0, 1, ['20', '22']]}};
+expectType<ObjectInTuple>({} as OmitDeep<ObjectInTuple, 'obj.a.3.3' | 'obj.c.2.9'>);

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -148,3 +148,12 @@ expectType<TupleInObject>({} as OmitDeep<TupleInObject, 'obj.b.bb.zzz' | `obj.a.
 
 type ObjectInTuple = {obj: {a: [0, 1, {bb: {bbb: 10}}]; c: [0, 1, ['20', '22']]}};
 expectType<ObjectInTuple>({} as OmitDeep<ObjectInTuple, 'obj.a.3.3' | 'obj.c.2.9'>);
+
+declare const tupleNegativeIndex: OmitDeep<{tuple: ['a', 'b']}, 'tuple.-1'>;
+expectType<{tuple: ['a', 'b']}>(tupleNegativeIndex);
+
+declare const tupleNegativeNestedIndex: OmitDeep<{tuple: [{x: 1}]}, 'tuple.-1.x'>;
+expectType<{tuple: [{x: 1}]}>(tupleNegativeNestedIndex);
+
+declare const tupleMixedValidAndNegativeIndex: OmitDeep<{tuple: [{x: 1; y: 2}]}, 'tuple.0.x' | 'tuple.-1.y'>;
+expectType<{tuple: [{y: 2}]}>(tupleMixedValidAndNegativeIndex);

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {OmitDeep, IsEqual} from '../index.d.ts';
+import type {OmitDeep} from '../index.d.ts';
 
 declare class ClassA {
 	a: string;


### PR DESCRIPTION
`OmitDeep` returns objects containing `never` if the specified index is out-of-bounds of a tuple within a object.

```typescript
OmitDeep<{obj: [0, 1, 2]}, 'obj.3'>;
//=> {obj: never}
```

https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbwKYA8xIMYwCoE90C+cAZlBCHAOQwDOAJpQNwCwAUKJLHDPkogPIhgMACJIkYADRwAkjQCiARwCuAQwA2RUuSo90AWmJIaMJmzYB6C3ABy-bPIBccAG7BVcAAZyla9Z7gAI0xVZRo+T1R0LDx0ALoIYwA7ajgAd2gAa3SkdXU4YCS4AAV1VVwAczJlJLoAOnNWKzhVLD8G1ijMHF4AHhgoZSQAPgAKBCJVGlkFFQ1ehAhAgCtnJKQXJCgCaUFhMQkFpdW4AG0ABmkARmkAJgBdHapjuoBmSmHhgEoWJusurBIepsAE9dD9QYjcaTaY+ObqI4rZwXa53R67ISicRgREnFFwG5wB5PSgvd6fH6NPR8bDKMDqJAyJL8FbdOAAXkQx2cCFUyMuBPujCCPMCgVFYucV3OBAIwowzkCEAgDNUSVlv2arRg7RBaG6sSQEKGYwmLVhsz8uJ5fLg602UGF4sQkpdrulGrgCqCytV6qeeyxh1p9MZzNZWGkpJWdUCsbjAC8k5Q4AAfLwvVR1AAkCFuBAC6coGDqGA+301-31gOBnWrYKNAxN0PNM188xDDKZLOW3Qx+2xvU7YZ7feeMbjYrqSYTKfTnkzObzBbTVBLZYpvzY1Lgo6wTOHHK5SMQtvxhIQrsv7plBCFXv5qLOlFu50oUdut0o90ecss1m1XU62iBtjShM0pjbeEFjgblEBaNYNi2eVHwJaR7S2e85TgANMQOHE9xgA86QZKNF1eN453HZZSzqW46gATnLSk-jgUEgQ6UFDTA00YSgq1COI0N+yDAiIyIpJhzImMswo95V2jGiS3opjNzYIA

This PR fixes this behavior by ensuring the original tuple is preserved when the index is not found. This aligns with how `OmitDeep<Object, Key>` currently behaves: if a `Key` does not exist in the `Object`, it is simply ignored.

For fixed-length tuples (e.g., not variadic ones like `[a, b, ...c[]]`), `OmitDeep<FixedTuple, Index>` should now behave consistently with `OmitDeep<Object, Key>`. If the `Index` is inaccessible, the resulting tuple remains unchanged.

## Comparison with `[a, b, c]` and `[a, b, ...c[]]` cases
I believe users expect `OmitDeep` to only modify parts of an object that actually match the provided paths. Therefore, if a path is invalid or out-of-bounds, the original type should be kept as-is.

Therefore, expanding the tuple in this manner is not an appropriate solution.

[(in `test-d/omit-deep.ts`)](https://github.com/taiyakihitotsu/type-fest/blob/2924df4075f54882505055e982e16a86d423ce57/test-d/omit-deep.ts#L121)

```typescript
/** Test for arrays */
declare const recurseIntoArray: OmitDeep<{array: BaseType['objectArray']}, `array.${number}.a`>;
expectType<{array: Array<{b: 2}>}>(recurseIntoArray);

declare const recurseIntoArray2: OmitDeep<{array: BaseType['objectArray']}, 'array.0.a'>;
expectType<{array: [{b: 2}, ...Array<{a: 1; b: 2}>]}>(recurseIntoArray2);

declare const recurseIntoArray3: OmitDeep<{array: BaseType['objectArray']}, 'array.3.a'>;
expectType<{array: [
	{a: 1; b: 2}, // 0
	{a: 1; b: 2}, // 1
	{a: 1; b: 2}, // 2
	{b: 2}, // 3
	...Array<{a: 1; b: 2}>,
];}>(recurseIntoArray3);
```