### PR TITLE
Upgrade to XO v2

### DIFF
--- a/lint-processors/jsdoc-codeblocks.js
+++ b/lint-processors/jsdoc-codeblocks.js
@@ -5,7 +5,7 @@ import tsParser from '@typescript-eslint/parser';
 @import {Linter} from 'eslint';
 */
 
-const CODEBLOCK_REGEX = /(?<openingFence>(?<indent>^[ \t]*)```(?:ts|typescript)?\n)(?<code>[\s\S]*?)\n\s*```/gm;
+const CODEBLOCK_REGEX = /(?<openingFence>(?<indent>^[ \t]*)```(?:ts|typescript)?\n)(?<code>[\s\S]*?)\n\s*```/gmv;
 /**
 @typedef {{lineOffset: number, characterOffset: number, indent: string, unindentedText: string}} CodeblockData
 @type {Map<string, CodeblockData[]>}

--- a/lint-processors/jsdoc-codeblocks.test.js
+++ b/lint-processors/jsdoc-codeblocks.test.js
@@ -1454,7 +1454,7 @@ describe('jsdoc-codeblocks processor', {concurrency: true}, () => {
 
 	for (const {type, name, code, output, errors = []} of testCases) {
 		test(`${type} - ${name}`, async t => {
-			const fileName = `test-${type}-${name.replaceAll(/\s+/g, '-')}.d.ts`;
+			const fileName = `test-${type}-${name.replaceAll(/\s+/gv, '-')}.d.ts`;
 			const filePath = path.join(root, fileName);
 			await fs.writeFile(filePath, code);
 			t.after(async () => {

--- a/lint-rules/validate-jsdoc-codeblocks.js
+++ b/lint-rules/validate-jsdoc-codeblocks.js
@@ -2,7 +2,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import {createFSBackedSystem, createVirtualTypeScriptEnvironment} from '@typescript/vfs';
 
-const CODEBLOCK_REGEX = /(?<openingFence>```(?:ts|typescript)?\n)(?<code>[\s\S]*?)```/g;
+const CODEBLOCK_REGEX = /(?<openingFence>```(?:ts|typescript)?\n)(?<code>[\s\S]*?)```/gv;
 const FILENAME = 'example-codeblock.ts';
 const TWOSLASH_COMMENT = '//=>';
 
@@ -24,8 +24,7 @@ const compilerOptions = {
 	exactOptionalPropertyTypes: true,
 };
 
-const virtualFsMap = new Map();
-virtualFsMap.set(FILENAME, '// Can\'t be empty');
+const virtualFsMap = new Map([[FILENAME, '// Can\'t be empty']]);
 
 const rootDir = path.join(import.meta.dirname, '..');
 const system = createFSBackedSystem(virtualFsMap, rootDir, ts);
@@ -41,7 +40,7 @@ function parseCompilerOptions(code) {
 			continue;
 		}
 
-		const match = line.match(/^\s*\/\/ @(\w+): (.*)$/);
+		const match = line.match(/^\s*\/\/ @(\w+): (.*)$/v);
 		if (!match) {
 			// Stop parsing at the first non-matching line
 			return options;
@@ -265,12 +264,12 @@ function normalizeType(type, onlySortNumbers = false) {
 
 			if (onlySortNumbers) {
 				// Sort only numeric members while keeping non-numeric members at their original positions
-				const sortedNumericTypes = types.filter(([a]) => isNumeric(a)).sort(([a], [b]) => Number(a) - Number(b));
+				const sortedNumericTypes = types.filter(([a]) => isNumeric(a)).toSorted(([a], [b]) => Number(a) - Number(b));
 				let numericIndex = 0;
 				types = types.map(t => isNumeric(t[0]) ? sortedNumericTypes[numericIndex++][1] : t[1]);
 			} else {
 				types = types
-					.sort(([a], [b]) => a < b ? -1 : (a > b ? 1 : 0))
+					.toSorted(([a], [b]) => a < b ? -1 : (a > b ? 1 : 0))
 					.map(t => t[1]);
 			}
 
@@ -298,7 +297,7 @@ function normalizeType(type, onlySortNumbers = false) {
 		return node;
 	};
 
-	return print(visit(typeNode)).replaceAll(/^( +)/gm, indentation => {
+	return print(visit(typeNode)).replaceAll(/^( +)/gmv, indentation => {
 		// Replace spaces used for indentation with tabs
 		const spacesPerTab = 4;
 		const tabCount = Math.floor(indentation.length / spacesPerTab);
@@ -312,10 +311,10 @@ function getCommentForType(type) {
 
 	if (type.length < 80) {
 		comment = type
-			.replaceAll(/\r?\n\s*/g, ' ') // Collapse into single line
-			.replaceAll(/{\s+/g, '{') // Remove spaces after `{`
-			.replaceAll(/\s+}/g, '}') // Remove spaces before `}`
-			.replaceAll(/;(?=})/g, ''); // Remove semicolons before `}`
+			.replaceAll(/\r?\n\s*/gv, ' ') // Collapse into single line
+			.replaceAll(/\{\s+/gv, '{') // Remove spaces after `{`
+			.replaceAll(/\s+\}/gv, '}') // Remove spaces before `}`
+			.replaceAll(/;(?=\})/gv, ''); // Remove semicolons before `}`
 	}
 
 	return `${TWOSLASH_COMMENT} ${comment.replaceAll('\n', '\n// ')}`;

--- a/package.json
+++ b/package.json
@@ -55,15 +55,15 @@
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^8.0.1",
 		"@typescript-eslint/parser": "^8.44.0",
-		"eslint": "^9.35.0",
 		"@typescript/vfs": "^1.6.1",
 		"dedent": "^1.7.0",
