### PR TITLE
Align behavior of [Camel|Pascal|Kebab|Snake]-Cased types with lodash

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -48,14 +48,9 @@ import type {CamelCase} from 'type-fest';
 
 // Simple
 
-type CamelCase1 = CamelCase<'foo-bar'>;
-//=> 'fooBar'
-
-type CamelCase2 = CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}>;
-//=> 'fooBARBaz'
-
-type CamelCase3 = CamelCase<'foo-bar:BAZ', {splitOnPunctuation: true}>;
-//=> 'fooBarBaz'
+const someVariable: CamelCase<'foo-bar'> = 'fooBar';
+const preserveConsecutiveUppercase: CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'fooBARBaz';
+const splitOnPunctuation: CamelCase<'foo-bar:BAZ', {splitOnPunctuation: true}> = 'fooBarBaz';
 
 // Advanced
 

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -1,5 +1,5 @@
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
-import type {Words, WordsOptions} from './words.d.ts';
+import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
 
 /**
 CamelCase options.
@@ -15,8 +15,7 @@ export type CamelCaseOptions = WordsOptions & {
 	preserveConsecutiveUppercase?: boolean;
 };
 
-export type _DefaultCamelCaseOptions = {
-	splitOnNumbers: true;
+export type _DefaultCamelCaseOptions = _DefaultWordsOptions & {
 	preserveConsecutiveUppercase: false;
 };
 
@@ -49,8 +48,14 @@ import type {CamelCase} from 'type-fest';
 
 // Simple
 
-const someVariable: CamelCase<'foo-bar'> = 'fooBar';
-const preserveConsecutiveUppercase: CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'fooBARBaz';
+type CamelCase1 = CamelCase<'foo-bar'>;
+//=> 'fooBar'
+
+type CamelCase2 = CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}>;
+//=> 'fooBARBaz'
+
+type CamelCase3 = CamelCase<'foo-bar:BAZ', {splitOnPunctuation: true}>;
+//=> 'fooBarBaz'
 
 // Advanced
 

--- a/source/camel-cased-properties-deep.d.ts
+++ b/source/camel-cased-properties-deep.d.ts
@@ -48,6 +48,13 @@ const preserveConsecutiveUppercase: CamelCasedPropertiesDeep<{fooBAR: {fooBARBiz
 		}],
 	},
 };
+
+const splitOnPunctuation: CamelCasedPropertiesDeep<{'user@info': {'user::id': number; 'user::name': string}}, {splitOnPunctuation: true}> = {
+	userInfo: {
+		userId: 1,
+		userName: 'Tom',
+	},
+};
 ```
 
 @category Change case

--- a/source/camel-cased-properties.d.ts
+++ b/source/camel-cased-properties.d.ts
@@ -26,6 +26,10 @@ const result: CamelCasedProperties<User> = {
 const preserveConsecutiveUppercase: CamelCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: true}> = {
 	fooBAR: 'string',
 };
+
+const splitOnPunctuation: CamelCasedProperties<{'foo::bar': string}, {splitOnPunctuation: true}> = {
+	fooBar: 'string',
+};
 ```
 
 @category Change case

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -12,12 +12,19 @@ This can be useful when, for example, converting a camel-cased object property t
 import type {KebabCase} from 'type-fest';
 
 // Simple
+type KebabCase1 = KebabCase<'fooBar'>;
+//=> 'foo-bar'
 
-const someVariable: KebabCase<'fooBar'> = 'foo-bar';
-const someVariableNoSplitOnNumbers: KebabCase<'p2pNetwork', {splitOnNumbers: false}> = 'p2p-network';
+type KebabCase2 = KebabCase<'p2pNetwork', {splitOnNumbers: false}>;
+//=> 'p2p-network'
+
+type KebabCase3 = KebabCase<'div.card::after', {splitOnPunctuation: true}>;
+//=> 'div-card-after'
+
+type KebabCase4 = KebabCase<'foo-bar::01', {splitOnPunctuation: true}>
+//=> 'foo-bar-01'
 
 // Advanced
-
 type KebabCasedProperties<T> = {
 	[K in keyof T as KebabCase<K>]: T[K]
 };

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -12,14 +12,10 @@ This can be useful when, for example, converting a camel-cased object property t
 import type {KebabCase} from 'type-fest';
 
 // Simple
-type KebabCase1 = KebabCase<'fooBar'>;
-//=> 'foo-bar'
 
-type KebabCase2 = KebabCase<'p2pNetwork', {splitOnNumbers: false}>;
-//=> 'p2p-network'
-
-type KebabCase3 = KebabCase<'div.card::after', {splitOnPunctuation: true}>;
-//=> 'div-card-after'
+const someVariable: KebabCase<'fooBar'> = 'foo-bar';
+const someVariableNoSplitOnNumbers: KebabCase<'p2pNetwork', {splitOnNumbers: false}> = 'p2p-network';
+const someVariableWithPunctuation: KebabCase<'div.card::after', {splitOnPunctuation: true}> = 'div-card-after';
 
 // Advanced
 type KebabCasedProperties<T> = {

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -21,9 +21,6 @@ type KebabCase2 = KebabCase<'p2pNetwork', {splitOnNumbers: false}>;
 type KebabCase3 = KebabCase<'div.card::after', {splitOnPunctuation: true}>;
 //=> 'div-card-after'
 
-type KebabCase4 = KebabCase<'foo-bar::01', {splitOnPunctuation: true}>;
-//=> 'foo-bar-01'
-
 // Advanced
 type KebabCasedProperties<T> = {
 	[K in keyof T as KebabCase<K>]: T[K]

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -18,6 +18,7 @@ const someVariableNoSplitOnNumbers: KebabCase<'p2pNetwork', {splitOnNumbers: fal
 const someVariableWithPunctuation: KebabCase<'div.card::after', {splitOnPunctuation: true}> = 'div-card-after';
 
 // Advanced
+
 type KebabCasedProperties<T> = {
 	[K in keyof T as KebabCase<K>]: T[K]
 };

--- a/source/kebab-case.d.ts
+++ b/source/kebab-case.d.ts
@@ -21,7 +21,7 @@ type KebabCase2 = KebabCase<'p2pNetwork', {splitOnNumbers: false}>;
 type KebabCase3 = KebabCase<'div.card::after', {splitOnPunctuation: true}>;
 //=> 'div-card-after'
 
-type KebabCase4 = KebabCase<'foo-bar::01', {splitOnPunctuation: true}>
+type KebabCase4 = KebabCase<'foo-bar::01', {splitOnPunctuation: true}>;
 //=> 'foo-bar-01'
 
 // Advanced

--- a/source/kebab-cased-properties-deep.d.ts
+++ b/source/kebab-cased-properties-deep.d.ts
@@ -51,6 +51,13 @@ const splitOnNumbers: KebabCasedPropertiesDeep<{line1: {line2: [{line3: string}]
 		],
 	},
 };
+
+const splitOnPunctuation: KebabCasedPropertiesDeep<{'user@info': {'user::id': number; 'user::name': string}}, {splitOnPunctuation: true}> = {
+	'user-info': {
+		'user-id': 1,
+		'user-name': 'Tom',
+	},
+};
 ```
 
 @category Change case

--- a/source/kebab-cased-properties.d.ts
+++ b/source/kebab-cased-properties.d.ts
@@ -28,6 +28,10 @@ const result: KebabCasedProperties<User> = {
 const splitOnNumbers: KebabCasedProperties<{line1: string}, {splitOnNumbers: true}> = {
 	'line-1': 'string',
 };
+
+const splitOnPunctuation: KebabCasedProperties<{'foo::bar': string}, {splitOnPunctuation: true}> = {
+	'foo-bar': 'string',
+};
 ```
 
 @category Change case

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -10,14 +10,9 @@ import type {PascalCase} from 'type-fest';
 
 // Simple
 
-type PascalCase1 = PascalCase<'foo-bar'>;
-//=> 'FooBar'
-
-type PascalCase2 = PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}>;
-//=> 'FooBARBaz'
-
-type PascalCase3 = PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}>;
-//=> 'FooBarBaz'
+const someVariable: PascalCase<'foo-bar'> = 'FooBar';
+const preserveConsecutiveUppercase: PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'FooBARBaz';
+const splitOnPunctuation: PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}> = 'FooBarBaz';
 
 // Advanced
 
@@ -54,4 +49,5 @@ type _PascalCase<Value, Options extends Required<CamelCaseOptions>> = CamelCase<
 	? Capitalize<CamelCase<Value, Options>>
 	: CamelCase<Value, Options>;
 
-export {};
+export { };
+

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -50,4 +50,3 @@ type _PascalCase<Value, Options extends Required<CamelCaseOptions>> = CamelCase<
 	: CamelCase<Value, Options>;
 
 export {};
-

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -10,8 +10,15 @@ import type {PascalCase} from 'type-fest';
 
 // Simple
 
-const someVariable: PascalCase<'foo-bar'> = 'FooBar';
-const preserveConsecutiveUppercase: PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'FooBARBaz';
+type PascalCase1 = PascalCase<'foo-bar'>;
+//=> 'FooBar'
+
+type PascalCase2 = PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}>;
+//=> 'FooBARBaz'
+
+type PascalCase3 = PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}>;
+//=> 'FooBarBaz'
+
 
 // Advanced
 

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -19,7 +19,6 @@ type PascalCase2 = PascalCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true
 type PascalCase3 = PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}>;
 //=> 'FooBarBaz'
 
-
 // Advanced
 
 type PascalCasedProperties<T> = {

--- a/source/pascal-case.d.ts
+++ b/source/pascal-case.d.ts
@@ -49,5 +49,5 @@ type _PascalCase<Value, Options extends Required<CamelCaseOptions>> = CamelCase<
 	? Capitalize<CamelCase<Value, Options>>
 	: CamelCase<Value, Options>;
 
-export { };
+export {};
 

--- a/source/pascal-cased-properties-deep.d.ts
+++ b/source/pascal-cased-properties-deep.d.ts
@@ -48,6 +48,13 @@ const preserveConsecutiveUppercase: PascalCasedPropertiesDeep<{fooBAR: {fooBARBi
 		}],
 	},
 };
+
+const splitOnPunctuation: PascalCasedPropertiesDeep<{'user@info': {'user::id': number; 'user::name': string}}, {splitOnPunctuation: true}> = {
+	UserInfo: {
+		UserId: 1,
+		UserName: 'Tom',
+	},
+};
 ```
 
 @category Change case

--- a/source/pascal-cased-properties.d.ts
+++ b/source/pascal-cased-properties.d.ts
@@ -27,6 +27,10 @@ const result: PascalCasedProperties<User> = {
 const preserveConsecutiveUppercase: PascalCasedProperties<{fooBAR: string}, {preserveConsecutiveUppercase: true}> = {
 	FooBAR: 'string',
 };
+
+const splitOnPunctuation: PascalCasedProperties<{'foo::bar': string}, {splitOnPunctuation: true}> = {
+	FooBar: 'string',
+};
 ```
 
 @category Change case

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -12,10 +12,17 @@ This can be useful when, for example, converting a camel-cased object property t
 import type {SnakeCase} from 'type-fest';
 
 // Simple
+type SnakeCase1 = SnakeCase<'fooBar'>;
+//=> 'foo_bar'
 
-const someVariable: SnakeCase<'fooBar'> = 'foo_bar';
-const noSplitOnNumbers: SnakeCase<'p2pNetwork'> = 'p2p_network';
-const splitOnNumbers: SnakeCase<'p2pNetwork', {splitOnNumbers: true}> = 'p_2_p_network';
+type SnakeCase2 = SnakeCase<'p2pNetwork', {splitOnNumbers: false}>;
+//=> 'p2p_network'
+
+type SnakeCase3 = SnakeCase<'div.card::after', {splitOnPunctuation: true}>;
+//=> 'div_card_after'
+
+type SnakeCase4 = SnakeCase<'foo-bar::01', {splitOnPunctuation: true}>;
+//=> 'foo_bar_01'
 
 // Advanced
 

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -12,14 +12,11 @@ This can be useful when, for example, converting a camel-cased object property t
 import type {SnakeCase} from 'type-fest';
 
 // Simple
-type SnakeCase1 = SnakeCase<'fooBar'>;
-//=> 'foo_bar'
 
-type SnakeCase2 = SnakeCase<'p2pNetwork', {splitOnNumbers: false}>;
-//=> 'p2p_network'
-
-type SnakeCase3 = SnakeCase<'div.card::after', {splitOnPunctuation: true}>;
-//=> 'div_card_after'
+const someVariable: SnakeCase<'fooBar'> = 'foo_bar';
+const noSplitOnNumbers: SnakeCase<'p2pNetwork'> = 'p2p_network';
+const splitOnNumbers: SnakeCase<'p2pNetwork', {splitOnNumbers: true}> = 'p_2_p_network';
+const splitOnPunctuation: SnakeCase<'div.card::after', {splitOnPunctuation: true}> = 'div_card_after';
 
 // Advanced
 

--- a/source/snake-case.d.ts
+++ b/source/snake-case.d.ts
@@ -21,9 +21,6 @@ type SnakeCase2 = SnakeCase<'p2pNetwork', {splitOnNumbers: false}>;
 type SnakeCase3 = SnakeCase<'div.card::after', {splitOnPunctuation: true}>;
 //=> 'div_card_after'
 
-type SnakeCase4 = SnakeCase<'foo-bar::01', {splitOnPunctuation: true}>;
-//=> 'foo_bar_01'
-
 // Advanced
 
 type SnakeCasedProperties<T> = {

--- a/source/snake-cased-properties-deep.d.ts
+++ b/source/snake-cased-properties-deep.d.ts
@@ -51,6 +51,13 @@ const splitOnNumbers: SnakeCasedPropertiesDeep<{line1: {line2: [{line3: string}]
 		],
 	},
 };
+
+const splitOnPunctuation: SnakeCasedPropertiesDeep<{'user@info': {'user::id': number; 'user::name': string}}, {splitOnPunctuation: true}> = {
+	'user_info': {
+		'user_id': 1,
+		'user_name': 'Tom',
+	},
+};
 ```
 
 @category Change case

--- a/source/snake-cased-properties.d.ts
+++ b/source/snake-cased-properties.d.ts
@@ -28,6 +28,10 @@ const result: SnakeCasedProperties<User> = {
 const splitOnNumbers: SnakeCasedProperties<{line1: string}, {splitOnNumbers: true}> = {
 	'line_1': 'string',
 };
+
+const splitOnPunctuation: SnakeCasedProperties<{'foo::bar': string}, {splitOnPunctuation: true}> = {
+	'foo_bar': 'string',
+};
 ```
 
 @category Change case

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -110,114 +110,37 @@ type WordsImplementation<
 	LastCharacter extends string = '',
 	CurrentWord extends string = '',
 > = Sentence extends `${infer FirstCharacter}${infer RemainingCharacters}`
-	? FirstCharacter extends
-	| WordSeparators
-	| (Options['splitOnPunctuation'] extends true ? AsciiPunctuation : never)
-		? // Skip word separator
-		[
-			...SkipEmptyWord<CurrentWord>,
-			...WordsImplementation<RemainingCharacters, Options>,
-		]
+	? FirstCharacter extends WordSeparators | (Options['splitOnPunctuation'] extends true ? AsciiPunctuation : never)
+		// Skip word separator
+		? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options>]
 		: LastCharacter extends ''
-			? // Fist char of word
-			WordsImplementation<
-				RemainingCharacters,
-				Options,
-				FirstCharacter,
-				FirstCharacter
-			>
-			: // Case change: non-numeric to numeric
-			[false, true] extends [
-				IsNumeric<LastCharacter>,
-				IsNumeric<FirstCharacter>,
-			]
+			// Fist char of word
+			? WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>
+			// Case change: non-numeric to numeric
+			: [false, true] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
 				? Options['splitOnNumbers'] extends true
-					? // Split on number: push word
-					[
-						...SkipEmptyWord<CurrentWord>,
-						...WordsImplementation<
-							RemainingCharacters,
-							Options,
-							FirstCharacter,
-							FirstCharacter
-						>,
-					]
-					: // No split on number: concat word
-					WordsImplementation<
-						RemainingCharacters,
-						Options,
-						FirstCharacter,
-							`${CurrentWord}${FirstCharacter}`
-					>
-				: // Case change: numeric to non-numeric
-				[true, false] extends [
-					IsNumeric<LastCharacter>,
-					IsNumeric<FirstCharacter>,
-				]
+					// Split on number: push word
+					? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
+					// No split on number: concat word
+					: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
+				// Case change: numeric to non-numeric
+				: [true, false] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
 					? Options['splitOnNumbers'] extends true
-						? // Split on number: push word
-						[
-							...SkipEmptyWord<CurrentWord>,
-							...WordsImplementation<
-								RemainingCharacters,
-								Options,
-								FirstCharacter,
-								FirstCharacter
-							>,
-						]
-						: // No split on number: concat word
-						WordsImplementation<
-							RemainingCharacters,
-							Options,
-							FirstCharacter,
-								`${CurrentWord}${FirstCharacter}`
-						>
-					: // No case change: concat word
-					[true, true] extends [
-						IsNumeric<LastCharacter>,
-						IsNumeric<FirstCharacter>,
-					]
-						? WordsImplementation<
-							RemainingCharacters,
-							Options,
-							FirstCharacter,
-								`${CurrentWord}${FirstCharacter}`
-						>
-						: // Case change: lower to upper, push word
-						[true, true] extends [
-							IsLowercase<LastCharacter>,
-							IsUppercase<FirstCharacter>,
-						]
-							? [
-								...SkipEmptyWord<CurrentWord>,
-								...WordsImplementation<
-									RemainingCharacters,
-									Options,
-									FirstCharacter,
-									FirstCharacter
-								>,
-							]
-							: // Case change: upper to lower, brings back the last character, push word
-							[true, true] extends [
-								IsUppercase<LastCharacter>,
-								IsLowercase<FirstCharacter>,
-							]
-								? [
-									...RemoveLastCharacter<CurrentWord, LastCharacter>,
-									...WordsImplementation<
-										RemainingCharacters,
-										Options,
-										FirstCharacter,
-											`${LastCharacter}${FirstCharacter}`
-									>,
-								]
-								: // No case change: concat word
-								WordsImplementation<
-									RemainingCharacters,
-									Options,
-									FirstCharacter,
-										`${CurrentWord}${FirstCharacter}`
-								>
+						// Split on number: push word
+						? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
+						// No split on number: concat word
+						: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
+					// No case change: concat word
+					: [true, true] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
+						? WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
+					// Case change: lower to upper, push word
+						: [true, true] extends [IsLowercase<LastCharacter>, IsUppercase<FirstCharacter>]
+							? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
+						// Case change: upper to lower, brings back the last character, push word
+							: [true, true] extends [IsUppercase<LastCharacter>, IsLowercase<FirstCharacter>]
+								? [...RemoveLastCharacter<CurrentWord, LastCharacter>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${LastCharacter}${FirstCharacter}`>]
+							// No case change: concat word
+								: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
 	: [...SkipEmptyWord<CurrentWord>];
 
 export {};

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -42,11 +42,11 @@ export type WordsOptions = {
 	/**
 	 Split on ASCII punctuation mark. Set to `false` by default for now..
 
-	 type Example1 = Words<'hello:world', {splitOnPunctuation: true}>
-	 //=> ['hello', 'world']
-
-	 type Example2 = Words<'hello:world', {splitOnPunctuation: false}>
+	 type Example1 = Words<'hello:world', {splitOnPunctuation: false}>
 	 //=> ['hello', ':world']
+
+	 type Example2 = Words<'hello:world', {splitOnPunctuation: true}>
+	 //=> ['hello', 'world']
 	 */
 	splitOnPunctuation?: boolean;
 };

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -1,5 +1,6 @@
 import type {
 	ApplyDefaultOptions,
+	AsciiPunctuation,
 	IsNumeric,
 	WordSeparators,
 } from './internal/index.d.ts';
