### PR TITLE
`UnionToTuple`: Fix behavior with large unions

### DIFF
--- a/source/union-to-tuple.d.ts
+++ b/source/union-to-tuple.d.ts
@@ -1,6 +1,7 @@
 import type {ExcludeExactly} from './exclude-exactly.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {UnionMember} from './union-member.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
 
 /**
 Convert a union type into an unordered tuple type of its elements.
@@ -37,9 +38,11 @@ const petList = Object.keys(pets) as UnionToTuple<Pet>;
 
 @category Array
 */
-export type UnionToTuple<T, L = UnionMember<T>> =
-	IsNever<T> extends false
-		? [...UnionToTuple<ExcludeExactly<T, L>>, L]
-		: [];
+export type UnionToTuple<Union> = _UnionToTuple<Union>;
+
+type _UnionToTuple<Union, Accumulator extends UnknownArray = [], Member = UnionMember<Union>> =
+	IsNever<Union> extends true
+		? Accumulator
+		: _UnionToTuple<ExcludeExactly<Union, Member>, [Member, ...Accumulator]>;
 
 export {};

--- a/test-d/union-to-tuple.ts
+++ b/test-d/union-to-tuple.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectType} from 'tsd';
-import type {UnionToTuple} from '../index.d.ts';
+import type {IntClosedRange, UnionToTuple} from '../index.d.ts';
 
 type Options = UnionToTuple<'a' | 'b' | 'c'>;
 // Results unordered
@@ -18,6 +18,13 @@ expectType<Options2[number]>({} as (1 | false | true));
 // See [this comment](https://github.com/sindresorhus/type-fest/pull/1349#issuecomment-3858719735) for more details.
 type DifferentModifierUnion = {readonly a: 0} | {a: 0};
 expectType<DifferentModifierUnion>({} as UnionToTuple<DifferentModifierUnion>[number]);
+
+// Long unions
+type OneToFifty = IntClosedRange<1, 50>;
+type OneToTwoHundred = IntClosedRange<1, 200>;
+
+expectType<UnionToTuple<OneToFifty>[number]>({} as OneToFifty);
+expectType<UnionToTuple<OneToTwoHundred>[number]>({} as OneToTwoHundred);
 
 // Edge cases.
 expectType<[]>({} as UnionToTuple<never>);

--- a/test-d/union-to-tuple.ts
+++ b/test-d/union-to-tuple.ts
@@ -20,11 +20,8 @@ type DifferentModifierUnion = {readonly a: 0} | {a: 0};
 expectType<DifferentModifierUnion>({} as UnionToTuple<DifferentModifierUnion>[number]);
 
 // Long unions
-type OneToFifty = IntClosedRange<1, 50>;
-type OneToTwoHundred = IntClosedRange<1, 200>;
-
-expectType<UnionToTuple<OneToFifty>[number]>({} as OneToFifty);
-expectType<UnionToTuple<OneToTwoHundred>[number]>({} as OneToTwoHundred);
+expectType<50>({} as UnionToTuple<IntClosedRange<1, 50>>['length']);
+expectType<200>({} as UnionToTuple<IntClosedRange<1, 200>>['length']);
 
 // Edge cases.
 expectType<[]>({} as UnionToTuple<never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently, `UnionToTuple` hits recursion limits when the input union contains around 45 members.

This PR refactors `UnionToTuple` to leverage tail recursion, allowing it to generate longer tuples.