+		"eslint": "^10.1.0",
 		"expect-type": "^1.2.2",
 		"npm-run-all2": "^8.0.4",
 		"tsd": "^0.33.0",
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.47.0",
-		"xo": "^1.2.2"
+		"xo": "^2.0.2"
 	},
 	"tsd": {
 		"compilerOptions": {

--- a/source/all-union-fields.d.ts
+++ b/source/all-union-fields.d.ts
@@ -69,23 +69,23 @@ function displayPetInfoWithAllUnionFields(petInfo: AllUnionFields<Cat | Dog>) {
 @category Union
 */
 export type AllUnionFields<Union> =
-Extract<Union, NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray> extends infer SkippedMembers
-	? Exclude<Union, SkippedMembers> extends infer RelevantMembers
-		?
-		| SkippedMembers
-		| Simplify<
-		// Include fields that are common in all union members
-			SharedUnionFields<RelevantMembers> &
-		// Include readonly fields present in any union member
-			{
-				readonly [P in ReadonlyKeysOfUnion<RelevantMembers>]?: ValueOfUnion<RelevantMembers, P & KeysOfUnion<RelevantMembers>>
-			} &
-		// Include remaining fields that are neither common nor readonly
-			{
-				[P in Exclude<KeysOfUnion<RelevantMembers>, ReadonlyKeysOfUnion<RelevantMembers> | keyof RelevantMembers>]?: ValueOfUnion<RelevantMembers, P>
-			}
-		>
-		: never
-	: never;
+	Extract<Union, NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray> extends infer SkippedMembers
+		? Exclude<Union, SkippedMembers> extends infer RelevantMembers
+			? // eslint-disable-line @stylistic/operator-linebreak
+			| SkippedMembers
+			| Simplify<
+				// Include fields that are common in all union members
+				SharedUnionFields<RelevantMembers>
+				// Include readonly fields present in any union member
+				& {
+					readonly [P in ReadonlyKeysOfUnion<RelevantMembers>]?: ValueOfUnion<RelevantMembers, P & KeysOfUnion<RelevantMembers>>
+				}
+				// Include remaining fields that are neither common nor readonly
+				& {
+					[P in Exclude<KeysOfUnion<RelevantMembers>, ReadonlyKeysOfUnion<RelevantMembers> | keyof RelevantMembers>]?: ValueOfUnion<RelevantMembers, P>
+				}
+			>
+			: never
+		: never;
 
 export {};

--- a/source/array-splice.d.ts
+++ b/source/array-splice.d.ts
@@ -8,13 +8,13 @@ import type {TupleOf} from './tuple-of.d.ts';
 The implementation of `SplitArrayByIndex` for fixed length arrays.
 */
 type SplitFixedArrayByIndex<T extends UnknownArray, SplitIndex extends number> =
-SplitIndex extends 0
-	? [[], T]
-	: T extends readonly [...TupleOf<SplitIndex>, ...infer V]
-		? T extends readonly [...infer U, ...V]
-			? [U, V]
-			: [never, never]
-		: [never, never];
+	SplitIndex extends 0
+		? [[], T]
+		: T extends readonly [...TupleOf<SplitIndex>, ...infer V]
+			? T extends readonly [...infer U, ...V]
+				? [U, V]
+				: [never, never]
+			: [never, never];
 
 /**
 The implementation of `SplitArrayByIndex` for variable length arrays.
@@ -26,23 +26,23 @@ type SplitVariableArrayByIndex<T extends UnknownArray,
 		? TupleOf<GreaterThanOrEqual<T1, 0> extends true ? T1 : number, VariablePartOfArray<T>[number]>
 		: [],
 > =
-SplitIndex extends 0
-	? [[], T]
-	: GreaterThanOrEqual<StaticPartOfArray<T>['length'], SplitIndex> extends true
-		? [
-			SplitFixedArrayByIndex<StaticPartOfArray<T>, SplitIndex>[0],
-			[
-				...SplitFixedArrayByIndex<StaticPartOfArray<T>, SplitIndex>[1],
-				...VariablePartOfArray<T>,
-			],
-		]
-		: [
-			[
-				...StaticPartOfArray<T>,
-				...(T2 extends UnknownArray ? T2 : []),
-			],
-			VariablePartOfArray<T>,
-		];
+	SplitIndex extends 0
+		? [[], T]
+		: GreaterThanOrEqual<StaticPartOfArray<T>['length'], SplitIndex> extends true
+			? [
+				SplitFixedArrayByIndex<StaticPartOfArray<T>, SplitIndex>[0],
+				[
+					...SplitFixedArrayByIndex<StaticPartOfArray<T>, SplitIndex>[1],
+					...VariablePartOfArray<T>,
+				],
+			]
+			: [
+				[
+					...StaticPartOfArray<T>,
+					...(T2 extends UnknownArray ? T2 : []),
+				],
+				VariablePartOfArray<T>,
+			];
 
 /**
 Split the given array `T` by the given `SplitIndex`.

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -86,11 +86,11 @@ type CamelCasedPropertiesArrayDeep<
 		? [_CamelCasedPropertiesDeep<U, Options>, ..._CamelCasedPropertiesDeep<V, Options>]
 		: Value extends readonly [infer U, ...infer V]
 			? readonly [_CamelCasedPropertiesDeep<U, Options>, ..._CamelCasedPropertiesDeep<V, Options>]
-			: // Leading spread array
-			Value extends readonly [...infer U, infer V]
+			// Leading spread array
+			: Value extends readonly [...infer U, infer V]
 				? [..._CamelCasedPropertiesDeep<U, Options>, _CamelCasedPropertiesDeep<V, Options>]
-				: // Array
-				Value extends Array<infer U>
+				// Array
+				: Value extends Array<infer U>
 					? Array<_CamelCasedPropertiesDeep<U, Options>>
 					: Value extends ReadonlyArray<infer U>
 						? ReadonlyArray<_CamelCasedPropertiesDeep<U, Options>>

--- a/source/int-range.d.ts
+++ b/source/int-range.d.ts
@@ -56,9 +56,9 @@ type PrivateIntRange<
 	// The final `List` is `[...StartLengthTuple, ...[number, ...GapLengthTuple], ...[number, ...GapLengthTuple], ... ...]`, so can initialize the `List` with `[...StartLengthTuple]`
 	List extends unknown[] = TupleOf<Start, never>,
 	EndLengthTuple extends unknown[] = TupleOf<End>,
-> = Gap extends 0 ?
+> = Gap extends 0
 	// Handle the case that without `Step`
-	List['length'] extends End // The result of "List[length] === End"
+	? List['length'] extends End // The result of "List[length] === End"
 		? Exclude<List[number], never> // All unused elements are `never`, so exclude them
 		: PrivateIntRange<Start, End, Step, Gap, [...List, List['length'] ]>
 	// Handle the case that with `Step`

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -29,8 +29,8 @@ type B = StaticPartOfArray<A>;
 */
 export type StaticPartOfArray<T extends UnknownArray, Result extends UnknownArray = []> =
 	T extends unknown
-		? number extends T['length'] ?
-			T extends readonly [infer U, ...infer V]
+		? number extends T['length']
+			? T extends readonly [infer U, ...infer V]
 				? StaticPartOfArray<V, [...Result, U]>
 				: Result
 			: T
@@ -69,11 +69,11 @@ type NormalResult = SetArrayAccess<ReadonlyStringArray, false>;
 ```
 */
 export type SetArrayAccess<T extends UnknownArray, IsReadonly extends boolean> =
-T extends readonly [...infer U] ?
-	IsReadonly extends true
-		? readonly [...U]
-		: [...U]
-	: T;
+	T extends readonly [...infer U]
+		? IsReadonly extends true
+			? readonly [...U]
+			: [...U]
+		: T;
 
 /**
 Returns whether the given array `T` is readonly.

--- a/source/internal/keys.d.ts
+++ b/source/internal/keys.d.ts
@@ -87,14 +87,14 @@ type Key4 = ExactKey<Object, 1>;
 @category Object
 */
 export type ExactKey<T extends object, Key extends PropertyKey> =
-Key extends keyof T
-	? Key
-	: ToString<Key> extends keyof T
-		? ToString<Key>
-		: Key extends `${infer NumberKey extends number}`
-			? NumberKey extends keyof T
-				? NumberKey
-				: never
-			: never;
+	Key extends keyof T
+		? Key
+		: ToString<Key> extends keyof T
+			? ToString<Key>
+			: Key extends `${infer NumberKey extends number}`
+				? NumberKey extends keyof T
+					? NumberKey
+					: never
+				: never;
 
 export {};

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -124,10 +124,18 @@ type D = ReverseSign<PositiveInfinity>;
 */
 export type ReverseSign<N extends number> =
 	// Handle edge cases
-	N extends 0 ? 0 : N extends PositiveInfinity ? NegativeInfinity : N extends NegativeInfinity ? PositiveInfinity :
-	// Handle negative numbers
-	`${N}` extends `-${infer P extends number}` ? P
-		// Handle positive numbers
-		: `-${N}` extends `${infer R extends number}` ? R : never;
+	N extends 0
+		? 0
+		: N extends PositiveInfinity
+			? NegativeInfinity
+			: N extends NegativeInfinity
+				? PositiveInfinity
+				// Handle negative numbers
+				: `${N}` extends `-${infer P extends number}`
+					? P
+					// Handle positive numbers
+					: `-${N}` extends `${infer R extends number}`
+						? R
+						: never;
 
 export {};

--- a/source/internal/tuple.d.ts
+++ b/source/internal/tuple.d.ts
@@ -46,8 +46,8 @@ type B = TupleMax<[1, 2, 5, 3, 99, -1]>;
 ```
 */
 export type TupleMax<A extends number[], Result extends number = NegativeInfinity> = number extends A[number]
-	? never :
-	A extends [infer F extends number, ...infer R extends number[]]
+	? never
+	: A extends [infer F extends number, ...infer R extends number[]]
 		? GreaterThan<F, Result> extends true
 			? TupleMax<R, F>
 			: TupleMax<R, Result>

--- a/source/is-integer.d.ts
+++ b/source/is-integer.d.ts
@@ -47,14 +47,14 @@ type J = IsInteger<1e-7>;
 @category Numeric
 */
 export type IsInteger<T> =
-T extends bigint
-	? true
-	: T extends number
-		? number extends T
-			? false
-			: T extends PositiveInfinity | NegativeInfinity
+	T extends bigint
+		? true
+		: T extends number
+			? number extends T
 				? false
-				: Not<IsFloat<T>>
-		: false;
+				: T extends PositiveInfinity | NegativeInfinity
+					? false
+					: Not<IsFloat<T>>
+			: false;
 
 export {};

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -121,11 +121,11 @@ export type IsStringLiteral<S> = IfNotAnyOrNever<S,
 export type _IsStringLiteral<S> =
 // If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
 // and since `{}` extends index signatures, the result becomes `false`.
-S extends string
-	? {} extends Record<S, never>
-		? false
-		: true
-	: false;
+	S extends string
+		? {} extends Record<S, never>
+			? false
+			: true
+		: false;
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).

--- a/source/is-union.d.ts
+++ b/source/is-union.d.ts
@@ -21,20 +21,20 @@ export type IsUnion<T> = InternalIsUnion<T>;
 The actual implementation of `IsUnion`.
 */
 type InternalIsUnion<T, U = T> =
-(
-	IsNever<T> extends true
-		? false
-		: T extends any
-			? IsEqual<U, T> extends true
-				? false
-				: true
-			: never
-) extends infer Result
+	(
+		IsNever<T> extends true
+			? false
+			: T extends any
+				? IsEqual<U, T> extends true
+					? false
+					: true
+				: never
+	) extends infer Result
 	// In some cases `Result` will return `false | true` which is `boolean`,
 	// that means `T` has at least two types and it's a union type,
 	// so we will return `true` instead of `boolean`.
-	? boolean extends Result ? true
-		: Result
-	: never; // Should never happen
+		? boolean extends Result ? true
+			: Result
+		: never; // Should never happen
 
 export {};

--- a/source/iterable-element.d.ts
+++ b/source/iterable-element.d.ts
@@ -57,10 +57,10 @@ type Fruit = IterableElement<typeof fruits>;
 @category Iterable
 */
 export type IterableElement<TargetIterable> =
-	TargetIterable extends Iterable<infer ElementType> ?
-		ElementType :
-		TargetIterable extends AsyncIterable<infer ElementType> ?
-			ElementType :
-			never;
+	TargetIterable extends Iterable<infer ElementType>
+		? ElementType
+		: TargetIterable extends AsyncIterable<infer ElementType>
+			? ElementType
+			: never;
 
 export {};

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -98,13 +98,13 @@ export type Jsonify<T> = IsAny<T> extends true
 		? null
 		: T extends JsonPrimitive
 			? T
-			: // Any object with toJSON is special case
-			T extends {toJSON(): infer J}
+			// Any object with toJSON is special case
+			: T extends {toJSON(): infer J}
 				? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
 					? J // Then T is Jsonable and its Jsonable value is J
 					: Jsonify<J> // Maybe if we look a level deeper we'll find a JsonValue
-				: // Instanced primitives are objects
-				T extends Number
+				// Instanced primitives are objects
+				: T extends Number
 					? number
 					: T extends String
 						? string

--- a/source/keys-of-union.d.ts
+++ b/source/keys-of-union.d.ts
@@ -38,7 +38,7 @@ type AllKeys = KeysOfUnion<Union>;
 @category Object
 */
 export type KeysOfUnion<ObjectType> =
-  // Hack to fix https://github.com/sindresorhus/type-fest/issues/1008
-  keyof UnionToIntersection<ObjectType extends unknown ? Record<keyof ObjectType, never> : never>;
+	// Hack to fix https://github.com/sindresorhus/type-fest/issues/1008
+	keyof UnionToIntersection<ObjectType extends unknown ? Record<keyof ObjectType, never> : never>;
 
 export {};

--- a/source/merge-exclusive.d.ts
+++ b/source/merge-exclusive.d.ts
@@ -38,8 +38,8 @@ exclusiveOptions = {exclusive1: true, exclusive2: 'hi'};
 @category Object
 */
 export type MergeExclusive<FirstType, SecondType> =
-	(FirstType | SecondType) extends object ?
-		(Without<FirstType, SecondType> & SecondType) | (Without<SecondType, FirstType> & FirstType) :
-		FirstType | SecondType;
+	(FirstType | SecondType) extends object
+		? (Without<FirstType, SecondType> & SecondType) | (Without<SecondType, FirstType> & FirstType)
+		: FirstType | SecondType;
 
 export {};

--- a/source/numeric.d.ts
+++ b/source/numeric.d.ts
@@ -121,9 +121,9 @@ declare function setPercentage<T extends number>(length: Float<T>): void;
 @category Numeric
 */
 export type Float<T> =
-T extends unknown // To distributive type
-	? IsFloat<T> extends true ? T : never
-	: never; // Never happens
+	T extends unknown // To distributive type
+		? IsFloat<T> extends true ? T : never
+		: never; // Never happens
 
 /**
 A negative (`-∞ < x < 0`) `number` that is not an integer.

--- a/source/omit-deep.d.ts
+++ b/source/omit-deep.d.ts
@@ -93,34 +93,34 @@ type OmitDeepHelper<T, PathTuple extends UnknownArray> =
 Omit one path from the given object/array.
 */
 type OmitDeepWithOnePath<T, Path extends string | number> =
-T extends NonRecursiveType
-	? T
-	: T extends UnknownArray ? SetArrayAccess<OmitDeepArrayWithOnePath<T, Path>, IsArrayReadonly<T>>
-		: T extends object ? OmitDeepObjectWithOnePath<T, Path>
-			: T;
+	T extends NonRecursiveType
+		? T
+		: T extends UnknownArray ? SetArrayAccess<OmitDeepArrayWithOnePath<T, Path>, IsArrayReadonly<T>>
+			: T extends object ? OmitDeepObjectWithOnePath<T, Path>
+				: T;
 
 /**
 Omit one path from the given object.
 */
 type OmitDeepObjectWithOnePath<ObjectT extends object, P extends string | number> =
-P extends `${infer RecordKeyInPath}.${infer SubPath}`
-	? {
-		[Key in keyof ObjectT]:
-		IsEqual<RecordKeyInPath, ToString<Key>> extends true
-			? ExactKey<ObjectT, Key> extends infer RealKey
-				? RealKey extends keyof ObjectT
-					? OmitDeepWithOnePath<ObjectT[RealKey], SubPath>
+	P extends `${infer RecordKeyInPath}.${infer SubPath}`
+		? {
+			[Key in keyof ObjectT]:
+			IsEqual<RecordKeyInPath, ToString<Key>> extends true
+				? ExactKey<ObjectT, Key> extends infer RealKey
+					? RealKey extends keyof ObjectT
+						? OmitDeepWithOnePath<ObjectT[RealKey], SubPath>
+						: ObjectT[Key]
 					: ObjectT[Key]
 				: ObjectT[Key]
-			: ObjectT[Key]
-	}
-	: ExactKey<ObjectT, P> extends infer Key
-		? IsNever<Key> extends true
-			? ObjectT
-			: Key extends PropertyKey
-				? Omit<ObjectT, Key>
-				: ObjectT
-		: ObjectT;
+		}
+		: ExactKey<ObjectT, P> extends infer Key
+			? IsNever<Key> extends true
+				? ObjectT
+				: Key extends PropertyKey
+					? Omit<ObjectT, Key>
+					: ObjectT
+			: ObjectT;
 
 /**
 Omit one path from from the given array.

--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -699,12 +699,12 @@ Type for [npm's `package.json` file](https://docs.npmjs.com/creating-a-package-j
 @category File
 */
 export type PackageJson =
-	JsonObject &
-	PackageJson.NodeJsStandard &
-	PackageJson.PackageJsonStandard &
-	PackageJson.NonStandardEntryPoints &
-	PackageJson.TypeScriptConfiguration &
-	PackageJson.YarnConfiguration &
-	PackageJson.JSPMConfiguration;
+	JsonObject
+	& PackageJson.NodeJsStandard
+	& PackageJson.PackageJsonStandard
+	& PackageJson.NonStandardEntryPoints
+	& PackageJson.TypeScriptConfiguration
+	& PackageJson.YarnConfiguration
+	& PackageJson.JSPMConfiguration;
 
 export {};

--- a/source/readonly-deep.d.ts
+++ b/source/readonly-deep.d.ts
@@ -83,8 +83,8 @@ export type ReadonlyDeep<T> = T extends BuiltIns
 				? ReadonlyMapDeep<KeyType, ValueType>
 				: T extends Readonly<ReadonlySet<infer ItemType>>
 					? ReadonlySetDeep<ItemType>
-					: // Identify tuples to avoid converting them to arrays inadvertently; special case `readonly [...never[]]`, as it emerges undesirably from recursive invocations of ReadonlyDeep below.
-					T extends readonly [] | readonly [...never[]]
+					// Identify tuples to avoid converting them to arrays inadvertently; special case `readonly [...never[]]`, as it emerges undesirably from recursive invocations of ReadonlyDeep below.
+					: T extends readonly [] | readonly [...never[]]
 						? readonly []
 						: T extends readonly [infer U, ...infer V]
 							? readonly [ReadonlyDeep<U>, ...ReadonlyDeep<V>]

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -110,23 +110,23 @@ type D = RemovePrefix<`handle${Capitalize<string>}`, 'handle'>;
 @category Template literal
 */
 export type RemovePrefix<S extends string, Prefix extends string, Options extends RemovePrefixOptions = {}> =
-IfNotAnyOrNever<
-	S,
 	IfNotAnyOrNever<
-		Prefix,
-		_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>,
-		string,
-		S
-	>
->;
+		S,
+		IfNotAnyOrNever<
+			Prefix,
+			_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>,
+			string,
+			S
+		>
+	>;
 
 type _RemovePrefix<S extends string, Prefix extends string, Options extends Required<RemovePrefixOptions>> =
-Prefix extends string // For distributing `Prefix`
-	? S extends `${Prefix}${infer Rest}`
-		? Or<IsStringLiteral<Prefix>, Not<Options['strict']>> extends true
-			? Rest
-			: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
-		: S // Return back `S` when `Prefix` is not present at the start of `S`
-	: never;
+	Prefix extends string // For distributing `Prefix`
+		? S extends `${Prefix}${infer Rest}`
+			? Or<IsStringLiteral<Prefix>, Not<Options['strict']>> extends true
+				? Rest
+				: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
+			: S // Return back `S` when `Prefix` is not present at the start of `S`
+		: never;
 
 export {};

--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -27,7 +27,7 @@ declare function replace<
 >(
 	input: Input,
 	search: Search,
-	replacement: Replacement
+	replacement: Replacement,
 ): Replace<Input, Search, Replacement>;
 
 declare function replaceAll<
@@ -37,7 +37,7 @@ declare function replaceAll<
 >(
 	input: Input,
 	search: Search,
-	replacement: Replacement
+	replacement: Replacement,
 ): Replace<Input, Search, Replacement, {all: true}>;
 
 // The return type is the exact string literal, not just `string`.

--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -40,11 +40,9 @@ type _RequireAtLeastOne<
 	KeysType extends keyof ObjectType,
 > = {
 	// For each `Key` in `KeysType` make a mapped type:
-	[Key in KeysType]-?: Required<Pick<ObjectType, Key>> & // 1. Make `Key`'s type required
-	// 2. Make all other keys in `KeysType` optional
-		Partial<Pick<ObjectType, Exclude<KeysType, Key>>>;
-}[KeysType] &
-// 3. Add the remaining keys not in `KeysType`
-Except<ObjectType, KeysType>;
+	[Key in KeysType]-?: Required<Pick<ObjectType, Key>> // 1. Make `Key`'s type required
+		& Partial<Pick<ObjectType, Exclude<KeysType, Key>>>; // 2. Make all other keys in `KeysType` optional
+}[KeysType]
+& Except<ObjectType, KeysType>; // 3. Add the remaining keys not in `KeysType`
 
 export {};

--- a/source/require-exactly-one.d.ts
+++ b/source/require-exactly-one.d.ts
@@ -41,8 +41,8 @@ export type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = ke
 
 type _RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType> =
 	{[Key in KeysType]: (
-		Required<Pick<ObjectType, Key>> &
-		Partial<Record<Exclude<KeysType, Key>, never>>
+		Required<Pick<ObjectType, Key>>
+		& Partial<Record<Exclude<KeysType, Key>, never>>
 	)}[KeysType] & Omit<ObjectType, KeysType>;
 
 export {};

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -32,10 +32,10 @@ export type SetOptional<BaseType, Keys extends keyof BaseType> =
 type _SetOptional<BaseType, Keys extends keyof BaseType> =
 	BaseType extends unknown // To distribute `BaseType` when it's a union type.
 		? Simplify<
-		// Pick just the keys that are readonly from the base type.
-			Except<BaseType, Keys> &
-		// Pick the keys that should be mutable from the base type and make them mutable.
-			Partial<HomomorphicPick<BaseType, Keys>>
+			// Pick just the keys that are readonly from the base type.
+			Except<BaseType, Keys>
+			// Pick the keys that should be mutable from the base type and make them mutable.
+			& Partial<HomomorphicPick<BaseType, Keys>>
 		>
 		: never;
 

--- a/source/set-readonly.d.ts
+++ b/source/set-readonly.d.ts
@@ -32,8 +32,8 @@ export type SetReadonly<BaseType, Keys extends keyof BaseType> =
 export type _SetReadonly<BaseType, Keys extends keyof BaseType> =
 	BaseType extends unknown // To distribute `BaseType` when it's a union type.
 		? Simplify<
-			Except<BaseType, Keys> &
-			Readonly<HomomorphicPick<BaseType, Keys>>
+			Except<BaseType, Keys>
+			& Readonly<HomomorphicPick<BaseType, Keys>>
 		>
 		: never;
 

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -43,9 +43,9 @@ type _SetRequired<BaseType, Keys extends keyof BaseType> =
 			: never
 		: Simplify<
 		// Pick just the keys that are optional from the base type.
-			Except<BaseType, Keys> &
+			Except<BaseType, Keys>
 		// Pick the keys that should be required from the base type and make them required.
-			Required<HomomorphicPick<BaseType, Keys>>
+			& Required<HomomorphicPick<BaseType, Keys>>
 		>;
 
 /**

--- a/source/shared-union-fields.d.ts
+++ b/source/shared-union-fields.d.ts
@@ -66,14 +66,14 @@ function displayPetInfoWithSharedUnionFields(petInfo: SharedUnionFields<Cat | Do
 @category Union
 */
 export type SharedUnionFields<Union> =
-Extract<Union, NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray> extends infer SkippedMembers
-	? Exclude<Union, SkippedMembers> extends infer RelevantMembers
-		?
-		| SkippedMembers
-		| (IsNever<RelevantMembers> extends true
-			? never
-			: Simplify<Pick<RelevantMembers, keyof RelevantMembers>>)
-		: never
-	: never;
+	Extract<Union, NonRecursiveType | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown> | UnknownArray> extends infer SkippedMembers
+		? Exclude<Union, SkippedMembers> extends infer RelevantMembers
+			? // eslint-disable-line @stylistic/operator-linebreak
+			| SkippedMembers
+			| (IsNever<RelevantMembers> extends true
+				? never
+				: Simplify<Pick<RelevantMembers, keyof RelevantMembers>>)
+			: never
+		: never;
 
 export {};

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -129,7 +129,7 @@ type WontWork = UnwrapTagged<string>;
 @category Type
 */
 export type UnwrapTagged<TaggedType extends Tag<PropertyKey, any>> =
-RemoveAllTags<TaggedType>;
+	RemoveAllTags<TaggedType>;
 
 type RemoveAllTags<T> = T extends Tag<PropertyKey, any>
 	? {

--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -38,8 +38,8 @@ const petList = Object.keys(pets) as UnionToTuple<Pet>;
 @category Array
 */
 export type UnionToTuple<T, L = UnionMember<T>> =
-IsNever<T> extends false
-	? [...UnionToTuple<ExcludeExactly<T, L>>, L]
-	: [];
+	IsNever<T> extends false
+		? [...UnionToTuple<ExcludeExactly<T, L>>, L]
+		: [];
 
 export {};

--- a/source/writable.d.ts
+++ b/source/writable.d.ts
@@ -50,19 +50,19 @@ writableArray.push(4); // Will work as the array itself is now writable.
 @category Object
 */
 export type Writable<BaseType, Keys extends keyof BaseType = keyof BaseType> =
-BaseType extends ReadonlyMap<infer KeyType, infer ValueType>
-	? Map<KeyType, ValueType>
-	: BaseType extends ReadonlySet<infer ItemType>
-		? Set<ItemType>
-		: BaseType extends readonly unknown[]
-			// Handle array
-			? WritableArray<BaseType>
-			// Handle object
-			: Simplify<
-			// Pick just the keys that are not writable from the base type.
-				Except<BaseType, Keys> &
-			// Pick the keys that should be writable from the base type and make them writable by removing the `readonly` modifier from the key.
-				{-readonly [KeyType in keyof Pick<BaseType, Keys>]: Pick<BaseType, Keys>[KeyType]}
-			>;
+	BaseType extends ReadonlyMap<infer KeyType, infer ValueType>
+		? Map<KeyType, ValueType>
+		: BaseType extends ReadonlySet<infer ItemType>
+			? Set<ItemType>
+			: BaseType extends readonly unknown[]
+				// Handle array
+				? WritableArray<BaseType>
+				// Handle object
+				: Simplify<
+					// Pick just the keys that are not writable from the base type.
+					Except<BaseType, Keys>
+					// Pick the keys that should be writable from the base type and make them writable by removing the `readonly` modifier from the key.
+					& {-readonly [KeyType in keyof Pick<BaseType, Keys>]: Pick<BaseType, Keys>[KeyType]}
+				>;
 
 export {};

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -30,8 +30,8 @@ expectType<'foo#bar'>(delimiterFromPascal);
 const delimiterFromKebab: DelimiterCase<'foo-bar', '#'> = 'foo#bar';
 expectType<'foo#bar'>(delimiterFromKebab);
 
-const delimiterFromComplexKebab: DelimiterCase<'foo-bar-abc-123', '#'>
-	= 'foo#bar#abc#123';
+const delimiterFromComplexKebab: DelimiterCase<'foo-bar-abc-123', '#'> =
+	'foo#bar#abc#123';
 expectType<'foo#bar#abc#123'>(delimiterFromComplexKebab);
 
 const delimiterFromSpace: DelimiterCase<'foo bar', '#'> = 'foo#bar';
@@ -46,8 +46,8 @@ expectType<'foo#bar'>(delimiterFromSnake);
 const noDelimiterFromMono: DelimiterCase<'foobar', '#'> = 'foobar';
 expectType<'foobar'>(noDelimiterFromMono);
 
-const delimiterFromMixed: DelimiterCase<'foo-bar_abc xyzBarFoo', '#'>
-	= 'foo#bar#abc#xyz#bar#foo';
+const delimiterFromMixed: DelimiterCase<'foo-bar_abc xyzBarFoo', '#'> =
+	'foo#bar#abc#xyz#bar#foo';
 expectType<'foo#bar#abc#xyz#bar#foo'>(delimiterFromMixed);
 
 const delimiterFromVendorPrefixedCssProperty: DelimiterCase<
@@ -56,12 +56,12 @@ const delimiterFromVendorPrefixedCssProperty: DelimiterCase<
 > = 'webkit#animation';
 expectType<'webkit#animation'>(delimiterFromVendorPrefixedCssProperty);
 
-const delimiterFromDoublePrefixedKebab: DelimiterCase<'--very-prefixed', '#'>
-	= 'very#prefixed';
+const delimiterFromDoublePrefixedKebab: DelimiterCase<'--very-prefixed', '#'> =
+	'very#prefixed';
 expectType<'very#prefixed'>(delimiterFromDoublePrefixedKebab);
 
-const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'>
-	= 'foo#bar';
+const delimiterFromRepeatedSeparators: DelimiterCase<'foo____bar', '#'> =
+	'foo#bar';
 expectType<'foo#bar'>(delimiterFromRepeatedSeparators);
 
 const delimiterFromString: DelimiterCase<string, '#'> = 'foobar';
@@ -73,8 +73,8 @@ expectType<'foo#bar'>(delimiterFromScreamingSnake);
 const delimiterFromMixed2: DelimiterCase<'parseHTML', '#'> = 'parse#html';
 expectType<'parse#html'>(delimiterFromMixed2);
 
-const delimiterFromMixed3: DelimiterCase<'parseHTMLItem', '#'>
-	= 'parse#html#item';
+const delimiterFromMixed3: DelimiterCase<'parseHTMLItem', '#'> =
+	'parse#html#item';
 expectType<'parse#html#item'>(delimiterFromMixed3);
 
 const delimiterFromNumberInTheMiddleSplitOnNumbers: DelimiterCase<'foo2bar', '#', {splitOnNumbers: true}> = 'foo#2#bar';

--- a/test-d/exact.ts
+++ b/test-d/exact.ts
@@ -27,7 +27,7 @@ import type {Exact, Opaque} from '../index.d.ts';
 	const function_ = <T extends Exact<Type, T>>(arguments_: T) => arguments_;
 
 	{ // It should accept bigint
-		const input = BigInt(9_007_199_254_740_991);
+		const input = 9_007_199_254_740_991n;
 		function_(input);
 	}
 

--- a/test-d/internal/has-multiple-call-signatures.ts
+++ b/test-d/internal/has-multiple-call-signatures.ts
@@ -8,7 +8,6 @@ type Overloaded = {
 
 type Overloaded2 = {
 	(foo: number | undefined): string;
-	// eslint-disable-next-line @typescript-eslint/unified-signatures
 	(foo: number): string;
 };
 

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -11,8 +11,7 @@ import type {
 
 const stringLiteral = '';
 const numberLiteral = 1;
-// Note: tsd warns on direct literal usage so we cast to the literal type
-const bigintLiteral = BigInt(1) as 1n;
+const bigintLiteral = 1n;
 const booleanLiteral = true;
 const symbolLiteral = Symbol('');
 

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -113,7 +113,7 @@ expectAssignable<JsonValue>(nonJsonWithToJSON.toJSON());
 expectAssignable<Jsonify<NonJsonWithToJSON>>(nonJsonWithToJSON.toJSON());
 
 class NonJsonExtendPrimitiveWithToJSON extends Number {
-	public fixture = BigInt('42');
+	public fixture = 42n;
 
 	public toJSON(): {fixture: string} {
 		return {

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -25,16 +25,16 @@ expectType<'foo-bar'>(kebabFromCamelPascal);
 const kebabFromComplexKebab: KebabCase<'foo-bar-abc-123'> = 'foo-bar-abc-123';
 expectType<'foo-bar-abc-123'>(kebabFromComplexKebab);
 
-const kebabFromMixed: KebabCase<'foo-bar_abc xyzBarFoo'>
-	= 'foo-bar-abc-xyz-bar-foo';
+const kebabFromMixed: KebabCase<'foo-bar_abc xyzBarFoo'> =
+	'foo-bar-abc-xyz-bar-foo';
 expectType<'foo-bar-abc-xyz-bar-foo'>(kebabFromMixed);
 
-const kebabFromVendorPrefixedCssProperty: KebabCase<'-webkit-animation'>
-	= 'webkit-animation';
+const kebabFromVendorPrefixedCssProperty: KebabCase<'-webkit-animation'> =
+	'webkit-animation';
 expectType<'webkit-animation'>(kebabFromVendorPrefixedCssProperty);
 
-const kebabFromDoublePrefixedKebab: KebabCase<'--very-prefixed'>
-	= 'very-prefixed';
+const kebabFromDoublePrefixedKebab: KebabCase<'--very-prefixed'> =
+	'very-prefixed';
 expectType<'very-prefixed'>(kebabFromDoublePrefixedKebab);
 
 const kebabFromRepeatedSeparators: KebabCase<'foo____bar'> = 'foo-bar';

--- a/test-d/observable-like.ts
+++ b/test-d/observable-like.ts
@@ -1,7 +1,6 @@
 import {expectType, expectAssignable} from 'tsd';
 import type {ObservableLike} from '../source/globals/index.d.ts';
 
-// eslint-disable-next-line no-use-extend-native/no-use-extend-native
 expectAssignable<symbol>(Symbol.observable);
 
 const observable = (null as any) as ObservableLike;

--- a/test-d/package-json.ts
+++ b/test-d/package-json.ts
@@ -55,14 +55,14 @@ expectType<boolean | undefined>(packageJson.engineStrict);
 expectAssignable<
 	| undefined
 	| Array<LiteralUnion<
-'darwin' | 'linux' | 'win32' | '!darwin' | '!linux' | '!win32',
+		'darwin' | 'linux' | 'win32' | '!darwin' | '!linux' | '!win32',
 		string
 	>>
 >(packageJson.os);
 expectAssignable<
 	| undefined
 	| Array<LiteralUnion<
-'x64' | 'ia32' | 'arm' | 'mips' | '!x64' | '!ia32' | '!arm' | '!mips',
+		'x64' | 'ia32' | 'arm' | 'mips' | '!x64' | '!ia32' | '!arm' | '!mips',
 		string
 	>>
 >(packageJson.cpu);

--- a/test-d/replace.ts
+++ b/test-d/replace.ts
@@ -8,7 +8,7 @@ declare function replace<
 >(
 	input: Input,
 	search: Search,
-	replacement: Replacement
+	replacement: Replacement,
 ): Replace<Input, Search, Replacement>;
 
 declare function replaceAll<
@@ -18,7 +18,7 @@ declare function replaceAll<
 >(
 	input: Input,
 	search: Search,
-	replacement: Replacement
+	replacement: Replacement,
 ): Replace<Input, Search, Replacement, {all: true}>;
 
 expectType<'hello 🦄'>(replace('hello ?', '?', '🦄'));

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -19,7 +19,7 @@ const foo = {
 		readonlySet: new Set<string>() as ReadonlySet<string>,
 		readonlyArray: ['foo'] as readonly string[],
 		readonlyTuple: ['foo'] as const,
-		regExp: /.*/g,
+		regExp: /.*/gv,
 	},
 };
 

--- a/test-d/screaming-snake-case.ts
+++ b/test-d/screaming-snake-case.ts
@@ -22,20 +22,20 @@ expectType<'FOOBAR'>(noSnakeFromMono);
 const snakeFromCamelPascal: ScreamingSnakeCase<'FooBar'> = 'FOO_BAR';
 expectType<'FOO_BAR'>(snakeFromCamelPascal);
 
-const snakeFromComplexKebab: ScreamingSnakeCase<'foo-bar-abc-123'>
-	= 'FOO_BAR_ABC_123';
+const snakeFromComplexKebab: ScreamingSnakeCase<'foo-bar-abc-123'> =
+	'FOO_BAR_ABC_123';
 expectType<'FOO_BAR_ABC_123'>(snakeFromComplexKebab);
 
-const snakeFromMixed: ScreamingSnakeCase<'foo-bar_abc xyzBarFoo'>
-	= 'FOO_BAR_ABC_XYZ_BAR_FOO';
+const snakeFromMixed: ScreamingSnakeCase<'foo-bar_abc xyzBarFoo'> =
+	'FOO_BAR_ABC_XYZ_BAR_FOO';
 expectType<'FOO_BAR_ABC_XYZ_BAR_FOO'>(snakeFromMixed);
 
-const snakeFromVendorPrefixedCssProperty: ScreamingSnakeCase<'-webkit-animation'>
-	= 'WEBKIT_ANIMATION';
+const snakeFromVendorPrefixedCssProperty: ScreamingSnakeCase<'-webkit-animation'> =
+	'WEBKIT_ANIMATION';
 expectType<'WEBKIT_ANIMATION'>(snakeFromVendorPrefixedCssProperty);
 
-const snakeFromDoublePrefixedKebab: ScreamingSnakeCase<'--very-prefixed'>
-	= 'VERY_PREFIXED';
+const snakeFromDoublePrefixedKebab: ScreamingSnakeCase<'--very-prefixed'> =
+	'VERY_PREFIXED';
 expectType<'VERY_PREFIXED'>(snakeFromDoublePrefixedKebab);
 
 const snakeFromRepeatedSeparators: ScreamingSnakeCase<'foo____bar'> = 'FOO_BAR';

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -25,16 +25,16 @@ expectType<'foo_bar'>(snakeFromCamelPascal);
 const snakeFromComplexKebab: SnakeCase<'foo-bar-abc-123'> = 'foo_bar_abc_123';
 expectType<'foo_bar_abc_123'>(snakeFromComplexKebab);
 
-const snakeFromMixed: SnakeCase<'foo-bar_abc xyzBarFoo'>
-	= 'foo_bar_abc_xyz_bar_foo';
+const snakeFromMixed: SnakeCase<'foo-bar_abc xyzBarFoo'> =
+	'foo_bar_abc_xyz_bar_foo';
 expectType<'foo_bar_abc_xyz_bar_foo'>(snakeFromMixed);
 
-const snakeFromVendorPrefixedCssProperty: SnakeCase<'-webkit-animation'>
-	= 'webkit_animation';
+const snakeFromVendorPrefixedCssProperty: SnakeCase<'-webkit-animation'> =
+	'webkit_animation';
 expectType<'webkit_animation'>(snakeFromVendorPrefixedCssProperty);
 
-const snakeFromDoublePrefixedKebab: SnakeCase<'--very-prefixed'>
-	= 'very_prefixed';
+const snakeFromDoublePrefixedKebab: SnakeCase<'--very-prefixed'> =
+	'very_prefixed';
 expectType<'very_prefixed'>(snakeFromDoublePrefixedKebab);
 
 const snakeFromRepeatedSeparators: SnakeCase<'foo____bar'> = 'foo_bar';
@@ -58,16 +58,16 @@ expectType<'parse_html'>(snakeFromMixed2);
 const snakeFromMixed3: SnakeCase<'parseHTMLItem'> = 'parse_html_item';
 expectType<'parse_html_item'>(snakeFromMixed3);
 
-const snakeFromNumberInTheMiddleSplitOnNumbers: SnakeCase<'foo2bar', {splitOnNumbers: true}>
-	= 'foo_2_bar';
+const snakeFromNumberInTheMiddleSplitOnNumbers: SnakeCase<'foo2bar', {splitOnNumbers: true}> =
+	'foo_2_bar';
 expectType<'foo_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbers);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: SnakeCase<'foO2Bar', {splitOnNumbers: true}>
-	= 'fo_o_2_bar';
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase: SnakeCase<'foO2Bar', {splitOnNumbers: true}> =
+	'fo_o_2_bar';
 expectType<'fo_o_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase);
 
-const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: SnakeCase<'foO2bar', {splitOnNumbers: true}>
-	= 'fo_o_2_bar';
+const snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2: SnakeCase<'foO2bar', {splitOnNumbers: true}> =
+	'fo_o_2_bar';
 expectType<'fo_o_2_bar'>(snakeFromNumberInTheMiddleSplitOnNumbersEdgeCase2);
 
 const snakeFromNumberInTheMiddleNoSplitOnNumbers: SnakeCase<'foo2bar'> = 'foo2bar';

--- a/xo.config.js
+++ b/xo.config.js
@@ -26,9 +26,12 @@ const xoConfig = [
 			'@typescript-eslint/consistent-indexed-object-style': 'off',
 			'@typescript-eslint/unified-signatures': 'off', // Temp
 			'@typescript-eslint/no-unnecessary-type-arguments': 'off',
+			'@typescript-eslint/no-unsafe-type-assertion': 'off',
 			'@stylistic/quote-props': 'off',
 			'@stylistic/function-paren-newline': 'off',
 			'@stylistic/object-curly-newline': 'off',
+			'@stylistic/curly-newline': 'off',
+			'@stylistic/operator-linebreak': ['error', 'before', {overrides: {'=': 'after'}}],
 			'n/file-extension-in-import': 'off',
 			'object-curly-newline': [
 				'error',
@@ -44,7 +47,7 @@ const xoConfig = [
 		},
 	},
 	{
-		files: 'source/**/*.d.ts',
+		files: ['source/**/*.d.ts', 'index.d.ts'],
 		rules: {
 			'no-restricted-imports': [
 				'error',
@@ -52,6 +55,14 @@ const xoConfig = [
 					paths: ['tsd', 'expect-type'],
 				},
 			],
+			'unicorn/require-module-specifiers': 'off',
+		},
+	},
+	{
+		files: 'test-d/**/*.ts',
+		rules: {
+			'unicorn/no-immediate-mutation': 'off',
+			'require-unicode-regexp': 'off',
 		},
 	},
 	{
@@ -110,6 +121,7 @@ const xoConfig = [
 			'@stylistic/eol-last': 'off',
 			'capitalized-comments': 'off',
 			'unicorn/prefer-structured-clone': 'off',
+			'unicorn/no-immediate-mutation': 'off',
 		},
 	},
 	{


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Update to XO v2 & ESLint v10.

Majority of the changes in this PR are styling-related. The ones which are not are also pretty simple, like:
- Replacing `.sort` with `.toSorted`.
- Replacing `BigInt` constructor calls to bigint literals.
- Adding `v` flag to regular expression.