@@ -38,10 +39,21 @@ export type WordsOptions = {
 	```
 	*/
 	splitOnNumbers?: boolean;
+	/**
+	 Split on ASCII punctuation mark. Set to `false` by default for now..
+
+	 type Example1 = Words<'hello:world', {splitOnPunctuation: true}>
+	 //=> ['hello', 'world']
+
+	 type Example2 = Words<'hello:world', {splitOnPunctuation: false}>
+	 //=> ['hello', ':world']
+	 */
+	splitOnPunctuation?: boolean;
 };
 
 export type _DefaultWordsOptions = {
 	splitOnNumbers: true;
+	splitOnPunctuation: false;
 };
 
 /**
@@ -50,6 +62,7 @@ Split a string (almost) like Lodash's `_.words()` function.
 - Split on each word that begins with a capital letter.
 - Split on each {@link WordSeparators}.
 - Split on numeric sequence.
+- Split on {@link AsciiPunctuation} (if `splitOnPunctuation: true`)
 
 @example
 ```
@@ -72,13 +85,24 @@ type Words4 = Words<'lifeIs42'>;
 
 type Words5 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 //=> ['p2p', 'Network']
+
+type Words6 = Words<'hello:world', {splitOnPunctuation: true}>;
+//=> ['hello', 'world']
+
+type Words7 = Words<'hello:world', {splitOnPunctuation: false}>;
+//=> ['hello', ':world']
 ```
 
 @category Change case
 @category Template literal
 */
-export type Words<Sentence extends string, Options extends WordsOptions = {}> =
-	WordsImplementation<Sentence, ApplyDefaultOptions<WordsOptions, _DefaultWordsOptions, Options>>;
+export type Words<
+	Sentence extends string,
+	Options extends WordsOptions = {},
+> = WordsImplementation<
+	Sentence,
+	ApplyDefaultOptions<WordsOptions, _DefaultWordsOptions, Options>
+>;
 
 type WordsImplementation<
 	Sentence extends string,
@@ -86,37 +110,114 @@ type WordsImplementation<
 	LastCharacter extends string = '',
 	CurrentWord extends string = '',
 > = Sentence extends `${infer FirstCharacter}${infer RemainingCharacters}`
-	? FirstCharacter extends WordSeparators
-		// Skip word separator
-		? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options>]
+	? FirstCharacter extends
+	| WordSeparators
+	| (Options['splitOnPunctuation'] extends true ? AsciiPunctuation : never)
+		? // Skip word separator
+		[
+			...SkipEmptyWord<CurrentWord>,
+			...WordsImplementation<RemainingCharacters, Options>,
+		]
 		: LastCharacter extends ''
-			// Fist char of word
-			? WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>
-			// Case change: non-numeric to numeric
-			: [false, true] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
+			? // Fist char of word
+			WordsImplementation<
+				RemainingCharacters,
+				Options,
+				FirstCharacter,
+				FirstCharacter
+			>
+			: // Case change: non-numeric to numeric
+			[false, true] extends [
+				IsNumeric<LastCharacter>,
+				IsNumeric<FirstCharacter>,
+			]
 				? Options['splitOnNumbers'] extends true
-					// Split on number: push word
-					? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
-					// No split on number: concat word
-					: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
-				// Case change: numeric to non-numeric
-				: [true, false] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
+					? // Split on number: push word
+					[
+						...SkipEmptyWord<CurrentWord>,
+						...WordsImplementation<
+							RemainingCharacters,
+							Options,
+							FirstCharacter,
+							FirstCharacter
+						>,
+					]
+					: // No split on number: concat word
+					WordsImplementation<
+						RemainingCharacters,
+						Options,
+						FirstCharacter,
+							`${CurrentWord}${FirstCharacter}`
+					>
+				: // Case change: numeric to non-numeric
+				[true, false] extends [
+					IsNumeric<LastCharacter>,
+					IsNumeric<FirstCharacter>,
+				]
 					? Options['splitOnNumbers'] extends true
-						// Split on number: push word
-						? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
-						// No split on number: concat word
-						: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
-					// No case change: concat word
-					: [true, true] extends [IsNumeric<LastCharacter>, IsNumeric<FirstCharacter>]
-						? WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
-					// Case change: lower to upper, push word
-						: [true, true] extends [IsLowercase<LastCharacter>, IsUppercase<FirstCharacter>]
-							? [...SkipEmptyWord<CurrentWord>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, FirstCharacter>]
-						// Case change: upper to lower, brings back the last character, push word
-							: [true, true] extends [IsUppercase<LastCharacter>, IsLowercase<FirstCharacter>]
-								? [...RemoveLastCharacter<CurrentWord, LastCharacter>, ...WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${LastCharacter}${FirstCharacter}`>]
-							// No case change: concat word
-								: WordsImplementation<RemainingCharacters, Options, FirstCharacter, `${CurrentWord}${FirstCharacter}`>
+						? // Split on number: push word
+						[
+							...SkipEmptyWord<CurrentWord>,
+							...WordsImplementation<
+								RemainingCharacters,
+								Options,
+								FirstCharacter,
+								FirstCharacter
+							>,
+						]
+						: // No split on number: concat word
+						WordsImplementation<
+							RemainingCharacters,
+							Options,
+							FirstCharacter,
+								`${CurrentWord}${FirstCharacter}`
+						>
+					: // No case change: concat word
+					[true, true] extends [
+						IsNumeric<LastCharacter>,
+						IsNumeric<FirstCharacter>,
+					]
+						? WordsImplementation<
+							RemainingCharacters,
+							Options,
+							FirstCharacter,
+								`${CurrentWord}${FirstCharacter}`
+						>
+						: // Case change: lower to upper, push word
+						[true, true] extends [
+							IsLowercase<LastCharacter>,
+							IsUppercase<FirstCharacter>,
+						]
+							? [
+								...SkipEmptyWord<CurrentWord>,
+								...WordsImplementation<
+									RemainingCharacters,
+									Options,
+									FirstCharacter,
+									FirstCharacter
+								>,
+							]
+							: // Case change: upper to lower, brings back the last character, push word
+							[true, true] extends [
+								IsUppercase<LastCharacter>,
+								IsLowercase<FirstCharacter>,
+							]
+								? [
+									...RemoveLastCharacter<CurrentWord, LastCharacter>,
+									...WordsImplementation<
+										RemainingCharacters,
+										Options,
+										FirstCharacter,
+											`${LastCharacter}${FirstCharacter}`
+									>,
+								]
+								: // No case change: concat word
+								WordsImplementation<
+									RemainingCharacters,
+									Options,
+									FirstCharacter,
+										`${CurrentWord}${FirstCharacter}`
+								>
 	: [...SkipEmptyWord<CurrentWord>];
 
 export {};

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -42,11 +42,16 @@ export type WordsOptions = {
 	/**
 	Split on ASCII punctuation mark. Set to `false` by default for now..
 
-	type Example1 = Words<'hello:world', {splitOnPunctuation: false}>
+	@example
+	```
+	import type {Words} from 'type-fest';
+
+	type Example1 = Words<'hello:world', {splitOnPunctuation: false}>;
 	//=> ['hello', ':world']
 
-	type Example2 = Words<'hello:world', {splitOnPunctuation: true}>
+	type Example2 = Words<'hello:world', {splitOnPunctuation: true}>;
 	//=> ['hello', 'world']
+	```
 	*/
 	splitOnPunctuation?: boolean;
 };

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -40,14 +40,14 @@ export type WordsOptions = {
 	*/
 	splitOnNumbers?: boolean;
 	/**
-	 Split on ASCII punctuation mark. Set to `false` by default for now..
+	Split on ASCII punctuation mark. Set to `false` by default for now..
 
-	 type Example1 = Words<'hello:world', {splitOnPunctuation: false}>
-	 //=> ['hello', ':world']
+	type Example1 = Words<'hello:world', {splitOnPunctuation: false}>
+	//=> ['hello', ':world']
 
-	 type Example2 = Words<'hello:world', {splitOnPunctuation: true}>
-	 //=> ['hello', 'world']
-	 */
+	type Example2 = Words<'hello:world', {splitOnPunctuation: true}>
+	//=> ['hello', 'world']
+	*/
 	splitOnPunctuation?: boolean;
 };
 

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -68,28 +68,28 @@ Split a string (almost) like Lodash's `_.words()` function.
 ```
 import type {Words} from 'type-fest';
 
-type Words0 = Words<'helloWorld'>;
+type Words1 = Words<'helloWorld'>;
 //=> ['hello', 'World']
 
-type Words1 = Words<'helloWORLD'>;
+type Words2 = Words<'helloWORLD'>;
 //=> ['hello', 'WORLD']
 
-type Words2 = Words<'hello-world'>;
+type Words3 = Words<'hello-world'>;
 //=> ['hello', 'world']
 
-type Words3 = Words<'--hello the_world'>;
+type Words4 = Words<'--hello the_world'>;
 //=> ['hello', 'the', 'world']
 
-type Words4 = Words<'lifeIs42'>;
+type Words5 = Words<'lifeIs42'>;
 //=> ['life', 'Is', '42']
 
-type Words5 = Words<'p2pNetwork', {splitOnNumbers: false}>;
+type Words6 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 //=> ['p2p', 'Network']
 
-type Words6 = Words<'hello:world', {splitOnPunctuation: true}>;
+type Words7 = Words<'hello:world', {splitOnPunctuation: true}>;
 //=> ['hello', 'world']
 
-type Words7 = Words<'hello:world', {splitOnPunctuation: false}>;
+type Words8 = Words<'hello:world', {splitOnPunctuation: false}>;
 //=> ['hello', ':world']
 ```
 

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -40,7 +40,7 @@ export type WordsOptions = {
 	*/
 	splitOnNumbers?: boolean;
 	/**
-	Split on ASCII punctuation mark. Set to `false` by default for now..
+	Split on {@link AsciiPunctuation | punctuation characters} (e.g., `#`, `&`, `*`, `:`, `?`, `@`, `~`).
 
 	@example
 	```
@@ -66,8 +66,8 @@ Split a string (almost) like Lodash's `_.words()` function.
 
 - Split on each word that begins with a capital letter.
 - Split on each {@link WordSeparators}.
+- Split on each {@link AsciiPunctuation} (if {@link WordsOptions.splitOnPunctuation} is enabled).
 - Split on numeric sequence.
-- Split on {@link AsciiPunctuation} (if `splitOnPunctuation: true`)
 
 @example
 ```

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -104,13 +104,7 @@ type Words8 = Words<'hello:world', {splitOnPunctuation: true}>;
 @category Change case
 @category Template literal
 */
-export type Words<
-	Sentence extends string,
-	Options extends WordsOptions = {},
-> = WordsImplementation<
-	Sentence,
-	ApplyDefaultOptions<WordsOptions, _DefaultWordsOptions, Options>
->;
+export type Words<Sentence extends string, Options extends WordsOptions = {}> = WordsImplementation<Sentence, ApplyDefaultOptions<WordsOptions, _DefaultWordsOptions, Options>>;
 
 type WordsImplementation<
 	Sentence extends string,

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -46,11 +46,11 @@ export type WordsOptions = {
 	```
 	import type {Words} from 'type-fest';
 
-	type Example1 = Words<'hello:world', {splitOnPunctuation: false}>;
-	//=> ['hello', ':world']
-
-	type Example2 = Words<'hello:world', {splitOnPunctuation: true}>;
+	type Example1 = Words<'hello:world', {splitOnPunctuation: true}>;
 	//=> ['hello', 'world']
+
+	type Example2 = Words<'hello:world', {splitOnPunctuation: false}>;
+	//=> ['hello', ':world']
 	```
 	*/
 	splitOnPunctuation?: boolean;
@@ -91,11 +91,11 @@ type Words5 = Words<'lifeIs42'>;
 type Words6 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 //=> ['p2p', 'Network']
 
-type Words7 = Words<'hello:world', {splitOnPunctuation: true}>;
-//=> ['hello', 'world']
-
-type Words8 = Words<'hello:world', {splitOnPunctuation: false}>;
+type Words7 = Words<'hello:world'>;
 //=> ['hello', ':world']
+
+type Words8 = Words<'hello:world', {splitOnPunctuation: true}>;
+//=> ['hello', 'world']
 ```
 
 @category Change case

--- a/source/words.d.ts
+++ b/source/words.d.ts
@@ -73,25 +73,28 @@ Split a string (almost) like Lodash's `_.words()` function.
 ```
 import type {Words} from 'type-fest';
 
-type Words1 = Words<'helloWorld'>;
+type Words0 = Words<'helloWorld'>;
 //=> ['hello', 'World']
 
-type Words2 = Words<'helloWORLD'>;
+type Words1 = Words<'helloWORLD'>;
 //=> ['hello', 'WORLD']
 
-type Words3 = Words<'hello-world'>;
+type Words2 = Words<'hello-world'>;
 //=> ['hello', 'world']
 
-type Words4 = Words<'--hello the_world'>;
+type Words3 = Words<'--hello the_world'>;
 //=> ['hello', 'the', 'world']
 
-type Words5 = Words<'lifeIs42'>;
+type Words4 = Words<'lifeIs42'>;
 //=> ['life', 'Is', '42']
 
-type Words6 = Words<'p2pNetwork', {splitOnNumbers: false}>;
+type Words5 = Words<'p2pNetwork', {splitOnNumbers: false}>;
 //=> ['p2p', 'Network']
 
-type Words7 = Words<'hello:world'>;
+type Words6 = Words<'hello:world', {splitOnPunctuation: true}>;
+//=> ['hello', 'world']
+
+type Words7 = Words<'hello:world', {splitOnPunctuation: false}>;
 //=> ['hello', ':world']
 
 type Words8 = Words<'hello:world', {splitOnPunctuation: true}>;

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -87,3 +87,13 @@ expectType<'a1BText'>('' as CamelCase<'a1b_text'>);
 
 expectType<'p2pNetwork'>('' as CamelCase<'p2pNetwork', {splitOnNumbers: false}>);
 expectType<'p2PNetwork'>('' as CamelCase<'p2pNetwork', {splitOnNumbers: true}>);
+
+// Punctuation
+expectType<CamelCase<'onDialog:close'>>('onDialog:close');
+expectType<CamelCase<'foo-bar>>baz'>>('fooBar>>baz');
+expectType<CamelCase<'foo-bar::01'>>('fooBar::01');
+
+expectType<CamelCase<'onDialog:close', {splitOnPunctuation: true}>>('onDialogClose');
+expectType<CamelCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('fooBarBaz');
+expectType<CamelCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecutiveUppercase: true}>>('fooBARBiz');
+expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true}>>('fooBar01');

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -97,3 +97,5 @@ expectType<CamelCase<'onDialog:close', {splitOnPunctuation: true}>>('onDialogClo
 expectType<CamelCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('fooBarBaz');
 expectType<CamelCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecutiveUppercase: true}>>('fooBARBiz');
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true}>>('fooBar01');
+expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('fooBar01');
+expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>>('fooBar01');

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -38,6 +38,7 @@ type UserPunctuated = {
 	'user::name': string;
 	date: Date;
 	'reg::exp': RegExp;
+	Role: UserRole;
 };
 
 type UserWithFriends = {
@@ -79,6 +80,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 };
 
 expectType<CamelCasedPropertiesDeep<UserWithFriends>>(result);
