### PR TITLE
`ExtendsStrict`: Add `distributiveUnions`, `strictNever` & `strictAny` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -213,7 +213,7 @@ export type {PackageJson} from './source/package-json.d.ts';
 export type {TsConfigJson} from './source/tsconfig-json.d.ts';
 
 // Improved built-in
-export type {ExtendsStrict} from './source/extends-strict.d.ts';
+export type {ExtendsStrict, ExtendsStrictOptions} from './source/extends-strict.d.ts';
 export type {ExtractStrict} from './source/extract-strict.d.ts';
 export type {ExcludeStrict} from './source/exclude-strict.d.ts';
 export type {ExcludeExactly} from './source/exclude-exactly.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -336,7 +336,7 @@ Click the type names for complete docs.
 
 ### Improved built-in
 
-- [`ExtendsStrict`](source/extends-strict.d.ts) - A stricter, non-distributive version of `extends` for checking whether one type is assignable to another.
+- [`ExtendsStrict`](source/extends-strict.d.ts) - A customizable version of `extends` for checking whether one type is assignable to another.
 - [`ExtractStrict`](source/extract-strict.d.ts) - A stricter version of `Extract<T, U>` that ensures every member of `U` can successfully extract something from `T`.
 - [`ExcludeStrict`](source/exclude-strict.d.ts) - A stricter version of `Exclude<T, U>` that ensures every member of `U` can successfully exclude something from `T`.
 - [`ExcludeExactly`](source/exclude-exactly.d.ts) - A stricter version of `Exclude<T, U>` that excludes types only when they are exactly identical.

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -47,6 +47,8 @@ export type ExtendsStrictOptions = {
 	type T4 = ExtendsStrict<never, any, {strictNever: true}>;
 	//=> true
 	```
+
+	Note: This option only has an effect when checking assignability from `never` (`ExtendsStrict<never, ...>`), and not when checking assignability to `never` (`ExtendsStrict<..., never>`).
 	*/
 	strictNever?: boolean;
 
@@ -89,6 +91,8 @@ export type ExtendsStrictOptions = {
 	type T3 = ExtendsStrict<any, unknown, {strictAny: false; distributiveUnions: true}>;
 	//=> true
 	```
+
+	Note: This option only has an effect when checking assignability from `any` (`ExtendsStrict<any, ...>`), and not when checking assignability to `any` (`ExtendsStrict<..., any>`).
 	*/
 	strictAny?: boolean;
 };

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -4,6 +4,7 @@ import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {And} from './and.d.ts';
 import type {Or} from './or.d.ts';
 import type {IsUnknown} from './is-unknown.d.ts';
