### PR TITLE
Add `NonNullableDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ export type {SetRequired} from './source/set-required.d.ts';
 export type {SetRequiredDeep} from './source/set-required-deep.d.ts';
 export type {SetNonNullable} from './source/set-non-nullable.d.ts';
 export type {SetNonNullableDeep} from './source/set-non-nullable-deep.d.ts';
+export type {NonNullableDeep} from './source/non-nullable-deep.d.ts';
 export type {ValueOf} from './source/value-of.d.ts';
 export type {AsyncReturnType} from './source/async-return-type.d.ts';
 export type {ConditionalExcept} from './source/conditional-except.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ Click the type names for complete docs.
 - [`SetRequiredDeep`](source/set-required-deep.d.ts) - Like `SetRequired` except it selects the keys deeply.
 - [`SetNonNullable`](source/set-non-nullable.d.ts) - Create a type that makes the given keys non-nullable.
 - [`SetNonNullableDeep`](source/set-non-nullable-deep.d.ts) - Create a type that makes the specified keys non-nullable (removes `null` and `undefined`), supports deeply nested key paths, and leaves all other keys unchanged.
+- [`NonNullableDeep`](source/non-nullable-deep.d.ts) - Recursively removes `null` and `undefined` from the specified type.
 - [`ValueOf`](source/value-of.d.ts) - Create a union of the given object's values, and optionally specify which keys to get the values from.
 - [`ConditionalKeys`](source/conditional-keys.d.ts) - Extract keys from a shape where values extend the given `Condition` type.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Like `Pick` except it selects properties from a shape where the values extend the given `Condition` type.

--- a/source/non-nullable-deep.d.ts
+++ b/source/non-nullable-deep.d.ts
@@ -9,34 +9,60 @@ Use-cases:
 - Normalizing data received from external sources where `null`/`undefined` have been cleaned.
 - Creating non-nullable variants of deeply nested types.
 
+NOTE: Optional modifiers (`?`) are not removed from properties. For example, `NonNullableDeep<{foo?: string | null | undefined}>` will result in `{foo?: string}`. To remove both optional modifiers and nullables, use {@link RequiredDeep} in conjunction with this type.
+
 @example
 ```
 import type {NonNullableDeep} from 'type-fest';
 