+expectType<CamelCasedPropertiesDeep<UserWithFriendsPunctuated, {splitOnPunctuation: true}>>(result);
 
 expectType<{fooBar: unknown}>({} as CamelCasedPropertiesDeep<{foo_bar: unknown}>);
 expectType<{fooBar: {barBaz: unknown}; biz: unknown}>({} as CamelCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -33,9 +33,21 @@ type User = {
 	Role: UserRole;
 };
 
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
+	date: Date;
+	'reg::exp': RegExp;
+};
+
 type UserWithFriends = {
 	UserInfo: User;
 	UserFriends: User[];
+};
+
+type UserWithFriendsPunctuated = {
+	'user@info': UserPunctuated;
+	'user#friends': UserPunctuated[];
 };
 
 const role = 'someRole' as UserRole;
@@ -65,6 +77,7 @@ const result: CamelCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
 expectType<CamelCasedPropertiesDeep<UserWithFriends>>(result);
 
 expectType<{fooBar: unknown}>({} as CamelCasedPropertiesDeep<{foo_bar: unknown}>);
@@ -72,3 +85,6 @@ expectType<{fooBar: {barBaz: unknown}; biz: unknown}>({} as CamelCasedProperties
 
 expectType<{fooBar: any}>({} as CamelCasedPropertiesDeep<{foo_bar: any}>);
 expectType<{fooBar: {barBaz: any}; biz: any}>({} as CamelCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);
+
+expectType<{'fooBar': unknown}>({} as CamelCasedPropertiesDeep<{'foo::bar': unknown}, {splitOnPunctuation: true}>);
+expectType<{'fooBar': {'barBaz': unknown}; biz: unknown}>({} as CamelCasedPropertiesDeep<{'foo::bar': {'bar@baz': unknown}; biz: unknown}, {splitOnPunctuation: true}>);

--- a/test-d/camel-cased-properties.ts
+++ b/test-d/camel-cased-properties.ts
@@ -16,10 +16,24 @@ expectType<{fooBAR: number; bARFoo: string}>(baz);
 declare const biz: CamelCasedProperties<{fooBAR: number; BARFoo: string}>;
 expectType<{fooBar: number; barFoo: string}>(biz);
 
+declare const fooBarPunctuated: CamelCasedProperties<{'hello@world1': {'foo::bar': string}}>;
+expectType<{'hello@world1': {'foo::bar': string}}>(fooBarPunctuated);
+
+declare const fooBarPunctuatedSplit: CamelCasedProperties<{'hello@world1': {'foo::bar': string}}, {splitOnPunctuation: true}>;
+expectType<{'helloWorld1': {'foo::bar': string}}>(fooBarPunctuatedSplit);
+
+declare const fooBarPunctuatedSplitNumberSplit: CamelCasedProperties<{'hello@world1': {'foo::bar': string}}, {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<{'helloWorld1': {'foo::bar': string}}>(fooBarPunctuatedSplitNumberSplit);
+
 // Verify example
 type User = {
 	UserId: number;
 	UserName: string;
+};
+
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
 };
 
 const result: CamelCasedProperties<User> = {
@@ -27,3 +41,4 @@ const result: CamelCasedProperties<User> = {
 	userName: 'Tom',
 };
 expectType<CamelCasedProperties<User>>(result);
+expectType<CamelCasedProperties<UserPunctuated, {splitOnPunctuation: true}>>(result);

--- a/test-d/internal/has-multiple-call-signatures.ts
+++ b/test-d/internal/has-multiple-call-signatures.ts
@@ -8,7 +8,7 @@ type Overloaded = {
 
 type Overloaded2 = {
 	(foo: number | undefined): string;
-	// eslint-disable-next-line @typescript-eslint/unified-signatures
+
 	(foo: number): string;
 };
 

--- a/test-d/internal/has-multiple-call-signatures.ts
+++ b/test-d/internal/has-multiple-call-signatures.ts
@@ -8,7 +8,7 @@ type Overloaded = {
 
 type Overloaded2 = {
 	(foo: number | undefined): string;
-
+	// eslint-disable-next-line @typescript-eslint/unified-signatures
 	(foo: number): string;
 };
 

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -94,6 +94,6 @@ expectType<KebabCase<'div.card::after', {splitOnPunctuation: true}>>('div-card-a
 expectType<KebabCase<'foo-bar::01'>>('foo-bar::01');
 expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true}>>('foo-bar::-01');
 
-expectType<KebabCase<'foo-bar::01', {splitOnPunctuation: true, splitOnNumbers:false}>>('foo-bar-01');
+expectType<KebabCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('foo-bar-01');
 expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>>('foo-bar-01');
 

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -118,4 +118,3 @@ expectType<'foo-bar::-01'>(withPunctuationAndNumberSplit2);
 
 declare const withPunctuationSplitAndNumberSplit2: KebabCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>;
 expectType<'foo-bar-01'>(withPunctuationSplitAndNumberSplit2);
-

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -80,20 +80,42 @@ const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: KebabCase<'FOO22Bar'>
 expectType<'foo22-bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);
 
 // Punctuation
-expectType<KebabCase<'onDialog:close'>>('on-dialog:close');
-expectType<KebabCase<'foo-bar>>baz'>>('foo-bar>>baz');
-expectType<KebabCase<'card::after'>>('card::after');
-expectType<KebabCase<'div.card::after'>>('div.card::after');
+declare const withPunctuation: KebabCase<'onDialog:close'>;
+expectType<'on-dialog:close'>(withPunctuation);
 
-expectType<KebabCase<'onDialog:close', {splitOnPunctuation: true}>>('on-dialog-close');
-expectType<KebabCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('foo-bar-baz');
-expectType<KebabCase<'card::after', {splitOnPunctuation: true}>>('card-after');
-expectType<KebabCase<'div.card::after', {splitOnPunctuation: true}>>('div-card-after');
+declare const withPunctuationAndSplit: KebabCase<'onDialog:close', {splitOnPunctuation: true}>;
+expectType<'on-dialog-close'>(withPunctuationAndSplit);
 
-// Punctuation with number
-expectType<KebabCase<'foo-bar::01'>>('foo-bar::01');
-expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true}>>('foo-bar::-01');
+declare const withPunctuation2: KebabCase<'foo-bar>>baz'>;
+expectType<'foo-bar>>baz'>(withPunctuation2);
 
-expectType<KebabCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('foo-bar-01');
-expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>>('foo-bar-01');
+declare const withPunctuationAndSplit2: KebabCase<'foo-bar>>baz', {splitOnPunctuation: true}>;
+expectType<'foo-bar-baz'>(withPunctuationAndSplit2);
+
+declare const withPunctuation3: KebabCase<'card::after'>;
+expectType<'card::after'>(withPunctuation3);
+
+declare const withPunctuationAndSplit3: KebabCase<'card::after', {splitOnPunctuation: true}>;
+expectType<'card-after'>(withPunctuationAndSplit3);
+
+declare const withPunctuation4: KebabCase<'div.card::after'>;
+expectType<'div.card::after'>(withPunctuation4);
+
+declare const withPunctuationAndSplit4: KebabCase<'div.card::after', {splitOnPunctuation: true}>;
+expectType<'div-card-after'>(withPunctuationAndSplit4);
+
+declare const withPunctuationAndNumber: KebabCase<'foo-bar::01'>;
+expectType<'foo-bar::01'>(withPunctuationAndNumber);
+
+declare const withPunctuationSplitAndNumber: KebabCase<'foo-bar::01', {splitOnPunctuation: true}>;
+expectType<'foo-bar-01'>(withPunctuationSplitAndNumber);
+
+declare const withPunctuationSplitAndNumberSplit: KebabCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<'foo-bar-01'>(withPunctuationSplitAndNumberSplit);
+
+declare const withPunctuationAndNumberSplit2: KebabCase<'foo-bar::01', {splitOnNumbers: true}>;
+expectType<'foo-bar::-01'>(withPunctuationAndNumberSplit2);
+
+declare const withPunctuationSplitAndNumberSplit2: KebabCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>;
+expectType<'foo-bar-01'>(withPunctuationSplitAndNumberSplit2);
 

--- a/test-d/kebab-case.ts
+++ b/test-d/kebab-case.ts
@@ -79,20 +79,21 @@ expectType<'fo-o2bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 const kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: KebabCase<'FOO22Bar'> = 'foo22-bar';
 expectType<'foo22-bar'>(kebabFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);
 
-declare const withPunctuation: KebabCase<'onDialog:close'>;
-expectType<'on-dialog:close'>(withPunctuation);
+// Punctuation
+expectType<KebabCase<'onDialog:close'>>('on-dialog:close');
+expectType<KebabCase<'foo-bar>>baz'>>('foo-bar>>baz');
+expectType<KebabCase<'card::after'>>('card::after');
+expectType<KebabCase<'div.card::after'>>('div.card::after');
 
-declare const withPunctuation2: KebabCase<'foo-bar>>baz'>;
-expectType<'foo-bar>>baz'>(withPunctuation2);
+expectType<KebabCase<'onDialog:close', {splitOnPunctuation: true}>>('on-dialog-close');
+expectType<KebabCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('foo-bar-baz');
+expectType<KebabCase<'card::after', {splitOnPunctuation: true}>>('card-after');
+expectType<KebabCase<'div.card::after', {splitOnPunctuation: true}>>('div-card-after');
 
-declare const withPunctuation3: KebabCase<'card::after'>;
-expectType<'card::after'>(withPunctuation3);
+// Punctuation with number
+expectType<KebabCase<'foo-bar::01'>>('foo-bar::01');
+expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true}>>('foo-bar::-01');
 
-declare const withPunctuation4: KebabCase<'div.card::after'>;
-expectType<'div.card::after'>(withPunctuation4);
+expectType<KebabCase<'foo-bar::01', {splitOnPunctuation: true, splitOnNumbers:false}>>('foo-bar-01');
+expectType<KebabCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>>('foo-bar-01');
 
-declare const withPunctuationAndNumber: KebabCase<'foo-bar::01'>;
-expectType<'foo-bar::01'>(withPunctuationAndNumber);
-
-declare const withPunctuationAndNumber2: KebabCase<'foo-bar::01', {splitOnNumbers: true}>;
-expectType<'foo-bar::-01'>(withPunctuationAndNumber2);

--- a/test-d/kebab-cased-properties-deep.ts
+++ b/test-d/kebab-cased-properties-deep.ts
@@ -17,9 +17,21 @@ type User = {
 	regExp: RegExp;
 };
 
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
+	date: Date;
+	'reg::exp': RegExp;
+};
+
 type UserWithFriends = {
 	userInfo: User;
 	userFriends: User[];
+};
+
+type UserWithFriendsPunctuated = {
+	'user@info': UserPunctuated;
+	'user#friends': UserPunctuated[];
 };
 
 const result: KebabCasedPropertiesDeep<UserWithFriends> = {
@@ -44,10 +56,15 @@ const result: KebabCasedPropertiesDeep<UserWithFriends> = {
 		},
 	],
 };