+import type {OrAll} from './or-all.d.ts';
 
 export type ExtendsStrictOptions = {
 	/**
@@ -27,7 +28,7 @@ export type ExtendsStrictOptions = {
 	/**
 	Whether `never` extends every other type.
 
-	When enabled, `never` is not treated as a bottom type and only extends itself (or `any`).
+	When enabled, `never` is not treated as a bottom type and only extends itself (or `any` / `unknown`).
 
 	@default true
 
@@ -45,6 +46,9 @@ export type ExtendsStrictOptions = {
 	//=> true
 
 	type T4 = ExtendsStrict<never, any, {strictNever: true}>;
+	//=> true
+
+	type T5 = ExtendsStrict<never, unknown, {strictNever: true}>;
 	//=> true
 	```
 
@@ -134,7 +138,7 @@ type _ExtendsStrict<Left, Right, Options extends Required<ExtendsStrictOptions>>
 		? Or<IsAny<Right>, IsUnknown<Right>>
 		: IsNever<Left> extends true
 			? Options['strictNever'] extends true
-				? Or<IsNever<Right>, IsAny<Right>>
+				? OrAll<[IsNever<Right>, IsAny<Right>, IsUnknown<Right>]>
 				: true
 			: Options['distributiveUnions'] extends true
 				? Left extends Right

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -35,16 +35,16 @@ export type ExtendsStrictOptions = {
 	```
 	import type {ExtendsStrict} from 'type-fest';
 
-	type T1 = ExtendsStrict<never, number, {strictNever: false}>;
-	//=> true
-
-	type T2 = ExtendsStrict<never, number, {strictNever: true}>;
+	type T1 = ExtendsStrict<never, number, {strictNever: true}>;
 	//=> false
 
-	type T3 = ExtendsStrict<never, never, {strictNever: false}>;
+	type T2 = ExtendsStrict<never, number, {strictNever: false}>;
 	//=> true
 
-	type T4 = ExtendsStrict<never, any, {strictNever: false}>;
+	type T3 = ExtendsStrict<never, never, {strictNever: true}>;
+	//=> true
+
+	type T4 = ExtendsStrict<never, any, {strictNever: true}>;
 	//=> true
 	```
 	*/
@@ -61,16 +61,16 @@ export type ExtendsStrictOptions = {
 	```
 	import type {ExtendsStrict} from 'type-fest';
 
-	type T1 = ExtendsStrict<any, number, {strictAny: false; distributiveUnions: false}>;
-	//=> true
-
-	type T2 = ExtendsStrict<any, number, {strictAny: true}>;
+	type T1 = ExtendsStrict<any, number, {strictAny: true}>;
 	//=> false
 
-	type T3 = ExtendsStrict<any, any, {strictAny: false}>;
+	type T2 = ExtendsStrict<any, number, {strictAny: false; distributiveUnions: false}>;
 	//=> true
 
-	type T4 = ExtendsStrict<any, unknown, {strictAny: false}>;
+	type T3 = ExtendsStrict<any, any, {strictAny: true}>;
+	//=> true
+
+	type T4 = ExtendsStrict<any, unknown, {strictAny: true}>;
 	//=> true
 	```
 

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -30,74 +30,74 @@ export type ExtendsStrictOptions = {
 
 	When enabled, `never` is not treated as a bottom type and only extends itself (or `any`).
 
-	@default false
-
-	@example
-	```
-	import type {ExtendsStrict} from 'type-fest';
-
-	type T1 = ExtendsStrict<never, number, {neverExtendsAll: true}>;
-	//=> true
-
-	type T2 = ExtendsStrict<never, number, {neverExtendsAll: false}>;
-	//=> false
-
-	type T3 = ExtendsStrict<never, never, {neverExtendsAll: true}>;
-	//=> true
-
-	type T4 = ExtendsStrict<never, any, {neverExtendsAll: true}>;
-	//=> true
-	```
-	*/
-	neverExtendsAll?: boolean;
-
-	/**
-	Whether `any` extends every other type.
-
-	When enabled, `any` does not extend every other type, it only extends itself (or `unknown`).
-
 	@default true
 
 	@example
 	```
 	import type {ExtendsStrict} from 'type-fest';
 
-	type T1 = ExtendsStrict<any, number, {anyExtendsAll: true; distributiveUnions: false}>;
+	type T1 = ExtendsStrict<never, number, {strictNever: false}>;
 	//=> true
 
-	type T2 = ExtendsStrict<any, number, {anyExtendsAll: false}>;
+	type T2 = ExtendsStrict<never, number, {strictNever: true}>;
 	//=> false
 
-	type T3 = ExtendsStrict<any, any, {anyExtendsAll: true}>;
+	type T3 = ExtendsStrict<never, never, {strictNever: false}>;
 	//=> true
 
-	type T4 = ExtendsStrict<any, unknown, {anyExtendsAll: true}>;
+	type T4 = ExtendsStrict<never, any, {strictNever: false}>;
 	//=> true
 	```
+	*/
+	strictNever?: boolean;
 
-	Note: If both `anyExtendsAll` and `distributiveUnions` are `true`, then `any` would distribute and the result would be the `boolean` type, except when checking assignability to `any` or `unknown`.
+	/**
+	Whether `any` extends every other type.
+
+	When enabled, `any` does not extend every other type, it only extends itself (or `unknown`).
+
+	@default false
 
 	@example
 	```
 	import type {ExtendsStrict} from 'type-fest';
 
-	type T1 = ExtendsStrict<any, number, {anyExtendsAll: true; distributiveUnions: true}>;
-	//=> boolean
-
-	type T2 = ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: true}>;
+	type T1 = ExtendsStrict<any, number, {strictAny: false; distributiveUnions: false}>;
 	//=> true
 
-	type T3 = ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: true}>;
+	type T2 = ExtendsStrict<any, number, {strictAny: true}>;
+	//=> false
+
+	type T3 = ExtendsStrict<any, any, {strictAny: false}>;
+	//=> true
+
+	type T4 = ExtendsStrict<any, unknown, {strictAny: false}>;
+	//=> true
+	```
+
+	Note: If `strictAny` is `false` and `distributiveUnions` is `true`, then `any` would distribute and the result would be the `boolean` type, except when checking assignability to `any` or `unknown`.
+
+	@example
+	```
+	import type {ExtendsStrict} from 'type-fest';
+
+	type T1 = ExtendsStrict<any, number, {strictAny: false; distributiveUnions: true}>;
+	//=> boolean
+
+	type T2 = ExtendsStrict<any, any, {strictAny: false; distributiveUnions: true}>;
+	//=> true
+
+	type T3 = ExtendsStrict<any, unknown, {strictAny: false; distributiveUnions: true}>;
 	//=> true
 	```
 	*/
-	anyExtendsAll?: boolean;
+	strictAny?: boolean;
 };
 
 type DefaultExtendsStrictOptions = {
 	distributiveUnions: false;
-	neverExtendsAll: false;
-	anyExtendsAll: true;
+	strictNever: true;
+	strictAny: false;
 };
 
 /**
@@ -112,10 +112,10 @@ import type {ExtendsStrict} from 'type-fest';
 type T1 = ExtendsStrict<number | string, string, {distributiveUnions: false}>;
 //=> false
 
-type T2 = ExtendsStrict<never, number, {neverExtendsAll: false}>;
+type T2 = ExtendsStrict<never, number, {strictNever: true}>;
 //=> false
 
-type T3 = ExtendsStrict<any, number, {anyExtendsAll: false}>;
+type T3 = ExtendsStrict<any, number, {strictAny: true}>;
 //=> false
 ```
 
@@ -127,12 +127,12 @@ export type ExtendsStrict<Left, Right, Options extends ExtendsStrictOptions = {}
 	_ExtendsStrict<Left, Right, ApplyDefaultOptions<ExtendsStrictOptions, DefaultExtendsStrictOptions, Options>>;
 
 type _ExtendsStrict<Left, Right, Options extends Required<ExtendsStrictOptions>> =
-	And<IsAny<Left>, Not<Options['anyExtendsAll']>> extends true
+	And<IsAny<Left>, Options['strictAny']> extends true
 		? Or<IsAny<Right>, IsUnknown<Right>>
 		: IsNever<Left> extends true
-			? Options['neverExtendsAll'] extends true
-				? true
-				: Or<IsNever<Right>, IsAny<Right>>
+			? Options['strictNever'] extends true
+				? Or<IsNever<Right>, IsAny<Right>>
+				: true
 			: Options['distributiveUnions'] extends true
 				? Left extends Right
 					? true

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -2,7 +2,6 @@ import type {IsNever} from './is-never.d.ts';
 import type {IsAny} from './is-any.d.ts';
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {And} from './and.d.ts';
-import type {Not} from './internal/type.d.ts';
 import type {Or} from './or.d.ts';
 import type {IsUnknown} from './is-unknown.d.ts';
 

--- a/source/extends-strict.d.ts
+++ b/source/extends-strict.d.ts
@@ -1,44 +1,144 @@
 import type {IsNever} from './is-never.d.ts';
 import type {IsAny} from './is-any.d.ts';
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {And} from './and.d.ts';
+import type {Not} from './internal/type.d.ts';
+import type {Or} from './or.d.ts';
+import type {IsUnknown} from './is-unknown.d.ts';
+
+export type ExtendsStrictOptions = {
+	/**
+	Whether to distribute over unions.
+
+	@default false
+
+	@example
+	```
+	import type {ExtendsStrict} from 'type-fest';
+
+	type T1 = ExtendsStrict<string | number, string, {distributiveUnions: true}>;
+	//=> boolean
+
+	type T2 = ExtendsStrict<string | number, string, {distributiveUnions: false}>;
+	//=> false
+	```
+	*/
+	distributiveUnions?: boolean;
+
+	/**
+	Whether `never` extends every other type.
+
+	When enabled, `never` is not treated as a bottom type and only extends itself (or `any`).
+
+	@default false
+
+	@example
+	```
+	import type {ExtendsStrict} from 'type-fest';
+
+	type T1 = ExtendsStrict<never, number, {neverExtendsAll: true}>;
+	//=> true
+
+	type T2 = ExtendsStrict<never, number, {neverExtendsAll: false}>;
+	//=> false
+
+	type T3 = ExtendsStrict<never, never, {neverExtendsAll: true}>;
+	//=> true
+
+	type T4 = ExtendsStrict<never, any, {neverExtendsAll: true}>;
+	//=> true
+	```
+	*/
+	neverExtendsAll?: boolean;
+
+	/**
+	Whether `any` extends every other type.
+
+	When enabled, `any` does not extend every other type, it only extends itself (or `unknown`).
+
+	@default true
+
+	@example
+	```
+	import type {ExtendsStrict} from 'type-fest';
+
+	type T1 = ExtendsStrict<any, number, {anyExtendsAll: true; distributiveUnions: false}>;
+	//=> true
+
+	type T2 = ExtendsStrict<any, number, {anyExtendsAll: false}>;
+	//=> false
+
+	type T3 = ExtendsStrict<any, any, {anyExtendsAll: true}>;
+	//=> true
+
+	type T4 = ExtendsStrict<any, unknown, {anyExtendsAll: true}>;
+	//=> true
+	```
+
+	Note: If both `anyExtendsAll` and `distributiveUnions` are `true`, then `any` would distribute and the result would be the `boolean` type, except when checking assignability to `any` or `unknown`.
+
+	@example
+	```
+	import type {ExtendsStrict} from 'type-fest';
+
+	type T1 = ExtendsStrict<any, number, {anyExtendsAll: true; distributiveUnions: true}>;
+	//=> boolean
+
+	type T2 = ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: true}>;
+	//=> true
+
+	type T3 = ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: true}>;
+	//=> true
+	```
+	*/
+	anyExtendsAll?: boolean;
+};
+
+type DefaultExtendsStrictOptions = {
+	distributiveUnions: false;
+	neverExtendsAll: false;
+	anyExtendsAll: true;
+};
 
 /**
-A stricter, non-distributive version of `extends` for checking whether one type is assignable to another.
+A customizable version of `extends` for checking whether one type is assignable to another.
 
-Unlike the built-in `extends` keyword, `ExtendsStrict`:
-
-1. Prevents distribution over union types by wrapping both types in tuples. For example, `ExtendsStrict<string | number, number>` returns `false`, whereas `string | number extends number` would result in `boolean`.
-
-2. Treats `never` as a special case: `never` doesn't extend every other type, it only extends itself (or `any`). For example, `ExtendsStrict<never, number>` returns `false` whereas `never extends number` would result in `true`.
+Refer {@link ExtendsStrictOptions} for the different ways you can customize the behavior of this type.
 
 @example
 ```
 import type {ExtendsStrict} from 'type-fest';
 
-type T1 = ExtendsStrict<number | string, string>;
+type T1 = ExtendsStrict<number | string, string, {distributiveUnions: false}>;
 //=> false
 
-type T2 = ExtendsStrict<never, number>;
+type T2 = ExtendsStrict<never, number, {neverExtendsAll: false}>;
 //=> false
 
-type T3 = ExtendsStrict<never, never>;
-//=> true
-
-type T4 = ExtendsStrict<string, number | string>;
-//=> true
-
-type T5 = ExtendsStrict<string, string>;
-//=> true
+type T3 = ExtendsStrict<any, number, {anyExtendsAll: false}>;
+//=> false
 ```
+
+@see {@link ExtendsStrictOptions}
 
 @category Improved Built-in
 */
-export type ExtendsStrict<Left, Right> =
-	IsAny<Left | Right> extends true
-		? true
+export type ExtendsStrict<Left, Right, Options extends ExtendsStrictOptions = {}> =
+	_ExtendsStrict<Left, Right, ApplyDefaultOptions<ExtendsStrictOptions, DefaultExtendsStrictOptions, Options>>;
+
+type _ExtendsStrict<Left, Right, Options extends Required<ExtendsStrictOptions>> =
+	And<IsAny<Left>, Not<Options['anyExtendsAll']>> extends true
+		? Or<IsAny<Right>, IsUnknown<Right>>
 		: IsNever<Left> extends true
-			? IsNever<Right>
-			: [Left] extends [Right]
+			? Options['neverExtendsAll'] extends true
 				? true
-				: false;
+				: Or<IsNever<Right>, IsAny<Right>>
+			: Options['distributiveUnions'] extends true
+				? Left extends Right
+					? true
+					: false
+				: [Left] extends [Right]
+					? true
+					: false;
 
 export {};

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -62,7 +62,7 @@ expectType<never>({} as ConditionalKeys<{length: number} | [number], number>);
 expectType<'a' | 'b' | 'c' | 'd' | 'e'>(
 	{} as ConditionalKeys<{a?: string; b: string | number; readonly c: boolean; readonly d?: bigint; e: never}, any>,
 );
-expectType<'a' | 'b' | 'c' | 'd'>(
+expectType<'a' | 'b' | 'c' | 'd' | 'e'>(
 	{} as ConditionalKeys<{a?: string; b: string | number; readonly c: boolean; readonly d?: bigint; e: never}, unknown>,
 );
 

--- a/test-d/extends-strict.ts
+++ b/test-d/extends-strict.ts
@@ -79,39 +79,39 @@ expectType<ExtendsStrict<null, unknown>>(true);
 
 // --- Options ---
 
-// Distributing over unions
+// `distributiveUnions`
 expectType<ExtendsStrict<string | number, string, {distributiveUnions: true}>>({} as boolean);
 expectType<ExtendsStrict<string | number, string, {distributiveUnions: false}>>(false);
 expectType<ExtendsStrict<number | bigint, string, {distributiveUnions: true}>>(false);
 expectType<ExtendsStrict<1 | 2 | 3, number, {distributiveUnions: true}>>(true);
 
-// `never` extends everything
-expectType<ExtendsStrict<never, string, {neverExtendsAll: true}>>(true);
-expectType<ExtendsStrict<never, never, {neverExtendsAll: true}>>(true);
-expectType<ExtendsStrict<never, any, {neverExtendsAll: true}>>(true);
-expectType<ExtendsStrict<never, unknown, {neverExtendsAll: true}>>(true);
+// `strictNever`
+expectType<ExtendsStrict<never, string, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, never, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, any, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, unknown, {strictNever: false}>>(true);
 
-expectType<ExtendsStrict<never, string, {neverExtendsAll: false}>>(false);
-expectType<ExtendsStrict<never, never, {neverExtendsAll: false}>>(true);
-expectType<ExtendsStrict<never, any, {neverExtendsAll: false}>>(true);
-expectType<ExtendsStrict<never, unknown, {neverExtendsAll: false}>>(false);
+expectType<ExtendsStrict<never, string, {strictNever: true}>>(false);
+expectType<ExtendsStrict<never, never, {strictNever: true}>>(true);
+expectType<ExtendsStrict<never, any, {strictNever: true}>>(true);
+expectType<ExtendsStrict<never, unknown, {strictNever: true}>>(false);
 
-// `any` extends everything
-expectType<ExtendsStrict<any, string, {anyExtendsAll: true}>>(true);
-expectType<ExtendsStrict<any, string, {anyExtendsAll: false}>>(false);
-expectType<ExtendsStrict<any, any, {anyExtendsAll: false}>>(true);
-expectType<ExtendsStrict<any, unknown, {anyExtendsAll: false}>>(true);
+// `strictAny`
+expectType<ExtendsStrict<any, string, {strictAny: false}>>(true);
+expectType<ExtendsStrict<any, string, {strictAny: true}>>(false);
+expectType<ExtendsStrict<any, any, {strictAny: true}>>(true);
+expectType<ExtendsStrict<any, unknown, {strictAny: true}>>(true);
 
-// When `anyExtendsAll` is `true`, behavior depends on `distributiveUnions`
-expectType<ExtendsStrict<any, string, {anyExtendsAll: true; distributiveUnions: true}>>({} as boolean);
-expectType<ExtendsStrict<any, never, {anyExtendsAll: true; distributiveUnions: true}>>({} as boolean);
-expectType<ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: true}>>(true);
-expectType<ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: true}>>(true);
+// When `strictAny` is `false`, behavior depends on `distributiveUnions`
+expectType<ExtendsStrict<any, string, {strictAny: false; distributiveUnions: true}>>({} as boolean);
+expectType<ExtendsStrict<any, never, {strictAny: false; distributiveUnions: true}>>({} as boolean);
+expectType<ExtendsStrict<any, any, {strictAny: false; distributiveUnions: true}>>(true);
+expectType<ExtendsStrict<any, unknown, {strictAny: false; distributiveUnions: true}>>(true);
 
