### PR TITLE
`Get`: Enhance `Get` type to support dot-separated keys

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -22,17 +22,44 @@ type DefaultGetOptions = {
 
 /**
 Like the `Get` type but receives an array of strings as a path parameter.
+
+When a key segment doesn't directly match a property and the type has keys containing dots
+that start with that segment, it tries progressively joining adjacent segments with dots
+to match those keys (e.g. `{'foo.bar': value}`).
 */
 type GetWithPath<BaseType, Keys, Options extends Required<GetOptions>> =
 	Keys extends readonly []
 		? BaseType
 		: Keys extends readonly [infer Head, ...infer Tail]
+			? Extract<Head, string> extends keyof BaseType
+				? GetWithPath<
+					PropertyOf<BaseType, Extract<Head, string>, Options>,
+					Extract<Tail, string[]>,
+					Options
+				>
+				: [keyof BaseType & `${Extract<Head, string>}.${string}`] extends [never]
+					? GetWithPath<
+						PropertyOf<BaseType, Extract<Head, string>, Options>,
+						Extract<Tail, string[]>,
+						Options
+					>
+					: GetWithPath_TryDotKey<BaseType, Extract<Head, string>, Extract<Tail, string[]>, Options>
+			: never;
+
+/**
+Try progressively longer dot-joined key prefixes to handle object keys that contain dots.
+Falls back to `PropertyOf` for the original key when no dotted key matches.
+*/
+type GetWithPath_TryDotKey<BaseType, Prefix extends string, Remaining extends readonly string[], Options extends Required<GetOptions>> =
+	Remaining extends readonly [infer Next extends string, ...infer Rest extends string[]]
+		? `${Prefix}.${Next}` extends keyof BaseType
 			? GetWithPath<
-				PropertyOf<BaseType, Extract<Head, string>, Options>,
-				Extract<Tail, string[]>,
+				PropertyOf<BaseType, `${Prefix}.${Next}`, Options>,
+				Rest,
 				Options
 			>
-			: never;
+			: GetWithPath_TryDotKey<BaseType, `${Prefix}.${Next}`, Rest, Options>
+		: PropertyOf<BaseType, Prefix, Options>;
 
 /**
 Adds `undefined` to `Type` if `strict` is enabled.

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -23,9 +23,7 @@ type DefaultGetOptions = {
 /**
 Like the `Get` type but receives an array of strings as a path parameter.
 
-When a key segment doesn't directly match a property and the type has keys containing dots
-that start with that segment, it tries progressively joining adjacent segments with dots
-to match those keys (e.g. `{'foo.bar': value}`).
+When a key segment doesn't directly match a property and the type has keys containing dots that start with that segment, it tries progressively joining adjacent segments with dots to match those keys (e.g. `{'foo.bar': value}`).
 */
 type GetWithPath<BaseType, Keys, Options extends Required<GetOptions>> =
 	Keys extends readonly []

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -152,3 +152,66 @@ expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, readonly []>>()
 	type FooPaths2 = 'array.1';
 	expectTypeOf<Get<Foo, FooPaths2>>().toEqualTypeOf<string | undefined>();
 }
+
+// Test keys containing dots (https://github.com/sindresorhus/type-fest/issues/1372)
+// eslint-disable-next-line no-lone-blocks
+{
+	type WithDotKeys = {
+		['test1.test2']: {
+			test3: {
+				test4: number;
+			};
+		};
+	};
+
+	expectTypeOf<Get<WithDotKeys, 'test1.test2'>>().toEqualTypeOf<{test3: {test4: number}}>();
+	expectTypeOf<Get<WithDotKeys, 'test1.test2.test3'>>().toEqualTypeOf<{test4: number}>();
+	expectTypeOf<Get<WithDotKeys, 'test1.test2.test3.test4'>>().toEqualTypeOf<number>();
+
+	expectTypeOf<Get<WithDotKeys, 'test1.test2', NonStrict>>().toEqualTypeOf<{test3: {test4: number}}>();
+	expectTypeOf<Get<WithDotKeys, 'test1.test2.test3', NonStrict>>().toEqualTypeOf<{test4: number}>();
+	expectTypeOf<Get<WithDotKeys, 'test1.test2.test3.test4', NonStrict>>().toEqualTypeOf<number>();
+
+	// Array path should treat the dotted key as a single element
+	expectTypeOf<Get<WithDotKeys, ['test1.test2']>>().toEqualTypeOf<{test3: {test4: number}}>();
+	expectTypeOf<Get<WithDotKeys, ['test1.test2', 'test3', 'test4']>>().toEqualTypeOf<number>();
+
+	// Non-existent paths should still return unknown
+	expectTypeOf<Get<WithDotKeys, 'test1', NonStrict>>().toBeUnknown();
+	expectTypeOf<Get<WithDotKeys, 'test1.test2.nonexistent', NonStrict>>().toBeUnknown();
+
+	// Key with multiple dots
+	type WithMultiDotKey = {
+		['test1.test2.test3']: {
+			test4: number;
+		};
+	};
+
+	expectTypeOf<Get<WithMultiDotKey, 'test1.test2.test3'>>().toEqualTypeOf<{test4: number}>();
+	expectTypeOf<Get<WithMultiDotKey, 'test1.test2.test3.test4'>>().toEqualTypeOf<number>();
+	expectTypeOf<Get<WithMultiDotKey, 'test1.test2.test3', NonStrict>>().toEqualTypeOf<{test4: number}>();
+	expectTypeOf<Get<WithMultiDotKey, 'test1.test2.test3.test4', NonStrict>>().toEqualTypeOf<number>();
+	expectTypeOf<Get<WithMultiDotKey, 'test1.test2', NonStrict>>().toBeUnknown();
+	expectTypeOf<Get<WithMultiDotKey, 'test1', NonStrict>>().toBeUnknown();
+
+	// Multiple levels of dot-containing keys
+	type NestedDotKeys = {
+		['a.b']: {
+			['c.d']: {
+				value: string;
+			};
+		};
+	};
+
+	expectTypeOf<Get<NestedDotKeys, 'a.b.c.d.value', NonStrict>>().toBeString();
+	expectTypeOf<Get<NestedDotKeys, 'a.b.c.d', NonStrict>>().toEqualTypeOf<{value: string}>();
+
+	// When both a dotted key and a nested path exist, prefer the nested path (matches JS dot-access semantics)
+	type Ambiguous = {
+		a: {b: number};
+		'a.b': string;
+	};
+
+	expectTypeOf<Get<Ambiguous, 'a.b', NonStrict>>().toBeNumber();
+	expectTypeOf<Get<Ambiguous, ['a.b'], NonStrict>>().toBeString();
+}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1372 