+
 expectType<KebabCasedPropertiesDeep<UserWithFriends>>(result);
+expectType<KebabCasedPropertiesDeep<UserWithFriendsPunctuated, {splitOnPunctuation: true}>>(result);
 
 expectType<{'foo-bar': unknown}>({} as KebabCasedPropertiesDeep<{foo_bar: unknown}>);
 expectType<{'foo-bar': {'bar-baz': unknown}; biz: unknown}>({} as KebabCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);
 
 expectType<{'foo-bar': any}>({} as KebabCasedPropertiesDeep<{foo_bar: any}>);
 expectType<{'foo-bar': {'bar-baz': any}; biz: any}>({} as KebabCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);
+
+expectType<{'foo-bar': unknown}>({} as KebabCasedPropertiesDeep<{'foo::bar': unknown}, {splitOnPunctuation: true}>);
+expectType<{'foo-bar': {'bar-baz': unknown}; biz: unknown}>({} as KebabCasedPropertiesDeep<{'foo::bar': {'bar@baz': unknown}; biz: unknown}, {splitOnPunctuation: true}>);

--- a/test-d/kebab-cased-properties.ts
+++ b/test-d/kebab-cased-properties.ts
@@ -2,6 +2,7 @@ import {expectType} from 'tsd';
 import type {KebabCasedProperties} from '../index.d.ts';
 
 type Foobar = {helloWorld1: {fooBar: string}};