-expectType<ExtendsStrict<any, string, {anyExtendsAll: true; distributiveUnions: false}>>(true);
-expectType<ExtendsStrict<any, never, {anyExtendsAll: true; distributiveUnions: false}>>(false);
-expectType<ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: false}>>(true);
-expectType<ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: false}>>(true);
+expectType<ExtendsStrict<any, string, {strictAny: false; distributiveUnions: false}>>(true);
+expectType<ExtendsStrict<any, never, {strictAny: false; distributiveUnions: false}>>(false);
+expectType<ExtendsStrict<any, any, {strictAny: false; distributiveUnions: false}>>(true);
+expectType<ExtendsStrict<any, unknown, {strictAny: false; distributiveUnions: false}>>(true);
 
-// When `neverExtendsAll` is `true`, the result will be `true` and not `never` even if `distributiveUnions` is `true`
-expectType<ExtendsStrict<never, string, {neverExtendsAll: true; distributiveUnions: true}>>(true);
+// When `strictNever` is `false`, the result will be `true` and not `never` even if `distributiveUnions` is `true`
+expectType<ExtendsStrict<never, string, {strictNever: false; distributiveUnions: true}>>(true);

--- a/test-d/extends-strict.ts
+++ b/test-d/extends-strict.ts
@@ -23,7 +23,7 @@ expectType<ExtendsStrict<string, never>>(false);
 
 // Any and unknown
 expectType<ExtendsStrict<any, any>>(true);
