### PR TITLE
Resolve Bug : #1389 , Fix ConditionalPickDeep incorrectly recursing into unions with null/primitive members 

### DIFF
--- a/source/conditional-pick-deep.d.ts
+++ b/source/conditional-pick-deep.d.ts
@@ -15,7 +15,7 @@ Assert the condition according to the {@link ConditionalPickDeepOptions.conditio
 */
 type AssertCondition<Type, Condition, Options extends ConditionalPickDeepOptions> = Options['condition'] extends 'equality'
 	? IsEqual<Type, Condition>
-	: Type extends Condition
+	: [Type] extends [Condition]
 		? true
 		: false;
 
@@ -114,7 +114,7 @@ type _ConditionalPickDeep<
 > = ConditionalSimplifyDeep<ConditionalExcept<{
 	[Key in keyof Type]: AssertCondition<Type[Key], Condition, Options> extends true
 		? Type[Key]
-		: IsPlainObject<Type[Key]> extends true
+		: IsPlainObject<NonNullable<Type[Key]>> extends true
 			? _ConditionalPickDeep<Type[Key], Condition, Options>
 			: typeof conditionalPickDeepSymbol;
 }, (typeof conditionalPickDeepSymbol | undefined) | EmptyObject>, never, UnknownRecord>;

--- a/test-d/conditional-pick-deep.ts
+++ b/test-d/conditional-pick-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {ConditionalPickDeep} from '../index.d.ts';
+import type {ConditionalPickDeep, Paths} from '../index.d.ts';
 
 declare class ClassA {
 	public a: string;
@@ -8,6 +8,11 @@ declare class ClassA {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface InterfaceA {
 	a: number;
+}
+
+enum TestEnum {
+	TEST1 = 'TEST1',
+	TEST2 = 'TEST2',
 }
 
 type Example = {
@@ -40,6 +45,15 @@ type Example = {
 			string: string;
 		};
 	};
+};
+
+type EnumExample = {
+	enum: TestEnum;
+	string: string | null;
+};
+
+type UnionExample = {
+	a: string | null;
 };
 
 declare const stringPick: ConditionalPickDeep<Example, string>;
@@ -158,3 +172,23 @@ expectType<{set: Set<string>; never: never}>(setPick);
 
 declare const interfaceTest: ConditionalPickDeep<Example, InterfaceA>;
 expectType<{interface: InterfaceA; never: never}>(interfaceTest);
+
+declare const enumPick: ConditionalPickDeep<EnumExample, TestEnum>;
+expectType<{enum: TestEnum}>(enumPick);
+
+expectType<'enum'>({} as Paths<ConditionalPickDeep<EnumExample, TestEnum>>);
+
+declare const unionPick:
+ConditionalPickDeep<UnionExample, TestEnum>;
+expectType<never>(unionPick);
+
+type NestedEnumExample = {
+	obj: {
+		value: TestEnum;
+		other: string | null;
+	};
+};
+
+declare const nestedPick:
+ConditionalPickDeep<NestedEnumExample, TestEnum>;
+expectType<{obj: {value: TestEnum}}>(nestedPick);


### PR DESCRIPTION
## Bug

ConditionalPickDeep was incorrectly including keys whose value types are non-object unions (for example string | null) when the Condition is an enum.

This PR fixes the issue in two ways:

1) Makes the condition check non-distributive using tuple wrapping: [Type] extends [Condition]. 
2) Prevents recursion into non-object unions by using: IsPlainObject<NonNullable<Type[Key]>> extends true

Additional tests were added to cover:

- Enum selection edge case
- Union types that must not recurse
- Nested enum cases
- Verification using Paths<>