### PR TITLE
Use `NoInfer` utility type where applicable

### DIFF
--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -95,7 +95,7 @@ const parsed = parse(x); // The type of `parsed` is { hello: string }
 
 @category Type
 */
-export type GetTagMetadata<Type extends Tag<TagName, unknown>, TagName extends PropertyKey> = Type[typeof tag][TagName];
+export type GetTagMetadata<Type extends Tag<NoInfer<TagName>, unknown>, TagName extends PropertyKey> = Type[typeof tag][TagName];
 
 /**
 Get the untagged portion of a tagged type created with `Tagged`.


### PR DESCRIPTION
## Summary

Addresses #848 by applying TypeScript 5.4's `NoInfer` utility type where it genuinely improves inference behavior.

## Changes

### `GetTagMetadata` in `source/tagged.d.ts`

**Before:**
```ts
export type GetTagMetadata<Type extends Tag<TagName, unknown>, TagName extends PropertyKey> = ...
```

**After:**
```ts
export type GetTagMetadata<Type extends Tag<NoInfer<TagName>, unknown>, TagName extends PropertyKey> = ...
```

**Why `NoInfer` helps here:**

The constraint `Type extends Tag<TagName, unknown>` creates two potential inference sites for `TagName`:

1. The structural shape of `Type` — since `Type` must extend `Tag<TagName, unknown>`, TypeScript can infer `TagName` by inspecting which tags `Type` carries.
2. The explicit `TagName` argument itself.

When `GetTagMetadata` is used in a generic function that accepts both a tagged value and a tag name:

```ts
declare function readTag<T extends Tag<K, unknown>, K extends PropertyKey>(
  tagged: T,
  tagName: K
): GetTagMetadata<T, K>;
```

Without `NoInfer`, TypeScript may use the structure of `T` as an inference site for `K`, potentially widening `K` when `T` carries multiple tags. With `NoInfer<TagName>` in the constraint, `K` is inferred **only** from the explicit `tagName` argument — which is the intended semantics. The tagged value's structure should *validate* the lookup, not *determine* the tag name.

## What was reviewed

All source types in `source/` were reviewed for `NoInfer` applicability. Most type-fest types are pure type-level utilities that don't involve competing inference sites for the same type parameter — `NoInfer` is primarily beneficial in function generics, and most type-fest types are used as explicit type arguments rather than inferred from multiple argument positions simultaneously.

`GetTagMetadata` is the clearest case: it has both a constraint-based inference site *and* an explicit parameter for the same `TagName` variable, making `NoInfer` semantically correct.

## Tests

All existing tests pass:
- `test-d/opaque.ts` — covers `Tagged`, `GetTagMetadata`, `UnwrapTagged`, etc.
- TypeScript compiler (`tsc --noEmit`) passes with no errors.

Closes #848