-type User = {
+type UserDraft = {
 	name: string | null;
 	address: {
 		city: string | undefined;
-		street?: string | null;
+		postalCode: string | null;
+		landmark?: string | undefined;
 	};
-	contact: {
-		email?: string | null | undefined;
-		phone: string | undefined;
-	};
+	tags: Array<string | null>;
+	visits: Map<string | null, {
+		date: Date | null;
+		notes: Set<string | undefined>;
+	}>;
 };
 
-type UpdatedUser = NonNullableDeep<User>;
+type User = NonNullableDeep<UserDraft>;
 //=> {
 // 	name: string;
 // 	address: {
 // 		city: string;
-// 		street?: string;
+// 		postalCode: string;
+// 		landmark?: string;
 // 	};
-// 	contact: {
-// 		email?: string;
-// 		phone: string;
-// 	};
+// 	tags: string[];
+// 	visits: Map<string, {
+// 		date: Date;
+// 		notes: Set<string>;
+// 	}>;
 // }
+```
+
+@example
+```
+import type {NonNullableDeep} from 'type-fest';
+
+type ArrayExample = NonNullableDeep<[{a: number | undefined}, ...Array<{b: string | null}>]>;
+//=> [{a: number}, ...{b: string}[]]
+
+type MapExample = NonNullableDeep<{a: Map<{a: string | null}, {c: number | undefined}>}>;
+//=> {a: Map<{a: string}, {c: number}>}
+
+type SetExample = NonNullableDeep<Set<{a: string | null}> | null | undefined>;
+//=> Set<{a: string}>
+
+type PromiseExample = NonNullableDeep<{a: Promise<{b: string | null}>}>;
+//=> {a: Promise<{b: string}>}
+
+type FunctionExample = NonNullableDeep<(a: string | null) => number | undefined>;
+//=> (a: string) => number
 ```
 
 @category Utilities

--- a/source/non-nullable-deep.d.ts
+++ b/source/non-nullable-deep.d.ts
@@ -1,0 +1,76 @@
+import type {BuiltIns, HasMultipleCallSignatures} from './internal/type.d.ts';
+import type {IsNever} from './is-never.d.ts';
+import type {Simplify} from './simplify.d.ts';
+
+/**
+Recursively removes `null` and `undefined` from the specified type.
+
+Use-cases:
+- Normalizing data received from external sources where `null`/`undefined` have been cleaned.
+- Creating non-nullable variants of deeply nested types.
+
+@example
+```
+import type {NonNullableDeep} from 'type-fest';
+
+type User = {
+	name: string | null;
+	address: {
+		city: string | undefined;
+		street?: string | null;
+	};
+	contact: {
+		email?: string | null | undefined;
+		phone: string | undefined;
+	};
+};
+
+type UpdatedUser = NonNullableDeep<User>;
+//=> {
+// 	name: string;
+// 	address: {
+// 		city: string;
+// 		street?: string;
+// 	};
+// 	contact: {
+// 		email?: string;
+// 		phone: string;
+// 	};
+// }
+```
+
+@category Utilities
+@category Object
+@category Array
+@category Set
+@category Map
+*/
+export type NonNullableDeep<T> =
+	T extends BuiltIns | (new (...arguments_: any[]) => unknown)
+		? Exclude<T, null | undefined> // `Exclude` is used instead of `NonNullable` because `NonNullable<void>` results in `void & {}`.
+		: T extends Map<infer KeyType, infer ValueType>
+			? Map<NonNullableDeep<KeyType>, NonNullableDeep<ValueType>>
+			: T extends Set<infer ItemType>
+				? Set<NonNullableDeep<ItemType>>
+				: T extends ReadonlyMap<infer KeyType, infer ValueType>
+					? ReadonlyMap<NonNullableDeep<KeyType>, NonNullableDeep<ValueType>>
+					: T extends ReadonlySet<infer ItemType>
+						? ReadonlySet<NonNullableDeep<ItemType>>
+						: T extends WeakMap<infer KeyType, infer ValueType>
+							? WeakMap<NonNullableDeep<KeyType>, NonNullableDeep<ValueType>>
+							: T extends WeakSet<infer ItemType>
+								? WeakSet<NonNullableDeep<ItemType>>
+								: T extends Promise<infer ValueType>
+									? Promise<NonNullableDeep<ValueType>>
+									: T extends (...arguments_: any[]) => unknown
+										? HasMultipleCallSignatures<T> extends true
+											? T
+											: ((...arguments_: NonNullableDeep<Parameters<T>>) => NonNullableDeep<ReturnType<T>>)
+												& (IsNever<keyof T> extends true
+													? unknown
+													: NonNullableDeep<Simplify<T>>) // `Simplify` removes the call signature
+										: T extends object
+											? {[P in keyof T]: NonNullableDeep<T[P]>}
+											: unknown;
+
+export {};

--- a/source/set-non-nullable-deep.d.ts
+++ b/source/set-non-nullable-deep.d.ts
@@ -1,4 +1,6 @@
 import type {NonRecursiveType, StringToNumber} from './internal/index.d.ts';
+import type {IsAny} from './is-any.d.ts';
+import type {NonNullableDeep} from './non-nullable-deep.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {SetNonNullable} from './set-non-nullable.d.ts';
 import type {Simplify} from './simplify.d.ts';
@@ -55,8 +57,9 @@ type ArrayExample2 = SetNonNullableDeep<{a: [(number | null)?, (number | null)?]
 
 @category Object
 */
-export type SetNonNullableDeep<BaseType, KeyPaths extends Paths<BaseType>> =
-	SetNonNullableDeepHelper<BaseType, UnionToTuple<KeyPaths>>;
+export type SetNonNullableDeep<BaseType, KeyPaths extends Paths<BaseType>> = IsAny<KeyPaths> extends true
+	? NonNullableDeep<BaseType>
+	: SetNonNullableDeepHelper<BaseType, UnionToTuple<KeyPaths>>;
 
 /**
 Internal helper for {@link SetNonNullableDeep}.

--- a/source/set-non-nullable-deep.d.ts
+++ b/source/set-non-nullable-deep.d.ts
@@ -10,7 +10,7 @@ import type {UnknownArray} from './unknown-array.d.ts';
 /**
 Create a type that makes the specified keys non-nullable (removes `null` and `undefined`), supports deeply nested key paths, and leaves all other keys unchanged.
 
-NOTE: Optional modifiers (`?`) are not removed from properties. For example, `SetNonNullableDeep<{foo?: string | null | undefined}, 'foo'>` will result in `{foo?: string}`.
+NOTE: Optional modifiers (`?`) are not removed from properties. For example, `SetNonNullableDeep<{foo?: string | null | undefined}, 'foo'>` will result in `{foo?: string}`. To remove both optional modifiers and nullables, use {@link SetRequiredDeep} in conjunction with this type.
 
 @example
 ```

--- a/test-d/non-nullable-deep.ts
+++ b/test-d/non-nullable-deep.ts
@@ -1,0 +1,128 @@
+import {expectType} from 'tsd';
+import type {NonNullableDeep} from '../source/non-nullable-deep.d.ts';
+import type {Primitive} from '../source/primitive.d.ts';
+import type {Simplify} from '../source/simplify.d.ts';
+
+expectType<string>({} as NonNullableDeep<string | null | undefined>);
+expectType<string | number | boolean | bigint | symbol>({} as NonNullableDeep<Primitive>);
+
+// Built-ins
+expectType<Date>({} as NonNullableDeep<Date | null>);
+expectType<RegExp>({} as NonNullableDeep<RegExp | undefined>);
+expectType<void>({} as any as NonNullableDeep<void | null | undefined>);
+expectType<{date: Date; regex: RegExp}>({} as NonNullableDeep<{date: Date | null; regex: RegExp | undefined}>);
+
+// Becomes `never` when the value is only `null` or `undefined`
+expectType<never>({} as NonNullableDeep<null>);
+expectType<never>({} as NonNullableDeep<undefined>);
+expectType<{a: never; b: never; c: never}>({} as NonNullableDeep<{a: null; b: undefined; c: null | undefined}>);
+expectType<[never, never, never, ...never[]]>({} as NonNullableDeep<[null, undefined, null | undefined, ...null[]]>);
+
+// Objects
+expectType<{a: string}>({} as NonNullableDeep<{a: string | null}>);
+expectType<{a: {b: string; c: number}}>({} as NonNullableDeep<{a: {b: string | null; c: number | undefined}}>);
+expectType<{a: {b: string}}>({} as NonNullableDeep<{a: {b: string | null} | null}>);
+expectType<{a: {b: {c: {d: string}}}}>({} as NonNullableDeep<{a: {b: {c: {d: string | null}}}}>);
+expectType<{[x: string]: {a: number}}>({} as NonNullableDeep<{[x: string]: {a: number | null} | null}>);
+expectType<{0: {1: string}; 2: number}>({} as NonNullableDeep<{0: {1: string | null} | null; 2: number | undefined}>);
+
+// Arrays
+expectType<Array<string | number>>({} as NonNullableDeep<Array<string | number | null>>);
+expectType<[foo: string | number, bar: number]>({} as NonNullableDeep<[foo: string | number | null, bar: number | null | undefined]>);
+expectType<[string, number, ...string[]]>({} as NonNullableDeep<[string, number | undefined, ...Array<string | null>]>);
+expectType<[...string[], string, number]>({} as NonNullableDeep<[...Array<string | null>, string, number | undefined]>);
+expectType<[string, number, ...string[], string, number]>({} as NonNullableDeep<[string, number | undefined, ...Array<string | null>, string, number | undefined]>);
+
+expectType<Array<Array<{a: string | [number, {a: string}]}>>>({} as
+	NonNullableDeep<Array<undefined | Array<{a: null | string | [null | undefined | number, {a: string | undefined} | undefined]}>>>,
+);
+
+// Maps, sets, and promises
+expectType<Map<{a: string}, [{b: number}]>>({} as NonNullableDeep<Map<{a: string | null}, [{b: number | undefined}]>>);
+expectType<Set<{a: string}>>({} as NonNullableDeep<Set<{a: string | null}>>);
+expectType<ReadonlyMap<{a: string}, [{b: number}]>>({} as NonNullableDeep<ReadonlyMap<{a: string | null}, [{b: number | undefined}]>>);
+expectType<ReadonlySet<{a: string}>>({} as NonNullableDeep<ReadonlySet<{a: string | null}>>);
+expectType<WeakMap<{a: string}, [{b: number}]>>({} as NonNullableDeep<WeakMap<{a: string | null}, [{b: number | undefined}]>>);
+expectType<WeakSet<{a: string}>>({} as NonNullableDeep<WeakSet<{a: string | null}>>);
+expectType<Promise<{a: string} | {b: number}>>({} as NonNullableDeep<Promise<{a: string | null} | {b: number | null}>>);
+expectType<Promise<Map<string, {a: number}>>>({} as NonNullableDeep<Promise<Map<string | null, {a: number | undefined} | null>>>);
+
+// Preserves `optional` and `readonly` modifiers.
+expectType<{a?: string}>({} as NonNullableDeep<{a?: string | null | undefined}>);
+expectType<{readonly a?: {b?: string | number}; readonly c: number}>(
+	{} as NonNullableDeep<{readonly a?: {b?: string | number} | null; readonly c: number | undefined}>,
+);
+expectType<ReadonlyArray<{a: string}>>({} as NonNullableDeep<ReadonlyArray<{a: string | null}>>);
+expectType<[string?, number?]>({} as NonNullableDeep<[string?, (number | undefined)?]>);
+expectType<readonly [string?, ...Array<number | {a: string}>]>(
+	{} as NonNullableDeep<readonly [string?, ...Array<number | {a: null | string}>]>,
+);
+
+// Unions
+expectType<{a: string} | [number] | Map<string, {a: string}>>(
+	{} as NonNullableDeep<{a: string | null} | [number | null] | Map<string, {a: string | undefined}>>,
+);
+expectType<{a: [string, number] | {a: {b: string} | {c: string}}}>(
+	{} as NonNullableDeep<{a: null | [string, number | null] | {a: {b: string} | {c: string | undefined} | null}}>,
+);
+
+// Constructors remain unchanged
+expectType<new (a: string | null | undefined) => {a: string}>({} as NonNullableDeep<new (a: string | null | undefined) => {a: string}>);
+
+// Functions
+expectType<() => string>({} as NonNullableDeep<() => string | undefined>);
+expectType<(a: string) => void>({} as NonNullableDeep<(a: string | null) => void>);
+expectType<(x: string, y: number) => string>(
+	{} as NonNullableDeep<(x: string | null | undefined, y: number | null | undefined) => string | null | undefined>,
+);
+expectType<(x: [string, {a: string}]) => Map<{a: string}, Set<{b: number}>>>(
+	{} as NonNullableDeep<(x: [string | null, {a: string | undefined}]) => Map<{a: string | null}, Set<{b: number | undefined}>>>,
+);
+
+type FunctionWithProperties = {
+	(a1: string | null | undefined, a2: number | null | undefined): boolean | null | undefined;
+	p1: string | null | undefined;
+	readonly p2: number | null | undefined;
+};
+declare const functionWithProperties: NonNullableDeep<FunctionWithProperties>;
+expectType<boolean>(functionWithProperties('foo', 1));
+// @ts-expect-error
+expectType<boolean>(functionWithProperties(null, 1));
+// @ts-expect-error
+expectType<boolean>(functionWithProperties(undefined, 1));
+// @ts-expect-error
+expectType<boolean>(functionWithProperties('foo', undefined));
+// @ts-expect-error
+expectType<boolean>(functionWithProperties('foo', null));
+expectType<{p1: string; readonly p2: number}>({} as Simplify<typeof functionWithProperties>); // `Simplify` removes the call signature from `typeof functionWithProperties`
+
+type FunctionWithProperties2 = {
+	(a1: boolean, ...a2: Array<string | null | undefined>): number;
+	p1: {p2?: string | null} | undefined;
+};
+declare const functionWithProperties2: NonNullableDeep<FunctionWithProperties2>;
+expectType<number>(functionWithProperties2(true, 'foo', 'bar'));
+// @ts-expect-error
+expectType<number>(functionWithProperties2(true, 'foo', 'bar', null));
+// @ts-expect-error
+expectType<number>(functionWithProperties2(true, undefined));
+expectType<{p1: {p2?: string}}>({} as Simplify<typeof functionWithProperties2>);
+
+// Functions containing multiple call signatures are not transformed
+type FunctionWithProperties4 = {
+	(a1: number | null): string | null;
+	(a1: string | undefined, a2: number | undefined): number | undefined;
+	p1: string | null;
+};
+declare const functionWithProperties4: NonNullableDeep<FunctionWithProperties4>;
+expectType<string | null>(functionWithProperties4(null));
+expectType<number | undefined>(functionWithProperties4(undefined, undefined));
+expectType<{p1: string | null}>({} as Simplify<typeof functionWithProperties4>);
+
+// `any`, `never`, and `unknown` as nested values
+expectType<{a: {b: any}; c: never; d: unknown}>({} as NonNullableDeep<{a: {b: any}; c: never; d: unknown}>);
+
+// Boundary cases
+expectType<never>({} as NonNullableDeep<never>);
+expectType<any>({} as NonNullableDeep<any>);
+expectType<unknown>({} as NonNullableDeep<unknown>);

--- a/test-d/non-nullable-deep.ts
+++ b/test-d/non-nullable-deep.ts
@@ -109,15 +109,15 @@ expectType<number>(functionWithProperties2(true, undefined));
 expectType<{p1: {p2?: string}}>({} as Simplify<typeof functionWithProperties2>);
 
 // Functions containing multiple call signatures are not transformed
-type FunctionWithProperties4 = {
+type FunctionWithProperties3 = {
 	(a1: number | null): string | null;
 	(a1: string | undefined, a2: number | undefined): number | undefined;
 	p1: string | null;
 };
-declare const functionWithProperties4: NonNullableDeep<FunctionWithProperties4>;
-expectType<string | null>(functionWithProperties4(null));
-expectType<number | undefined>(functionWithProperties4(undefined, undefined));
-expectType<{p1: string | null}>({} as Simplify<typeof functionWithProperties4>);
+declare const functionWithProperties3: NonNullableDeep<FunctionWithProperties3>;
+expectType<string | null>(functionWithProperties3(null));
+expectType<number | undefined>(functionWithProperties3(undefined, undefined));
+expectType<{p1: string | null}>({} as Simplify<typeof functionWithProperties3>);
 
 // `any`, `never`, and `unknown` as nested values
 expectType<{a: {b: any}; c: never; d: unknown}>({} as NonNullableDeep<{a: {b: any}; c: never; d: unknown}>);

--- a/test-d/set-non-nullable-deep.ts
+++ b/test-d/set-non-nullable-deep.ts
@@ -67,6 +67,14 @@ expectType<{a: {b: string} | {c: string} | {b: {c: string | null}}}>(
 	{} as SetNonNullableDeep<{a: {b: string | null} | {c: string} | {b: {c: string | null} | undefined}}, 'a.b'>,
 );
 
+// Calls `NonNullableDeep` when `KeyPaths` is `any`
+expectType<{a: number; readonly b?: {c: string}}>(
+	{} as SetNonNullableDeep<{a: number | null; readonly b?: {c: string | undefined} | null}, any>,
+);
+expectType<[[{a: string}], Map<{a: string}, string>]>(
+	{} as SetNonNullableDeep<[[{a: string | null}], Map<{a: string | null}, string | null>], any>,
+);
+
 // Preserves non-nullable values when they are in a union with objects
 expectType<{a?: {b: string} | number}>({} as SetNonNullableDeep<{a?: {b: string} | number | null | undefined}, 'a'>);
 expectType<{a: {b: Array<{c?: number | null}> | number}}>({} as SetNonNullableDeep<{a: {b: Array<{c?: number | null}> | number | null}}, 'a.b'>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1400 

Also, handles the following from #1117:
> `SetNonNullableDeep` currently doesn't deeply remove all nullables if `KeyPaths` is `any`.