### PR TITLE
Add `UnwrapRequired` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export type {OmitIndexSignature} from './source/omit-index-signature.d.ts';
 export type {PickIndexSignature} from './source/pick-index-signature.d.ts';
 export type {PartialDeep, PartialDeepOptions} from './source/partial-deep.d.ts';
 export type {UnwrapPartial} from './source/unwrap-partial.d.ts';
+export type {UnwrapRequired} from './source/unwrap-required.d.ts';
 export type {RequiredDeep} from './source/required-deep.d.ts';
 export type {PickDeep} from './source/pick-deep.d.ts';
 export type {OmitDeep} from './source/omit-deep.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ Click the type names for complete docs.
 - [`PartialOnUndefinedDeep`](source/partial-on-undefined-deep.d.ts) - Create a deep version of another type where all keys accepting `undefined` type are set to optional.
 - [`UndefinedOnPartialDeep`](source/undefined-on-partial-deep.d.ts) - Create a deep version of another type where all optional keys are set to also accept `undefined`.
 - [`UnwrapPartial`](source/unwrap-partial.d.ts) - Revert the `Partial` modifier on an object type.
+- [`UnwrapRequired`](source/unwrap-required.d.ts) - Revert the `Required` modifier on an object type.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of another type.
 - [`LiteralUnion`](source/literal-union.d.ts) - Create a union type by combining primitive types and literal types without sacrificing auto-completion in IDEs for the literal type part of the union.
 - [`Tagged`](source/tagged.d.ts) - Create a [tagged type](https://medium.com/@KevinBGreene/surviving-the-typescript-ecosystem-branding-and-type-tagging-6cf6e516523d) that can support [multiple tags](https://github.com/sindresorhus/type-fest/issues/665) and [per-tag metadata](https://medium.com/@ethanresnick/advanced-typescript-tagged-types-improved-with-type-level-metadata-5072fc125fcf).
@@ -534,6 +535,8 @@ There are many advanced types most users don't know about.
 			email: 'ex@mple.com',
 	});
 	```
+
+	`Required<T>` can be reverted with [`UnwrapRequired`](source/unwrap-required.d.ts).
 	</details>
 
 - [`Readonly<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype) - Make all properties in `T` readonly.

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -22,11 +22,7 @@ Note: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no eff
 */
 export type UnwrapRequired<RequiredObjectType> =
 	RequiredObjectType extends Required<infer ObjectType>
-		? (
-			Required<ObjectType> extends RequiredObjectType
-				? ObjectType
-				: RequiredObjectType
-		)
+		? ObjectType
 		: RequiredObjectType;
 
 export {};

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -18,9 +18,9 @@ type DraftContactFormData = UnwrapRequired<ContactFormData>;
 //=> {email: string; message?: string}
 ```
 
-Note 1: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no effect on the original type.
-
-Note 2: `Required<T>` is lossy for arrays and tuples with optional elements, so `UnwrapRequired` has no effect on array and tuple types. Object types with optional properties are unaffected by this limitation (and work as expected with `UnwrapRequired`).
+Note:
+	- If the provided type isn’t of the form `Required<T>`, `UnwrapRequired` simply returns the input type.
+	- `UnwrapRequired` doesn't work with arrays, if instantiated with arrays, it simply returns the input type.
 
 @category Object
 */

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -24,7 +24,11 @@ Note 2: `Required<T>` is lossy for tuples with optional elements. `UnwrapRequire
 */
 export type UnwrapRequired<RequiredObjectType> =
 	RequiredObjectType extends Required<infer ObjectType>