-expectType<ExtendsStrict<any, never>>(true);
+expectType<ExtendsStrict<any, never>>(false);
 expectType<ExtendsStrict<never, any>>(true);
 expectType<ExtendsStrict<any, number>>(true);
 expectType<ExtendsStrict<any, unknown>>(true); // `any` is assignable to `unknown`
@@ -76,3 +76,42 @@ expectType<ExtendsStrict<null, undefined>>(false);
 expectType<ExtendsStrict<undefined, null>>(false);
 expectType<ExtendsStrict<undefined, unknown>>(true);
 expectType<ExtendsStrict<null, unknown>>(true);
+
+// --- Options ---
+
+// Distributing over unions
+expectType<ExtendsStrict<string | number, string, {distributiveUnions: true}>>({} as boolean);
+expectType<ExtendsStrict<string | number, string, {distributiveUnions: false}>>(false);
+expectType<ExtendsStrict<number | bigint, string, {distributiveUnions: true}>>(false);
+expectType<ExtendsStrict<1 | 2 | 3, number, {distributiveUnions: true}>>(true);
+
+// `never` extends everything
+expectType<ExtendsStrict<never, string, {neverExtendsAll: true}>>(true);
+expectType<ExtendsStrict<never, never, {neverExtendsAll: true}>>(true);
+expectType<ExtendsStrict<never, any, {neverExtendsAll: true}>>(true);
+expectType<ExtendsStrict<never, unknown, {neverExtendsAll: true}>>(true);
+
+expectType<ExtendsStrict<never, string, {neverExtendsAll: false}>>(false);
+expectType<ExtendsStrict<never, never, {neverExtendsAll: false}>>(true);
+expectType<ExtendsStrict<never, any, {neverExtendsAll: false}>>(true);
+expectType<ExtendsStrict<never, unknown, {neverExtendsAll: false}>>(false);
+
+// `any` extends everything
+expectType<ExtendsStrict<any, string, {anyExtendsAll: true}>>(true);
+expectType<ExtendsStrict<any, string, {anyExtendsAll: false}>>(false);
+expectType<ExtendsStrict<any, any, {anyExtendsAll: false}>>(true);
+expectType<ExtendsStrict<any, unknown, {anyExtendsAll: false}>>(true);
+
+// When `anyExtendsAll` is `true`, behavior depends on `distributiveUnions`
+expectType<ExtendsStrict<any, string, {anyExtendsAll: true; distributiveUnions: true}>>({} as boolean);
+expectType<ExtendsStrict<any, never, {anyExtendsAll: true; distributiveUnions: true}>>({} as boolean);
+expectType<ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: true}>>(true);
+expectType<ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: true}>>(true);
+
+expectType<ExtendsStrict<any, string, {anyExtendsAll: true; distributiveUnions: false}>>(true);
+expectType<ExtendsStrict<any, never, {anyExtendsAll: true; distributiveUnions: false}>>(false);
+expectType<ExtendsStrict<any, any, {anyExtendsAll: true; distributiveUnions: false}>>(true);
+expectType<ExtendsStrict<any, unknown, {anyExtendsAll: true; distributiveUnions: false}>>(true);
+
+// When `neverExtendsAll` is `true`, the result will be `true` and not `never` even if `distributiveUnions` is `true`
+expectType<ExtendsStrict<never, string, {neverExtendsAll: true; distributiveUnions: true}>>(true);