+type FoobarPunctuated = {'hello@World1': {'foo::Bar': string}};
 
 declare const foo: KebabCasedProperties<Foobar>;
 expectType<{'hello-world1': {fooBar: string}}>(foo);
@@ -9,13 +10,30 @@ expectType<{'hello-world1': {fooBar: string}}>(foo);
 declare const bar: KebabCasedProperties<Foobar, {splitOnNumbers: true}>;
 expectType<{'hello-world-1': {fooBar: string}}>(bar);
 
+declare const fooBarPunctuated: KebabCasedProperties<FoobarPunctuated>;
+expectType<{'hello@-world1': {'foo::Bar': string}}>(fooBarPunctuated);
+
+declare const fooBarPunctuatedSplit: KebabCasedProperties<FoobarPunctuated, {splitOnPunctuation: true}>;
+expectType<{'hello-world1': {'foo::Bar': string}}>(fooBarPunctuatedSplit);
+
+declare const fooBarPunctuatedSplitNumberSplit: KebabCasedProperties<FoobarPunctuated, {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<{'hello-world-1': {'foo::Bar': string}}>(fooBarPunctuatedSplitNumberSplit);
+
 // Verify example
 type User = {
 	userId: number;
 	userName: string;
 };
+
+type UserPunctuated = {
+	'user::Id': number;
+	'user::Name': string;
+};
+
 const result: KebabCasedProperties<User> = {
 	'user-id': 1,
 	'user-name': 'Tom',
 };
 expectType<KebabCasedProperties<User>>(result);
+
+expectType<KebabCasedProperties<UserPunctuated, {splitOnPunctuation: true}>>(result);

--- a/test-d/pascal-case.ts
+++ b/test-d/pascal-case.ts
@@ -34,4 +34,3 @@ expectType<PascalCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecuti
 expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true}>>('FooBar01');
 expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('FooBar01');
 expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>>('FooBar01');
