### PR TITLE
`ApplyDefaultOptions`: Fix behavior with explicit `undefined`

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -3,7 +3,6 @@ import type {IsEqual} from '../is-equal.d.ts';
 import type {KeysOfUnion} from '../keys-of-union.d.ts';
 import type {RequiredKeysOf} from '../required-keys-of.d.ts';
 import type {Merge} from '../merge.d.ts';
-import type {OptionalKeysOf} from '../optional-keys-of.d.ts';
 import type {IsAny} from '../is-any.d.ts';
 import type {If} from '../if.d.ts';
 import type {IsNever} from '../is-never.d.ts';
@@ -228,7 +227,7 @@ export type ApplyDefaultOptions<
 		If<IsNever<SpecifiedOptions>, Defaults,
 			Simplify<Merge<Defaults, {
 				[Key in keyof SpecifiedOptions
-				as Key extends OptionalKeysOf<Options> ? undefined extends SpecifiedOptions[Key] ? never : Key : Key
+				as undefined extends Required<Options>[Key & keyof Options] ? Key : undefined extends SpecifiedOptions[Key] ? never : Key
 				]: SpecifiedOptions[Key]
 			}> & Required<Options>>>>; // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
 

--- a/test-d/internal/apply-default-options.ts
+++ b/test-d/internal/apply-default-options.ts
@@ -36,9 +36,8 @@ expectType<{fixedLengthOnly: false; strict: true}>(requiredOptions);
 declare const undefinedsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth: undefined}>; // Possible when `exactOptionalPropertyTypes` is disabled
 expectType<DefaultPathsOptions>(undefinedsGetOverwritten);
 
-// Caveat: User specified `undefined` for optional properties with explicit undefined also gets overwritten
 declare const undefinedsGetOverwritten2: ApplyDefaultOptions<{recurseIntoArrays?: boolean | undefined}, {recurseIntoArrays: true}, {recurseIntoArrays: undefined}>;
-expectType<{recurseIntoArrays: true}>(undefinedsGetOverwritten2);
+expectType<{recurseIntoArrays: undefined}>(undefinedsGetOverwritten2);
 
 declare const undefinedAsValidValue: ApplyDefaultOptions<{recurseIntoArrays: boolean | undefined}, {}, {recurseIntoArrays: undefined}>;
 expectType<{recurseIntoArrays: undefined}>(undefinedAsValidValue);

--- a/xo.config.js
+++ b/xo.config.js
@@ -66,6 +66,7 @@ const xoConfig = [
 		rules: {
 			'unicorn/no-immediate-mutation': 'off',
 			'require-unicode-regexp': 'off',
+			'@typescript-eslint/no-unnecessary-type-assertion': 'off',
 		},
 	},
 	{


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Minor change, this PR solves the caveat mentioned below:
https://github.com/sindresorhus/type-fest/blob/a5491644b32160f804dd10d0b44dad461037f4c1/test-d/internal/apply-default-options.ts#L39-L41