### PR TITLE
`MergeDeep`: Fix optionality preservation for shared keys

### DIFF
--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -57,8 +57,26 @@ type DoMergeDeepRecord<
 		[Key in keyof Source as Key extends keyof Destination ? never : Key]: Source[Key];
 	}
 // Case in rule 3: Both the source and the destination contain the key.
+// Split into two sub-cases to correctly handle optionality:
+// 3a: Key is optional in both Source and Destination → result is optional.
 	& {
-		[Key in keyof Source as Key extends keyof Destination ? Key : never]: MergeDeepRecordProperty<Required<Destination>[Key], Required<Source>[Key], Options>;
+		[Key in keyof Source as Key extends keyof Destination
+			? {} extends Pick<Source, Key>
+				? {} extends Pick<Destination, Key>
+					? Key
+					: never
+				: never
+			: never]?: MergeDeepRecordProperty<Required<Destination>[Key], Required<Source>[Key], Options>;
+	}
+// 3b: Key is required in at least one of Source or Destination → result is required.
+	& {
+		[Key in keyof Source as Key extends keyof Destination
+			? {} extends Pick<Source, Key>
+				? {} extends Pick<Destination, Key>
+					? never
+					: Key
+				: Key
+			: never]-?: MergeDeepRecordProperty<Required<Destination>[Key], Required<Source>[Key], Options>;
 	};
 
 /**

--- a/test-d/merge-deep.ts
+++ b/test-d/merge-deep.ts
@@ -318,10 +318,69 @@ type RecordNotPartial = {
 type RecordPartial = Partial<RecordNotPartial>;
 
 expectType<RecordNotPartial>({} as MergeDeep<RecordPartial, RecordNotPartial>);
-expectType<RecordPartial>({} as MergeDeep<RecordNotPartial, RecordPartial>);
+// When source keys are optional but destination keys are required,
+// the result keys should be required (fix for #941).
+expectType<RecordNotPartial>({} as MergeDeep<RecordNotPartial, RecordPartial>);
 
 type NotOptional = {a: string; b: number; c: boolean};
 type OptionalWithUndefined = {a: string | undefined; b?: number; c?: boolean | undefined};
 
-expectType<OptionalWithUndefined>({} as MergeDeep<NotOptional, OptionalWithUndefined>);
+// `a` is required in both → required. `b` is required in dest → required.
+// `c` is required in dest → required. Values preserve `| undefined` from source.
+expectType<{a: string | undefined; b: number; c: boolean | undefined}>({} as MergeDeep<NotOptional, OptionalWithUndefined>);
 expectType<NotOptional>({} as MergeDeep<OptionalWithUndefined, NotOptional>);
+
+// Test for #941: MergeDeep should preserve required keys from destination
+// when source has the same keys as optional.
+type FullPerson = {name: string; age: number; address: {city: string; zip: number}};
+type PartialPersonInfo = {name?: string; address?: {city?: string}};
+
+// Source has optional keys, destination has required keys → result should be required.
+expectType<{
+	name: string;
+	age: number;
+	address: {city: string; zip: number};
+}>({} as MergeDeep<FullPerson, PartialPersonInfo>);
+
+// Both optional → result should be optional.
+type BothOptional = {x?: string; y?: number};
+type BothOptional2 = {x?: boolean; z?: string};
+expectType<{x?: boolean; y?: number; z?: string}>({} as MergeDeep<BothOptional, BothOptional2>);
+
+// Source required, destination optional → result should be required.
+type WithOptionalKey = {name?: string; age?: number};
+type WithRequiredKey = {name: string};
+expectType<{name: string; age?: number}>({} as MergeDeep<WithOptionalKey, WithRequiredKey>);
+
+// Edge case: any type with optionality
+type AnyOptDest = {a?: any; b: string};
+type AnyRequiredSource = {a: number; b?: string};
+declare const anyTest: MergeDeep<AnyOptDest, AnyRequiredSource>;
+const _anyA: number = anyTest.a;
+const _anyB: string = anyTest.b;
+
+// Edge case: never type — optional never field (Supabase pattern)
+type WithNeverOpt = {id?: never; name: string};
+type WithName = {name?: string; extra: number};
+declare const neverTest: MergeDeep<WithNeverOpt, WithName>;
+const _neverName: string = neverTest.name;
+const _neverExtra: number = neverTest.extra;
+
+// Edge case: Deep nesting — optionality at each level
+type DeepRequiredNested = {a: {b: {c: string; d: number}}};
+type DeepOptNested = {a?: {b?: {c?: boolean}}};
+declare const deepTest: MergeDeep<DeepRequiredNested, DeepOptNested>;
+// A: required in dest → required. Source value type (boolean) overrides dest (string).
+const _deepA: {b: {c: boolean; d: number}} = deepTest.a;
+
+// Edge case: empty objects
+expectType<{a: string}>({} as MergeDeep<{a: string}, {}>);
+expectType<{a: string}>({} as MergeDeep<{}, {a: string}>);
+
+// Edge case: same type required
+type SameType = {a: string; b: number};
+expectType<SameType>({} as MergeDeep<SameType, SameType>);
+
+// Edge case: same type optional
+type SameOptType = {a?: string; b?: number};
+expectType<SameOptType>({} as MergeDeep<SameOptType, SameOptType>);


### PR DESCRIPTION
Fixes #941.

## Problem

`MergeDeep` incorrectly makes required destination keys optional when source has the same key as optional:

```ts
type Dest = {name: string; age: number};
type Src = {name?: string};

type Result = MergeDeep<Dest, Src>;
// ❌ Before: {name?: string; age: number}  — name became optional
// ✅ After:  {name: string; age: number}   — name stays required
```

## Root cause

In `DoMergeDeepRecord`, Case 3 (`[Key in keyof Source as Key extends keyof Destination ? Key : never]`) iterates over `keyof Source`, which preserves Source's optional modifier (`?`). When Source has `name?`, the result key inherits that optionality regardless of Destination.

## Fix

Split Case 3 into two sub-cases using `{} extends Pick<Type, Key>` to detect optionality:

- **Case 3a**: Key is optional in **both** Source and Destination → result is optional (`?`)
- **Case 3b**: Key is required in **at least one** of Source or Destination → result is required (`-?`)

Both sub-cases wrap values in `Required<>` before passing to `MergeDeepRecordProperty` to strip the optional `undefined` from value types.

## Tests

- Fixed 2 existing tests that encoded the buggy behavior
- Added regression test for #941 (required dest + optional source)
- Added tests for both-optional, source-required + dest-optional
- Added edge case tests: `any`, `never`, deep nesting, empty objects, same-type

All tests pass (`npm test`).