-

--- a/test-d/pascal-case.ts
+++ b/test-d/pascal-case.ts
@@ -32,4 +32,6 @@ expectType<PascalCase<'onDialog:close', {splitOnPunctuation: true}>>('OnDialogCl
 expectType<PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('FooBarBaz');
 expectType<PascalCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecutiveUppercase: true}>>('FooBARBiz');
 expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true}>>('FooBar01');
+expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('FooBar01');
+expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>>('FooBar01');
 

--- a/test-d/pascal-case.ts
+++ b/test-d/pascal-case.ts
@@ -22,3 +22,14 @@ expectType<PascalCase<'foo\tBAR-Biz_BUZZ'>>('FooBarBizBuzz');
 
 expectType<PascalCase<string, {preserveConsecutiveUppercase: true}>>({} as Capitalize<string>);
 expectType<PascalCase<string>>({} as Capitalize<string>);
+
+// Punctuation
+expectType<PascalCase<'onDialog:close'>>('OnDialog:close');
+expectType<PascalCase<'foo-bar>>baz'>>('FooBar>>baz');
+expectType<PascalCase<'foo-bar::01'>>('FooBar::01');
+
+expectType<PascalCase<'onDialog:close', {splitOnPunctuation: true}>>('OnDialogClose');
+expectType<PascalCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('FooBarBaz');
+expectType<PascalCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecutiveUppercase: true}>>('FooBARBiz');
+expectType<PascalCase<'foo-bar::01', {splitOnPunctuation: true}>>('FooBar01');
+

