### PR TITLE
`CamelCase`: Add `preserveLeadingUnderscores` option

### DIFF
--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -46,7 +46,6 @@ type LeadingUnderscores<Type extends string, Underscores extends string = ''> =
 		? LeadingUnderscores<Rest, `_${Underscores}`>
 		: Underscores;
 
-
 /**
 Convert an array of words to camel-case.
 */
@@ -117,9 +116,9 @@ export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extend
 		: `${Options['preserveLeadingUnderscores'] extends true
 			? LeadingUnderscores<Type>
 			: ''}${Uncapitalize<CamelCaseFromArray<
-			Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
-			ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
-		>>}`
+				Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
+				ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
+			>>}`
 	: Type;
 
 export {};

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -46,7 +46,6 @@ type LeadingUnderscores<Type extends string, Underscores extends string = ''> =
 		? LeadingUnderscores<Rest, `_${Underscores}`>
 		: Underscores;
 
-type StripLeadingUnderscores<S extends string> = S extends `_${infer Rest}` ? StripLeadingUnderscores<Rest> : S;
 
 /**
 Convert an array of words to camel-case.
@@ -115,17 +114,12 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extends string
 	? string extends Type
 		? Type
-		: Options['preserveLeadingUnderscores'] extends true
-			? StripLeadingUnderscores<Type> extends infer Stripped extends string
-				? `${LeadingUnderscores<Type>}${Uncapitalize<CamelCaseFromArray<
-					Words<Stripped extends Uppercase<Stripped> ? Lowercase<Stripped> : Stripped, Options>,
-					ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
-				>>}`
-				: never
-			: Uncapitalize<CamelCaseFromArray<
-				Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
-				ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
-			>>
+		: `${Options['preserveLeadingUnderscores'] extends true
+			? LeadingUnderscores<Type>
+			: ''}${Uncapitalize<CamelCaseFromArray<
+			Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
+			ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
+		>>}`
 	: Type;
 
 export {};

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -13,11 +13,25 @@ export type CamelCaseOptions = WordsOptions & {
 	@default false
 	*/
 	preserveConsecutiveUppercase?: boolean;
+
+	/**
+	Whether to preserve leading underscores.
+
+	This matches the behavior of the [`camelcase`](https://github.com/sindresorhus/camelcase) package v9+.
+
+	@default false
+	*/
+	preserveLeadingUnderscores?: boolean;
 };
 
 export type _DefaultCamelCaseOptions = _DefaultWordsOptions & {
 	preserveConsecutiveUppercase: false;
+	preserveLeadingUnderscores: false;
 };
+
+type LeadingUnderscores<S extends string> = S extends `_${infer Rest}` ? `_${LeadingUnderscores<Rest>}` : '';
+
+type StripLeadingUnderscores<S extends string> = S extends `_${infer Rest}` ? StripLeadingUnderscores<Rest> : S;
 
 /**
 Convert an array of words to camel-case.
@@ -42,6 +56,8 @@ This can be useful when, for example, converting some kebab-cased command-line f
 
 By default, consecutive uppercase letter are preserved. See {@link CamelCaseOptions.preserveConsecutiveUppercase preserveConsecutiveUppercase} option to change this behaviour.
 
+Use the `preserveLeadingUnderscores` option to retain leading underscores, matching the runtime behavior of [`camelcase`](https://github.com/sindresorhus/camelcase) v9+.
+
 @example
 ```
 import type {CamelCase} from 'type-fest';
@@ -51,6 +67,7 @@ import type {CamelCase} from 'type-fest';
 const someVariable: CamelCase<'foo-bar'> = 'fooBar';
 const preserveConsecutiveUppercase: CamelCase<'foo-BAR-baz', {preserveConsecutiveUppercase: true}> = 'fooBARBaz';
 const splitOnPunctuation: CamelCase<'foo-bar:BAZ', {splitOnPunctuation: true}> = 'fooBarBaz';
+const preserveLeadingUnderscores: CamelCase<'_foo_bar', {preserveLeadingUnderscores: true}> = '_fooBar';
 
 // Advanced
 