-		? ObjectType
+		? (
+			Required<ObjectType> extends RequiredObjectType
+				? ObjectType
+				: RequiredObjectType
+		)
 		: RequiredObjectType;
 
 export {};

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -16,7 +16,9 @@ type DraftContactFormData = UnwrapRequired<ContactFormData>;
 //=> {email: string; message?: string}
 ```
 
-Note: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no effect on the original type.
+Note 1: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no effect on the original type.
+
+Note 2: `Required<T>` is lossy for tuples with optional elements. `UnwrapRequired` cannot recover the original tuple type in these cases. Object types with optional properties are unaffected by this limitation (and work as expected with `UnwrapRequired`).
 
 @category Object
 */

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -25,11 +25,9 @@ Note 2: `Required<T>` is lossy for arrays and tuples with optional elements, so 
 @category Object
 */
 export type UnwrapRequired<RequiredObjectType> =
-	// Isolate members where `Required<T>` produces unwanted results (accounting for unions)
-	Extract<RequiredObjectType, MapsSetsOrArrays | NonRecursiveType> extends infer PreservedType
-		// Recombine the preserved types with the unwrapped members
-		? PreservedType | _UnwrapRequired<Exclude<RequiredObjectType, PreservedType>>
-		: RequiredObjectType;
+	RequiredObjectType extends NonRecursiveType | MapsSetsOrArrays
+		? RequiredObjectType
+		: _UnwrapRequired<RequiredObjectType>;
 
 type _UnwrapRequired<RequiredObjectType> =
 	RequiredObjectType extends Required<infer ObjectType>

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -1,6 +1,23 @@
 /**
 Revert the `Required` modifier on an object type.
 
+Use-case: Infer the underlying type `T` when only `Required<T>` is available or the original type may not be directly accessible.
+
+@example
+```
+import type {UnwrapRequired} from 'type-fest';
+
+type ContactFormData = Required<{
+	email: string;
+	message?: string;
+}>;
+
+type DraftContactFormData = UnwrapRequired<ContactFormData>;
+//=> {email: string; message?: string}
+```
+
+Note: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no effect on the original type.
+
 @category Object
 */
 export type UnwrapRequired<RequiredObjectType> =

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -1,0 +1,15 @@
+/**
+Revert the `Required` modifier on an object type.
+
+@category Object
+*/
+export type UnwrapRequired<RequiredObjectType> =
+	RequiredObjectType extends Required<infer ObjectType>
+		? (
+			Required<ObjectType> extends RequiredObjectType
+				? ObjectType
+				: RequiredObjectType
+		)
+		: RequiredObjectType;
+
+export {};

--- a/source/unwrap-required.d.ts
+++ b/source/unwrap-required.d.ts
@@ -1,3 +1,5 @@
+import type {MapsSetsOrArrays, NonRecursiveType} from './internal/type.d.ts';
+
 /**
 Revert the `Required` modifier on an object type.
 
@@ -18,17 +20,20 @@ type DraftContactFormData = UnwrapRequired<ContactFormData>;
 
 Note 1: If the provided type isn’t of `Required<T>`, `UnwrapRequired` has no effect on the original type.
 
-Note 2: `Required<T>` is lossy for tuples with optional elements. `UnwrapRequired` cannot recover the original tuple type in these cases. Object types with optional properties are unaffected by this limitation (and work as expected with `UnwrapRequired`).
+Note 2: `Required<T>` is lossy for arrays and tuples with optional elements, so `UnwrapRequired` has no effect on array and tuple types. Object types with optional properties are unaffected by this limitation (and work as expected with `UnwrapRequired`).
 
 @category Object
 */
 export type UnwrapRequired<RequiredObjectType> =
+	// Isolate members where `Required<T>` produces unwanted results (accounting for unions)
+	Extract<RequiredObjectType, MapsSetsOrArrays | NonRecursiveType> extends infer PreservedType
+		// Recombine the preserved types with the unwrapped members
+		? PreservedType | _UnwrapRequired<Exclude<RequiredObjectType, PreservedType>>
+		: RequiredObjectType;
+
+type _UnwrapRequired<RequiredObjectType> =
 	RequiredObjectType extends Required<infer ObjectType>
-		? (
-			Required<ObjectType> extends RequiredObjectType
-				? ObjectType
-				: RequiredObjectType
-		)
+		? ObjectType
 		: RequiredObjectType;
 
 export {};

--- a/test-d/unwrap-required.ts
+++ b/test-d/unwrap-required.ts
@@ -56,3 +56,7 @@ expectType<any>({} as UnwrapRequired<Required<any>>);
 expectType<TestType>({} as UnwrapRequired<TestType>);
 expectType<{a: string; b: number}>({} as UnwrapRequired<{a: string; b: number}>);
 expectType<readonly string[]>({} as UnwrapRequired<readonly string[]>);
+expectType<Set<string>>({} as UnwrapRequired<Set<string>>);
+expectType<Map<string, string>>({} as UnwrapRequired<Map<string, string>>);
+expectType<string>({} as UnwrapRequired<string>);
+expectType<() => string>({} as UnwrapRequired<() => string>);

--- a/test-d/unwrap-required.ts
+++ b/test-d/unwrap-required.ts
@@ -48,18 +48,11 @@ type RequiredUnionType = Required<TestType> | Required<AnotherTestType>;
 expectType<TestType | AnotherTestType>({} as UnwrapRequired<RequiredUnionType>);
 expectType<TestType | AnotherTestType>({} as UnwrapRequired<Required<TestType> | AnotherTestType>);
 
-// `UnwrapRequired` works with arrays and tuples
-type TestTuple = [string?, number?, boolean?];
-
-expectType<[string, number, boolean]>({} as UnwrapRequired<Required<TestTuple>>);
-expectType<string[]>({} as UnwrapRequired<string[]>);
-expectType<readonly string[]>({} as UnwrapRequired<readonly string[]>);
-
 // `UnwrapRequired` works with unknown types
 expectType<unknown>({} as UnwrapRequired<Required<unknown>>);
 expectType<any>({} as UnwrapRequired<Required<any>>);
-expectType<never>({} as UnwrapRequired<never>);
 
 // `UnwrapRequired` has no effect on non-required types
 expectType<TestType>({} as UnwrapRequired<TestType>);
 expectType<{a: string; b: number}>({} as UnwrapRequired<{a: string; b: number}>);
+expectType<readonly string[]>({} as UnwrapRequired<readonly string[]>);

--- a/test-d/unwrap-required.ts
+++ b/test-d/unwrap-required.ts
@@ -47,6 +47,9 @@ type RequiredUnionType = Required<TestType> | Required<AnotherTestType>;
 
 expectType<TestType | AnotherTestType>({} as UnwrapRequired<RequiredUnionType>);
 expectType<TestType | AnotherTestType>({} as UnwrapRequired<Required<TestType> | AnotherTestType>);
+expectType<TestType | string>({} as UnwrapRequired<Required<TestType> | string>);
+expectType<TestType | Map<string, string>>({} as UnwrapRequired<Required<TestType> | Map<string, string>>);
+expectType<TestType | Map<string, string> | string>({} as UnwrapRequired<Required<TestType> | Map<string, string> | string>);
 
 // `UnwrapRequired` works with unknown types
 expectType<unknown>({} as UnwrapRequired<Required<unknown>>);
@@ -56,7 +59,15 @@ expectType<any>({} as UnwrapRequired<Required<any>>);
 expectType<TestType>({} as UnwrapRequired<TestType>);
 expectType<{a: string; b: number}>({} as UnwrapRequired<{a: string; b: number}>);
 expectType<readonly string[]>({} as UnwrapRequired<readonly string[]>);
+expectType<readonly [string, number?]>({} as UnwrapRequired<readonly [string, number?]>);
 expectType<Set<string>>({} as UnwrapRequired<Set<string>>);
+expectType<ReadonlySet<string>>({} as UnwrapRequired<ReadonlySet<string>>);
+expectType<WeakSet<{a: string}>>({} as UnwrapRequired<WeakSet<{a: string}>>);
 expectType<Map<string, string>>({} as UnwrapRequired<Map<string, string>>);
+expectType<ReadonlyMap<string, string>>({} as UnwrapRequired<ReadonlyMap<string, string>>);
+expectType<WeakMap<{a: string}, string>>({} as UnwrapRequired<WeakMap<{a: string}, string>>);
+expectType<Date>({} as UnwrapRequired<Date>);
+expectType<RegExp>({} as UnwrapRequired<RegExp>);
+expectType<Promise<string>>({} as UnwrapRequired<Promise<string>>);
 expectType<string>({} as UnwrapRequired<string>);
 expectType<() => string>({} as UnwrapRequired<() => string>);

--- a/test-d/unwrap-required.ts
+++ b/test-d/unwrap-required.ts
@@ -1,0 +1,65 @@
+import {expectType} from 'tsd';
+import type {UnwrapRequired} from '../index.d.ts';
+
+type TestType = {
+	a?: string;
+	b: number;
+};
+
+expectType<TestType>({} as UnwrapRequired<Required<TestType>>);
+
+// `UnwrapRequired` preserves optional properties
+type AnotherTestType = {
+	c?: boolean;
+	d?: 'literal';
+};
+
+type TestTypeWithOptionalProps = TestType & AnotherTestType;
+
+expectType<TestTypeWithOptionalProps>({} as UnwrapRequired<Required<TestTypeWithOptionalProps>>);
+
+// `UnwrapRequired` preserves nested `Required` properties
+type TestTypeWithRequiredProp = TestType & {
+	c: Required<AnotherTestType>;
+};
+
+expectType<TestTypeWithRequiredProp>({} as UnwrapRequired<Required<TestTypeWithRequiredProp>>);
+
+// `UnwrapRequired` preserves readonly properties
+type TestTypeWithReadonlyProps = {
+	readonly a?: string;
+	readonly b: number;
+	readonly c?: boolean;
+};
+
+expectType<TestTypeWithReadonlyProps>({} as UnwrapRequired<Required<TestTypeWithReadonlyProps>>);
+
+// `UnwrapRequired` works with methods
+type TestTypeWithMethod = {
+	a?: string;
+	c?(): void;
+};
+
+expectType<TestTypeWithMethod>({} as UnwrapRequired<Required<TestTypeWithMethod>>);
+
+// `UnwrapRequired` works with union types
+type RequiredUnionType = Required<TestType> | Required<AnotherTestType>;
+
+expectType<TestType | AnotherTestType>({} as UnwrapRequired<RequiredUnionType>);
+expectType<TestType | AnotherTestType>({} as UnwrapRequired<Required<TestType> | AnotherTestType>);
+
+// `UnwrapRequired` works with arrays and tuples
+type TestTuple = [string?, number?, boolean?];
+
+expectType<[string, number, boolean]>({} as UnwrapRequired<Required<TestTuple>>);
+expectType<string[]>({} as UnwrapRequired<string[]>);
+expectType<readonly string[]>({} as UnwrapRequired<readonly string[]>);
+
+// `UnwrapRequired` works with unknown types
+expectType<unknown>({} as UnwrapRequired<Required<unknown>>);
+expectType<any>({} as UnwrapRequired<Required<any>>);
+expectType<never>({} as UnwrapRequired<never>);
+
+// `UnwrapRequired` has no effect on non-required types
+expectType<TestType>({} as UnwrapRequired<TestType>);
+expectType<{a: string; b: number}>({} as UnwrapRequired<{a: string; b: number}>);


### PR DESCRIPTION
Following up on #1294 and #1296, this PR introduces `UnwrapRequired`, a type that reverts the `Required` modifier on object types.

`UnwrapRequired` mirrors `UnwrapPartial`’s implementation:

* No-op for non-`Required` types.
* Simplicity over special-casing unions and arrays.
* Includes similar test cases.