--- a/test-d/pascal-cased-properties-deep.ts
+++ b/test-d/pascal-cased-properties-deep.ts
@@ -18,9 +18,21 @@ type User = {
 	regExp: RegExp;
 };
 
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
+	date: Date;
+	'reg::exp': RegExp;
+};
+
 type UserWithFriends = {
 	userInfo: User;
 	userFriends: User[];
+};
+
+type UserWithFriendsPunctuated = {
+	'user@info': UserPunctuated;
+	'user#friends': UserPunctuated[];
 };
 
 const result: PascalCasedPropertiesDeep<UserWithFriends> = {
@@ -46,12 +58,16 @@ const result: PascalCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<PascalCasedPropertiesDeep<UserWithFriends>>(result);
+expectType<PascalCasedPropertiesDeep<UserWithFriendsPunctuated, {splitOnPunctuation: true}>>(result);
 
 expectType<{'FooBar': unknown}>({} as PascalCasedPropertiesDeep<{foo_bar: unknown}>);
 expectType<{'FooBar': {'BarBaz': unknown}; Biz: unknown}>({} as PascalCasedPropertiesDeep<{foo_bar: {bar_baz: unknown}; biz: unknown}>);
 
 expectType<{'FooBar': any}>({} as PascalCasedPropertiesDeep<{foo_bar: any}>);
 expectType<{'FooBar': {'BarBaz': any}; Biz: any}>({} as PascalCasedPropertiesDeep<{foo_bar: {bar_baz: any}; biz: any}>);
+
+expectType<{'FooBar': unknown}>({} as PascalCasedPropertiesDeep<{'foo::bar': unknown}, {splitOnPunctuation: true}>);
+expectType<{'FooBar': {'BarBaz': unknown}; Biz: unknown}>({} as PascalCasedPropertiesDeep<{'foo::bar': {'bar@baz': unknown}; biz: unknown}, {splitOnPunctuation: true}>);
 
 type bazBizDeep = {fooBAR: number; baz: {fooBAR: Array<{BARFoo: string}>}};
 

--- a/test-d/pascal-cased-properties.ts
+++ b/test-d/pascal-cased-properties.ts
@@ -2,6 +2,8 @@ import {expectType} from 'tsd';
 import type {PascalCasedProperties} from '../index.d.ts';
 
 declare const foo: PascalCasedProperties<{helloWorld: {fooBar: string}}>;
+type FoobarPunctuated = {'hello@World1': {'foo::Bar': string}};
+
 expectType<{HelloWorld: {fooBar: string}}>(foo);
 
 declare const bar: PascalCasedProperties<Array<{helloWorld: string}>>;
@@ -10,16 +12,32 @@ expectType<Array<{helloWorld: string}>>(bar);
 declare const fooBar: PascalCasedProperties<() => {a: string}>;
 expectType<() => {a: string}>(fooBar);
 
+declare const fooBarPunctuated: PascalCasedProperties<FoobarPunctuated>;
+expectType<{'Hello@World1': {'foo::Bar': string}}>(fooBarPunctuated);
+
+declare const fooBarPunctuatedSplit: PascalCasedProperties<FoobarPunctuated, {splitOnPunctuation: true}>;
+expectType<{'HelloWorld1': {'foo::Bar': string}}>(fooBarPunctuatedSplit);
+
+declare const fooBarPunctuatedSplitNumberSplit: PascalCasedProperties<FoobarPunctuated, {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<{'HelloWorld1': {'foo::Bar': string}}>(fooBarPunctuatedSplitNumberSplit);
+
 // Verify example
 type User = {
 	userId: number;
 	userName: string;
 };
+
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
+};
+
 const result: PascalCasedProperties<User> = {
 	UserId: 1,
 	UserName: 'Tom',
 };
 expectType<PascalCasedProperties<User>>(result);
+expectType<PascalCasedProperties<UserPunctuated, {splitOnPunctuation: true}>>(result);
 
 declare const baz: PascalCasedProperties<{fooBAR: number; BARFoo: string}, {preserveConsecutiveUppercase: true}>;
 expectType<{FooBAR: number; BARFoo: string}>(baz);

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -83,22 +83,41 @@ const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: SnakeCase<'FOO22Bar'>
 expectType<'foo22_bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);
 
 // Punctuation
-expectType<SnakeCase<'onDialog:close'>>('on_dialog:close');
-expectType<SnakeCase<'foo-bar>>baz'>>('foo_bar>>baz');
-expectType<SnakeCase<'card::after'>>('card::after');
-expectType<SnakeCase<'div.card::after'>>('div.card::after');
-expectType<SnakeCase<'foo-bar::01'>>('foo_bar::01');
+declare const withPunctuation: SnakeCase<'onDialog:close'>;
+expectType<'on_dialog:close'>(withPunctuation);
 
-expectType<SnakeCase<'onDialog:close', {splitOnPunctuation: true}>>('on_dialog_close');
-expectType<SnakeCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('foo_bar_baz');
-expectType<SnakeCase<'card::after', {splitOnPunctuation: true}>>('card_after');
-expectType<SnakeCase<'div.card::after', {splitOnPunctuation: true}>>('div_card_after');
-expectType<SnakeCase<'foo-bar::01', {splitOnPunctuation: true}>>('foo_bar_01');
+declare const withPunctuationSplit: SnakeCase<'onDialog:close', {splitOnPunctuation: true}>;
+expectType<'on_dialog_close'>(withPunctuationSplit);
 
-// Punctuation with number
-expectType<SnakeCase<'foo-bar::01'>>('foo_bar::01');
-expectType<SnakeCase<'foo-bar::01', {splitOnNumbers: true}>>('foo_bar::_01');
+declare const withPunctuation2: SnakeCase<'foo-bar>>baz'>;
+expectType<'foo_bar>>baz'>(withPunctuation2);
 
-expectType<SnakeCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('foo_bar_01');
-expectType<SnakeCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>>('foo_bar_01');
+declare const withPunctuationSplit2: SnakeCase<'foo-bar>>baz', {splitOnPunctuation: true}>;
+expectType<'foo_bar_baz'>(withPunctuationSplit2);
 
+declare const withPunctuation3: SnakeCase<'card::after'>;
+expectType<'card::after'>(withPunctuation3);
+
+declare const withPunctuationSplit3: SnakeCase<'card::after', {splitOnPunctuation: true}>;
+expectType<'card_after'>(withPunctuationSplit3);
+
+declare const withPunctuation4: SnakeCase<'div.card::after'>;
+expectType<'div.card::after'>(withPunctuation4);
+
+declare const withPunctuationSplit4: SnakeCase<'div.card::after', {splitOnPunctuation: true}>;
+expectType<'div_card_after'>(withPunctuationSplit4);
+
+declare const withPunctuationAndNumber: SnakeCase<'foo-bar::01'>;
+expectType<'foo_bar::01'>(withPunctuationAndNumber);
+
+declare const withPunctuationSplitAndNumber: SnakeCase<'foo-bar::01', {splitOnPunctuation: true}>;
+expectType<'foo_bar_01'>(withPunctuationSplitAndNumber);
+
+declare const withPunctuationSplitAndNumberSplit: SnakeCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<'foo_bar_01'>(withPunctuationSplitAndNumber);
+
+declare const withPunctuationAndNumberSplit2: SnakeCase<'foo-bar::01', {splitOnNumbers: true}>;
+expectType<'foo_bar::_01'>(withPunctuationAndNumberSplit2);
+
+declare const withPunctuationSplitAndNumberSplit2: SnakeCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>;
+expectType<'foo_bar_01'>(withPunctuationSplitAndNumberSplit2);

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -114,10 +114,13 @@ declare const withPunctuationSplitAndNumber: SnakeCase<'foo-bar::01', {splitOnPu
 expectType<'foo_bar_01'>(withPunctuationSplitAndNumber);
 
 declare const withPunctuationSplitAndNumberSplit: SnakeCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>;
-expectType<'foo_bar_01'>(withPunctuationSplitAndNumber);
+expectType<'foo_bar_01'>(withPunctuationSplitAndNumberSplit);
 
 declare const withPunctuationAndNumberSplit2: SnakeCase<'foo-bar::01', {splitOnNumbers: true}>;
 expectType<'foo_bar::_01'>(withPunctuationAndNumberSplit2);
 
 declare const withPunctuationSplitAndNumberSplit2: SnakeCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>;
 expectType<'foo_bar_01'>(withPunctuationSplitAndNumberSplit2);
+
+declare const withPunctuationSplitAndNumber2: SnakeCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>;
+expectType<'foo_bar_01'>(withPunctuationSplitAndNumber2);

--- a/test-d/snake-case.ts
+++ b/test-d/snake-case.ts
@@ -82,20 +82,23 @@ expectType<'fo_o2bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase2);
 const snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3: SnakeCase<'FOO22Bar'> = 'foo22_bar';
 expectType<'foo22_bar'>(snakeFromNumberInTheMiddleNoSplitOnNumbersEdgeCase3);
 
-declare const withPunctuation: SnakeCase<'onDialog:close'>;
-expectType<'on_dialog:close'>(withPunctuation);
+// Punctuation
+expectType<SnakeCase<'onDialog:close'>>('on_dialog:close');
+expectType<SnakeCase<'foo-bar>>baz'>>('foo_bar>>baz');
+expectType<SnakeCase<'card::after'>>('card::after');
+expectType<SnakeCase<'div.card::after'>>('div.card::after');
+expectType<SnakeCase<'foo-bar::01'>>('foo_bar::01');
 
-declare const withPunctuation2: SnakeCase<'foo-bar>>baz'>;
-expectType<'foo_bar>>baz'>(withPunctuation2);
+expectType<SnakeCase<'onDialog:close', {splitOnPunctuation: true}>>('on_dialog_close');
+expectType<SnakeCase<'foo-bar>>baz', {splitOnPunctuation: true}>>('foo_bar_baz');
+expectType<SnakeCase<'card::after', {splitOnPunctuation: true}>>('card_after');
+expectType<SnakeCase<'div.card::after', {splitOnPunctuation: true}>>('div_card_after');
+expectType<SnakeCase<'foo-bar::01', {splitOnPunctuation: true}>>('foo_bar_01');
 
-declare const withPunctuation3: SnakeCase<'card::after'>;
-expectType<'card::after'>(withPunctuation3);
+// Punctuation with number
+expectType<SnakeCase<'foo-bar::01'>>('foo_bar::01');
+expectType<SnakeCase<'foo-bar::01', {splitOnNumbers: true}>>('foo_bar::_01');
 
-declare const withPunctuation4: SnakeCase<'div.card::after'>;
-expectType<'div.card::after'>(withPunctuation4);
+expectType<SnakeCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('foo_bar_01');
+expectType<SnakeCase<'foo-bar::01', {splitOnNumbers: true; splitOnPunctuation: true}>>('foo_bar_01');
 
-declare const withPunctuationAndNumber: SnakeCase<'foo-bar::01'>;
-expectType<'foo_bar::01'>(withPunctuationAndNumber);
-
-declare const withPunctuationAndNumber2: SnakeCase<'foo-bar::01', {splitOnNumbers: true}>;
-expectType<'foo_bar::_01'>(withPunctuationAndNumber2);

--- a/test-d/snake-cased-properties-deep.ts
+++ b/test-d/snake-cased-properties-deep.ts
@@ -17,9 +17,21 @@ type User = {
 	regExp: RegExp;
 };
 
+type UserPunctuated = {
+	'user::id': number;
+	'user::name': string;
+	date: Date;
+	'reg::exp': RegExp;
+};
+
 type UserWithFriends = {
 	userInfo: User;
 	userFriends: User[];
+};
+
+type UserWithFriendsPunctuated = {
+	'user@info': UserPunctuated;
+	'user#friends': UserPunctuated[];
 };
 
 const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
@@ -45,9 +57,13 @@ const result: SnakeCasedPropertiesDeep<UserWithFriends> = {
 	],
 };
 expectType<SnakeCasedPropertiesDeep<UserWithFriends>>(result);
+expectType<SnakeCasedPropertiesDeep<UserWithFriendsPunctuated, {splitOnPunctuation: true}>>(result);
 
 expectType<{foo_bar: unknown}>({} as SnakeCasedPropertiesDeep<{fooBar: unknown}>);
 expectType<{foo_bar: {bar_baz: unknown}; biz: unknown}>({} as SnakeCasedPropertiesDeep<{fooBar: {barBaz: unknown}; biz: unknown}>);
 
 expectType<{foo_bar: any}>({} as SnakeCasedPropertiesDeep<{fooBar: any}>);
 expectType<{foo_bar: {bar_baz: any}; biz: any}>({} as SnakeCasedPropertiesDeep<{fooBar: {barBaz: any}; biz: any}>);
+
+expectType<{'foo_bar': unknown}>({} as SnakeCasedPropertiesDeep<{'foo::bar': unknown}, {splitOnPunctuation: true}>);
+expectType<{'foo_bar': {'bar_baz': unknown}; biz: unknown}>({} as SnakeCasedPropertiesDeep<{'foo::bar': {'bar@baz': unknown}; biz: unknown}, {splitOnPunctuation: true}>);

--- a/test-d/snake-cased-properties.ts
+++ b/test-d/snake-cased-properties.ts
@@ -2,6 +2,7 @@ import {expectType} from 'tsd';
 import type {SnakeCasedProperties} from '../index.d.ts';
 
 type Foobar = {helloWorld1: {fooBar: string}};
+type FoobarPunctuated = {'hello@World1': {'foo::Bar': string}};
 
 declare const foo: SnakeCasedProperties<Foobar>;
 expectType<{hello_world1: {fooBar: string}}>(foo);
@@ -9,13 +10,29 @@ expectType<{hello_world1: {fooBar: string}}>(foo);
 declare const bar: SnakeCasedProperties<Foobar, {splitOnNumbers: true}>;
 expectType<{hello_world_1: {fooBar: string}}>(bar);
 
+declare const fooBarPunctuated: SnakeCasedProperties<FoobarPunctuated>;
+expectType<{'hello@_world1': {'foo::Bar': string}}>(fooBarPunctuated);
+
+declare const fooBarPunctuatedSplit: SnakeCasedProperties<FoobarPunctuated, {splitOnPunctuation: true}>;
+expectType<{'hello_world1': {'foo::Bar': string}}>(fooBarPunctuatedSplit);
+
+declare const fooBarPunctuatedSplitNumberSplit: SnakeCasedProperties<FoobarPunctuated, {splitOnPunctuation: true; splitOnNumbers: true}>;
+expectType<{'hello_world_1': {'foo::Bar': string}}>(fooBarPunctuatedSplitNumberSplit);
+
 // Verify example
 type User = {
 	userId: number;
 	userName: string;
 };
+
+type UserPunctuated = {
+	'user::Id': number;
+	'user::Name': string;
+};
+
 const result: SnakeCasedProperties<User> = {
 	user_id: 1,
 	user_name: 'Tom',
 };
 expectType<SnakeCasedProperties<User>>(result);
+expectType<SnakeCasedProperties<UserPunctuated, {splitOnPunctuation: true}>>(result);

--- a/test-d/words.ts
+++ b/test-d/words.ts
@@ -108,3 +108,5 @@ expectType<Words<'hello::', {splitOnPunctuation: true}>>(['hello']);
 expectType<Words<'hello:world', {splitOnPunctuation: true}>>(['hello', 'world']);
 expectType<Words<'hello::world', {splitOnPunctuation: true}>>(['hello', 'world']);
 expectType<Words<'hello-braveNew:world', {splitOnPunctuation: true}>>(['hello', 'brave', 'New', 'world']);
+expectType<Words<'item::01', {splitOnPunctuation:true, splitOnNumbers: false }>>(['item', '01'])
+expectType<Words<'item::01', {splitOnPunctuation:true, splitOnNumbers: true }>>(['item', '01'])

--- a/test-d/words.ts
+++ b/test-d/words.ts
@@ -93,3 +93,19 @@ expectType<Words<'01item01'>>(['01', 'item', '01']);
 expectType<Words<'10item10'>>(['10', 'item', '10']);
 expectType<Words<'010item010'>>(['010', 'item', '010']);
 expectType<Words<'item0_item_1 item -2'>>(['item', '0', 'item', '1', 'item', '2']);
+
+// SplitOnPunctuation: default (false) - punctuation stays attached to following word
+expectType<Words<':'>>([':']);
+expectType<Words<'::'>>([':', ':']);
+expectType<Words<'hello::'>>(['hello', ':', ':']);
+expectType<Words<'hello:world'>>(['hello', ':world']);
+expectType<Words<'hello::world'>>(['hello', ':', ':world']);
+expectType<Words<'hello-braveNew:world'>>(['hello', 'brave', 'New', ':world']);
+
+// SplitOnPunctuation: true - punctuation is split out when followed by uppercase letter
+expectType<Words<':', {splitOnPunctuation: true}>>([]);
+expectType<Words<'::', {splitOnPunctuation: true}>>([]);
+expectType<Words<'hello::', {splitOnPunctuation: true}>>(['hello']);
+expectType<Words<'hello:world', {splitOnPunctuation: true}>>(['hello', 'world']);
+expectType<Words<'hello::world', {splitOnPunctuation: true}>>(['hello', 'world']);
+expectType<Words<'hello-braveNew:world', {splitOnPunctuation: true}>>(['hello', 'brave', 'New', 'world']);

--- a/test-d/words.ts
+++ b/test-d/words.ts
@@ -94,7 +94,7 @@ expectType<Words<'10item10'>>(['10', 'item', '10']);
 expectType<Words<'010item010'>>(['010', 'item', '010']);
 expectType<Words<'item0_item_1 item -2'>>(['item', '0', 'item', '1', 'item', '2']);
 
-// SplitOnPunctuation: default (false) - punctuation stays attached to following word
+// SplitOnPunctuation
 expectType<Words<':'>>([':']);
 expectType<Words<'::'>>([':', ':']);
 expectType<Words<'hello::'>>(['hello', ':', ':']);
@@ -102,7 +102,6 @@ expectType<Words<'hello:world'>>(['hello', ':world']);
 expectType<Words<'hello::world'>>(['hello', ':', ':world']);
 expectType<Words<'hello-braveNew:world'>>(['hello', 'brave', 'New', ':world']);
 
-// SplitOnPunctuation: true - punctuation is split out when followed by uppercase letter
 expectType<Words<':', {splitOnPunctuation: true}>>([]);
 expectType<Words<'::', {splitOnPunctuation: true}>>([]);
 expectType<Words<'hello::', {splitOnPunctuation: true}>>(['hello']);

--- a/test-d/words.ts
+++ b/test-d/words.ts
@@ -108,5 +108,5 @@ expectType<Words<'hello::', {splitOnPunctuation: true}>>(['hello']);
 expectType<Words<'hello:world', {splitOnPunctuation: true}>>(['hello', 'world']);
 expectType<Words<'hello::world', {splitOnPunctuation: true}>>(['hello', 'world']);
 expectType<Words<'hello-braveNew:world', {splitOnPunctuation: true}>>(['hello', 'brave', 'New', 'world']);
-expectType<Words<'item::01', {splitOnPunctuation:true, splitOnNumbers: false }>>(['item', '01'])
-expectType<Words<'item::01', {splitOnPunctuation:true, splitOnNumbers: true }>>(['item', '01'])
+expectType<Words<'item::01', {splitOnPunctuation: true; splitOnNumbers: false}>>(['item', '01']);
+expectType<Words<'item::01', {splitOnPunctuation: true; splitOnNumbers: true}>>(['item', '01']);


### PR DESCRIPTION
- `WordsOptions`: `splitOnPunctuation` option added. Defaults to `false` for now, so no breaking changes are introduced. Updated JSDoc for the `Words` type.
- `CamelCase, PascalCase, KebabCase, SnakeCase`: 
  - added tests for the new punctuation option. 
  - Updated JSDocs to indicate how the new `splitOnPunctuation` option can be used. 
  - `CamelCase` uses `_DefaultWordsOptions` instead of specifying defaults directly (this would require updates every time a new default option would be added).
- Updated JSDocs follow the `type NamedType1 = NamedType<Value>; //=> result`  pattern.
 
 
Closes #1229 