@@ -83,10 +100,17 @@ const dbResult: CamelCasedProperties<RawOptions> = {
 export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extends string
 	? string extends Type
 		? Type
-		: Uncapitalize<CamelCaseFromArray<
-			Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
-			ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
-		>>
+		: Options['preserveLeadingUnderscores'] extends true
+			? StripLeadingUnderscores<Type> extends infer Stripped extends string
+				? `${LeadingUnderscores<Type>}${Uncapitalize<CamelCaseFromArray<
+					Words<Stripped extends Uppercase<Stripped> ? Lowercase<Stripped> : Stripped, Options>,
+					ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
+				>>}`
+				: never
+			: Uncapitalize<CamelCaseFromArray<
+				Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
+				ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
+			>>
 	: Type;
 
 export {};

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -29,7 +29,22 @@ export type _DefaultCamelCaseOptions = _DefaultWordsOptions & {
 	preserveLeadingUnderscores: false;
 };
 
-type LeadingUnderscores<S extends string> = S extends `_${infer Rest}` ? `_${LeadingUnderscores<Rest>}` : '';
+/**
+Extract leading underscores from a string.
+
+@example
+```
+type A = LeadingUnderscores<'__foo_bar'>;
+//=> '__'
+
+type B = LeadingUnderscores<'foo_bar'>;
+//=> ''
+```
+*/
+type LeadingUnderscores<Type extends string, Underscores extends string = ''> =
+	Type extends `_${infer Rest}`
+		? LeadingUnderscores<Rest, `_${Underscores}`>
+		: Underscores;
 
 type StripLeadingUnderscores<S extends string> = S extends `_${infer Rest}` ? StripLeadingUnderscores<Rest> : S;
 

--- a/source/camel-case.d.ts
+++ b/source/camel-case.d.ts
@@ -115,10 +115,11 @@ export type CamelCase<Type, Options extends CamelCaseOptions = {}> = Type extend
 		? Type
 		: `${Options['preserveLeadingUnderscores'] extends true
 			? LeadingUnderscores<Type>
-			: ''}${Uncapitalize<CamelCaseFromArray<
-				Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
-				ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
-			>>}`
+			: ''
+		}${Uncapitalize<CamelCaseFromArray<
+			Words<Type extends Uppercase<Type> ? Lowercase<Type> : Type, Options>,
+			ApplyDefaultOptions<CamelCaseOptions, _DefaultCamelCaseOptions, Options>
+		>>}`
 	: Type;
 
 export {};

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -99,3 +99,12 @@ expectType<CamelCase<'fooBAR:biz', {splitOnPunctuation: true; preserveConsecutiv
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true}>>('fooBar01');
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('fooBar01');
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>>('fooBar01');
+
+expectType<CamelCase<'_foo_bar', {preserveLeadingUnderscores: true}>>('_fooBar');
+expectType<CamelCase<'__foo_bar', {preserveLeadingUnderscores: true}>>('__fooBar');
+expectType<CamelCase<'_FOO_BAR', {preserveLeadingUnderscores: true}>>('_fooBar');
+expectType<CamelCase<'__FOO_BAR', {preserveLeadingUnderscores: true}>>('__fooBar');
+expectType<CamelCase<'_foo-bar', {preserveLeadingUnderscores: true}>>('_fooBar');
+expectType<CamelCase<'_fooBAR', {preserveLeadingUnderscores: true; preserveConsecutiveUppercase: true}>>('_fooBAR');
+expectType<CamelCase<'_foo_bar'>>('fooBar');
+expectType<CamelCase<'_foo_bar', {preserveLeadingUnderscores: false}>>('fooBar');

--- a/test-d/camel-case.ts
+++ b/test-d/camel-case.ts
@@ -100,6 +100,7 @@ expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true}>>('fooBar01');
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: false}>>('fooBar01');
 expectType<CamelCase<'foo-bar::01', {splitOnPunctuation: true; splitOnNumbers: true}>>('fooBar01');
 
+expectType<CamelCase<'foo_bar', {preserveLeadingUnderscores: true}>>('fooBar');
 expectType<CamelCase<'_foo_bar', {preserveLeadingUnderscores: true}>>('_fooBar');
 expectType<CamelCase<'__foo_bar', {preserveLeadingUnderscores: true}>>('__fooBar');
 expectType<CamelCase<'_FOO_BAR', {preserveLeadingUnderscores: true}>>('_fooBar');

--- a/test-d/camel-cased-properties-deep.ts
+++ b/test-d/camel-cased-properties-deep.ts
@@ -90,3 +90,7 @@ expectType<{fooBar: {barBaz: any}; biz: any}>({} as CamelCasedPropertiesDeep<{fo
 
 expectType<{'fooBar': unknown}>({} as CamelCasedPropertiesDeep<{'foo::bar': unknown}, {splitOnPunctuation: true}>);
 expectType<{'fooBar': {'barBaz': unknown}; biz: unknown}>({} as CamelCasedPropertiesDeep<{'foo::bar': {'bar@baz': unknown}; biz: unknown}, {splitOnPunctuation: true}>);
+
+expectType<{_fooBar: {_bazQux: string}}>({} as CamelCasedPropertiesDeep<{_foo_bar: {_baz_qux: string}}, {preserveLeadingUnderscores: true}>);
+expectType<{__fooBar: string}>({} as CamelCasedPropertiesDeep<{__foo_bar: string}, {preserveLeadingUnderscores: true}>);
+expectType<{fooBar: {bazQux: string}}>({} as CamelCasedPropertiesDeep<{_foo_bar: {_baz_qux: string}}>);

--- a/test-d/camel-cased-properties.ts
+++ b/test-d/camel-cased-properties.ts
@@ -42,3 +42,9 @@ const result: CamelCasedProperties<User> = {
 };
 expectType<CamelCasedProperties<User>>(result);
 expectType<CamelCasedProperties<UserPunctuated, {splitOnPunctuation: true}>>(result);
+
+declare const withLeadingUnderscores: CamelCasedProperties<{_foo_bar: string; __baz_qux: number}, {preserveLeadingUnderscores: true}>;
+expectType<{_fooBar: string; __bazQux: number}>(withLeadingUnderscores);
+
+declare const withLeadingUnderscoresDefault: CamelCasedProperties<{_foo_bar: string}>;
+expectType<{fooBar: string}>(withLeadingUnderscoresDefault);


### PR DESCRIPTION
Fixes #1299

`camelcase` v9 changed its behavior to preserve leading underscores (e.g. `_foo_bar` → `_fooBar`). This adds a matching opt-in `preserveLeadingUnderscores` option to `CamelCase`, `CamelCasedProperties`, and `CamelCasedPropertiesDeep` so the type-level and runtime behaviors can be kept in sync.

The option is opt-in (default `false`) to preserve backwards compatibility.