### PR TITLE
`ApplyDefaultOptions`: Fix behavior with generic instantiations & `any` values

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -223,13 +223,22 @@ export type ApplyDefaultOptions<
 	Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
 	SpecifiedOptions extends Options,
 > =
+	_ApplyDefaultOptions<Options, Defaults, SpecifiedOptions> extends infer Result extends Required<Options> // `extends Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
+		? Result
+		: never;
+
+type _ApplyDefaultOptions<
+	Options,
+	Defaults,
+	SpecifiedOptions,
+> =
 	If<IsAny<SpecifiedOptions>, Defaults,
 		If<IsNever<SpecifiedOptions>, Defaults,
-			Simplify<Merge<Defaults, {
+			Merge<Defaults, {
 				[Key in keyof SpecifiedOptions
 				as undefined extends Required<Options>[Key & keyof Options] ? Key : undefined extends SpecifiedOptions[Key] ? never : Key
 				]: SpecifiedOptions[Key]
-			}> & Required<Options>>>>; // `& Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
+			}>>>;
 
 /**
 Collapses literal types in a union into their corresponding primitive types, when possible. For example, `CollapseLiterals<'foo' | 'bar' | (string & {})>` returns `string`.

--- a/test-d/internal/apply-default-options.ts
+++ b/test-d/internal/apply-default-options.ts
@@ -45,6 +45,9 @@ expectType<{recurseIntoArrays: undefined}>(undefinedAsValidValue);
 declare const optionalOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, {maxRecursionDepth?: 5; bracketNotation?: true}>;
 expectType<DefaultPathsOptions>(optionalOptionsGetOverwritten);
 
+declare const anyAsValue: ApplyDefaultOptions<{includes?: any}, {includes: any}, {includes: string}>;
+expectType<{includes: string}>(anyAsValue);
+
 declare const neverAsOptionsGetOverwritten: ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, never>;
 expectType<DefaultPathsOptions>(neverAsOptionsGetOverwritten);
 
@@ -69,3 +72,17 @@ declare const noDefaultForRequiredOptions: ApplyDefaultOptions<{fixedLengthOnly:
 // The output of `ApplyDefaultOptions<SomeOption, ...>` should be assignable to `Required<SomeOption>`
 type SomeType<Options extends PathsOptions = {}> = _SomeType<ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, Options>>;
 type _SomeType<Options extends Required<PathsOptions>> = Options;
+
+// @ts-expect-error
+type SomeType2<Options extends PathsOptions = {}> = _SomeType2<ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, Options>>;
+type _SomeType2<Options extends Required<PathsOptions> & {extra: string}> = Options;
+
+type SomeTypeOptions = {foo: string; bar?: number};
+type DefaultSomeTypeOptions = {bar: 0};
+
+type SomeType3<Options extends SomeTypeOptions> = _SomeType3<ApplyDefaultOptions<SomeTypeOptions, DefaultSomeTypeOptions, Options>>;
+type _SomeType3<Options extends Required<SomeTypeOptions>> = Options;
+
+// @ts-expect-error
+type SomeType4<Options extends SomeTypeOptions> = _SomeType4<ApplyDefaultOptions<SomeTypeOptions, DefaultSomeTypeOptions, Options>>;
+type _SomeType4<Options extends Required<SomeTypeOptions> & {extra: string}> = Options;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR fixes the following issues with `ApplyDefaultOptions`:

1. `FinalOptions` in the following example currently becomes `{includes: any}`, instead it should be `{includes: string}`:
    
    ```ts
    type PathOptions = {includes?: any};
    type DefaultPathOptions = {includes: any};
    type FinalOptions = ApplyDefaultOptions<PathOptions, DefaultPathOptions, {includes: string}>;
    //=> {includes: any}
    ```
    
    This happens because:
    ```
    Simplify<Merge<{includes: any}, {includes: string}> & Required<{includes?: any}>>
    => Simplify<{includes: string} & {includes: any}>
    => {includes: any}
    ``` 

2. Generic instantiation fails currently if there are required options:

    ```ts
    type SomeTypeOptions = {foo: string; bar?: number}; // Has a required option
    type DefaultSomeTypeOptions = {bar: 0};
    
    type SomeType<Options extends SomeTypeOptions> =
	    _SomeType<ApplyDefaultOptions<SomeTypeOptions, DefaultSomeTypeOptions, Options>>;
    //            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    // Does not satisfy the constraint 'Required<SomeTypeOptions>', but it should.
    type _SomeType<Options extends Required<SomeTypeOptions>> = Options;
    ```