--- a/test-d/extends-strict.ts
+++ b/test-d/extends-strict.ts
@@ -89,7 +89,7 @@ expectType<ExtendsStrict<1 | 2 | 3, number, {distributiveUnions: true}>>(true);
 expectType<ExtendsStrict<never, string, {strictNever: true}>>(false);
 expectType<ExtendsStrict<never, never, {strictNever: true}>>(true);
 expectType<ExtendsStrict<never, any, {strictNever: true}>>(true);
-expectType<ExtendsStrict<never, unknown, {strictNever: true}>>(false);
+expectType<ExtendsStrict<never, unknown, {strictNever: true}>>(true);
 
 expectType<ExtendsStrict<never, string, {strictNever: false}>>(true);
 expectType<ExtendsStrict<never, never, {strictNever: false}>>(true);

--- a/test-d/extends-strict.ts
+++ b/test-d/extends-strict.ts
@@ -86,21 +86,26 @@ expectType<ExtendsStrict<number | bigint, string, {distributiveUnions: true}>>(f
 expectType<ExtendsStrict<1 | 2 | 3, number, {distributiveUnions: true}>>(true);
 
 // `strictNever`
-expectType<ExtendsStrict<never, string, {strictNever: false}>>(true);
-expectType<ExtendsStrict<never, never, {strictNever: false}>>(true);
-expectType<ExtendsStrict<never, any, {strictNever: false}>>(true);
-expectType<ExtendsStrict<never, unknown, {strictNever: false}>>(true);
-
 expectType<ExtendsStrict<never, string, {strictNever: true}>>(false);
 expectType<ExtendsStrict<never, never, {strictNever: true}>>(true);
 expectType<ExtendsStrict<never, any, {strictNever: true}>>(true);
 expectType<ExtendsStrict<never, unknown, {strictNever: true}>>(false);
 
+expectType<ExtendsStrict<never, string, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, never, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, any, {strictNever: false}>>(true);
+expectType<ExtendsStrict<never, unknown, {strictNever: false}>>(true);
+
 // `strictAny`
-expectType<ExtendsStrict<any, string, {strictAny: false}>>(true);
 expectType<ExtendsStrict<any, string, {strictAny: true}>>(false);
+expectType<ExtendsStrict<any, never, {strictAny: true}>>(false);
 expectType<ExtendsStrict<any, any, {strictAny: true}>>(true);
 expectType<ExtendsStrict<any, unknown, {strictAny: true}>>(true);
+
+expectType<ExtendsStrict<any, string, {strictAny: false}>>(true);
+expectType<ExtendsStrict<any, never, {strictAny: false}>>(false);
+expectType<ExtendsStrict<any, any, {strictAny: false}>>(true);
+expectType<ExtendsStrict<any, unknown, {strictAny: false}>>(true);
 
 // When `strictAny` is `false`, behavior depends on `distributiveUnions`
 expectType<ExtendsStrict<any, string, {strictAny: false; distributiveUnions: true}>>({} as boolean);

--- a/test-d/paths.ts
+++ b/test-d/paths.ts
@@ -208,6 +208,9 @@ expectType<`a.${string}`>(unionLeaves2); // Collapsed union
 declare const unionLeaves3: Paths<{a: string | {toLowerCase: number}}, {leavesOnly: true}>;
 expectType<'a' | 'a.toLowerCase'>(unionLeaves3);
 
+declare const unionLeaves4: Paths<{a: {b: string} | {c: string}}, {leavesOnly: true}>; // No common keys b/w `{b: string}` and `{c: string}`, but this shouldn't make `a` a leaf.
+expectType<'a.b' | 'a.c'>(unionLeaves4);
+
 declare const emptyObjectLeaves: Paths<{a: {}}, {leavesOnly: true}>;
 expectType<'a'>(emptyObjectLeaves);
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

In this current form, the `ExtendsStrict` type is not quite useful as its default behaviour is quite restrictive and makes it difficult to use the type in different scenarios.

So, this PR adds three new options to `ExtendsStrict`, which should make the type usable in a lot of different contexts.
