### PR TITLE
Add `GroupBy` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ export type {ConditionalExcept} from './source/conditional-except.d.ts';
 export type {ConditionalKeys} from './source/conditional-keys.d.ts';
 export type {ConditionalPick} from './source/conditional-pick.d.ts';
 export type {ConditionalPickDeep, ConditionalPickDeepOptions} from './source/conditional-pick-deep.d.ts';
+export type {GroupBy} from './source/group-by.d.ts';
 export type {UnionToIntersection} from './source/union-to-intersection.d.ts';
 export type {Stringified} from './source/stringified.d.ts';
 export type {StringSlice} from './source/string-slice.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,7 @@ Click the type names for complete docs.
 - [`ConditionalPick`](source/conditional-pick.d.ts) - Pick keys from the shape that matches the given `Condition`.
 - [`ConditionalPickDeep`](source/conditional-pick-deep.d.ts) - Pick keys recursively from the shape that matches the given condition.
 - [`ConditionalExcept`](source/conditional-except.d.ts) - Exclude keys from a shape that matches the given `Condition`.
+- [`GroupBy`](source/group-by.d.ts) - Groups items by the value of a specified key.
 - [`UnionToIntersection`](source/union-to-intersection.d.ts) - Convert a union type to an intersection type.
 - [`LiteralToPrimitive`](source/literal-to-primitive.d.ts) - Given a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types) return the [primitive type](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) it belongs to, or `never` if it's not a primitive.
 - [`LiteralToPrimitiveDeep`](source/literal-to-primitive-deep.d.ts) - Like `LiteralToPrimitive` except it converts literal types inside an object or array deeply.

--- a/source/group-by.d.ts
+++ b/source/group-by.d.ts
@@ -19,13 +19,13 @@ type Apple = {
 };
 
 type Banana = {
-    color: 'yellow';
-    kind: 'fruit';
+	color: 'yellow';
+	kind: 'fruit';
 };
 
 type Tomato = {
-    color: 'red';
-    kind: 'vegetable';
+	color: 'red';
+	kind: 'vegetable';
 };
 
 type GroupedByColor = GroupBy<Apple | Banana | Tomato, 'color'>;

--- a/source/group-by.d.ts
+++ b/source/group-by.d.ts
@@ -1,0 +1,59 @@
+import type { ConditionalKeys } from "./conditional-keys.d.ts";
+
+/**
+Groups items by the value of a specified key.
+
+This type creates an object where each key is a possible value of the specified property `GroupingKey`, and the corresponding value is the union of all items from the input type `Union` that have that value for property `GroupingKey`.
+
+Use-cases:
+- Grouping unions of objects by a discriminant property, such as categorizing different types of items by their type or color.
+- Creating type-safe grouped data structures from discriminated unions.
+
+@example
+```
+import type {GroupBy} from 'type-fest';
+
+type Apple = {
+	color: 'green';
+	kind: 'fruit';
+};
+
+type Banana = {
+    color: 'yellow';
+    kind: 'fruit';
+};
+
+type Tomato = {
+    color: 'red';
+    kind: 'vegetable';
+};
+
+type GroupedByColor = GroupBy<Apple | Banana | Tomato, 'color'>;
+// {
+//   green: Apple;
+//   yellow: Banana;
+//   red: Tomato;
+// }
+
+type GroupedByKind = GroupBy<Apple | Banana | Tomato, 'kind'>;
+// {
+//   fruit: Apple | Banana;
+//   vegetable: Tomato;
+// }
+```
+
+@category Object
+@category Union
+*/
+export type GroupBy<
+	Union,
+	GroupingKey extends ConditionalKeys<Union, PropertyKey>,
+> = {
+	[Key in Extract<Union[GroupingKey], PropertyKey>]: Union extends Union
+		? Key extends Union[GroupingKey]
+			? Union
+			: never
+		: never;
+};
+
+export {};

--- a/source/group-by.d.ts
+++ b/source/group-by.d.ts
@@ -1,4 +1,4 @@
-import type { ConditionalKeys } from "./conditional-keys.d.ts";
+import type {ConditionalKeys} from './conditional-keys.d.ts';
 
 /**
 Groups items by the value of a specified key.

--- a/test-d/group-by.ts
+++ b/test-d/group-by.ts
@@ -1,53 +1,53 @@
-import { expectType } from "tsd";
-import type { GroupBy } from "../source/group-by.d.ts";
+import {expectType} from 'tsd';
+import type {GroupBy} from '../source/group-by.d.ts';
 
 type Apple = {
-	color: "green";
-	kind: "fruit";
+	color: 'green';
+	kind: 'fruit';
 };
 
 type Banana = {
-	color: "yellow";
-	kind: "fruit";
+	color: 'yellow';
+	kind: 'fruit';
 };
 
 type Tomato = {
-	color: "red";
-	kind: "vegetable";
+	color: 'red';
+	kind: 'vegetable';
 };
 
 // Grouping a single type
-expectType<GroupBy<Apple, "color">>({
+expectType<GroupBy<Apple, 'color'>>({
 	green: {} as Apple,
 });
 
 // Grouping discriminated unions
-expectType<GroupBy<Apple | Banana | Tomato, "color">>({
+expectType<GroupBy<Apple | Banana | Tomato, 'color'>>({
 	green: {} as Apple,
 	yellow: {} as Banana,
 	red: {} as Tomato,
 });
 
-expectType<GroupBy<Apple | Banana | Tomato, "kind">>({
+expectType<GroupBy<Apple | Banana | Tomato, 'kind'>>({
 	fruit: {} as Apple | Banana,
 	vegetable: {} as Tomato,
 });
 
 // Grouping a key that is a union
 type WithUnionKey = {
-	type: "a" | "b";
+	type: 'a' | 'b';
 	value: number;
 };
 
-expectType<GroupBy<WithUnionKey, "type">>({
+expectType<GroupBy<WithUnionKey, 'type'>>({
 	a: {} as WithUnionKey,
 	b: {} as WithUnionKey,
 });
 
 // Test with numeric keys
-type WithNumberKey = { id: 1 | 2; name: string };
+type WithNumberKey = {id: 1 | 2; name: string};
 
-expectType<GroupBy<WithNumberKey, "id">>({
+expectType<GroupBy<WithNumberKey, 'id'>>({
 	1: {} as WithNumberKey,
 	2: {} as WithNumberKey,
 });
@@ -58,7 +58,7 @@ expectType<GroupBy<never, never>>({} as {});
 expectType<GroupBy<unknown, never>>({} as {});
 
 // @ts-expect-error key that doesn't exist
-type NonExistentKey = GroupBy<{ id: number }, "nonexistent">;
+type NonExistentKey = GroupBy<{id: number}, 'nonexistent'>;
 
 // @ts-expect-error key with non-PropertyKey value
-type InvalidKey = GroupBy<{ data: object }, "data">;
+type InvalidKey = GroupBy<{data: object}, 'data'>;

--- a/test-d/group-by.ts
+++ b/test-d/group-by.ts
@@ -1,0 +1,64 @@
+import { expectType } from "tsd";
+import type { GroupBy } from "../source/group-by.d.ts";
+
+type Apple = {
+	color: "green";
+	kind: "fruit";
+};
+
+type Banana = {
+	color: "yellow";
+	kind: "fruit";
+};
+
+type Tomato = {
+	color: "red";
+	kind: "vegetable";
+};
+
+// Grouping a single type
+expectType<GroupBy<Apple, "color">>({
+	green: {} as Apple,
+});
+
+// Grouping discriminated unions
+expectType<GroupBy<Apple | Banana | Tomato, "color">>({
+	green: {} as Apple,
+	yellow: {} as Banana,
+	red: {} as Tomato,
+});
+
+expectType<GroupBy<Apple | Banana | Tomato, "kind">>({
+	fruit: {} as Apple | Banana,
+	vegetable: {} as Tomato,
+});
+
+// Grouping a key that is a union
+type WithUnionKey = {
+	type: "a" | "b";
+	value: number;
+};
+
+expectType<GroupBy<WithUnionKey, "type">>({
+	a: {} as WithUnionKey,
+	b: {} as WithUnionKey,
+});
+
+// Test with numeric keys
+type WithNumberKey = { id: 1 | 2; name: string };
+
+expectType<GroupBy<WithNumberKey, "id">>({
+	1: {} as WithNumberKey,
+	2: {} as WithNumberKey,
+});
+
+// Edge cases with any, never, unknown
+expectType<GroupBy<any, never>>({} as {});
+expectType<GroupBy<never, never>>({} as {});
+expectType<GroupBy<unknown, never>>({} as {});
+
+// @ts-expect-error key that doesn't exist
+type NonExistentKey = GroupBy<{ id: number }, "nonexistent">;
+
+// @ts-expect-error key with non-PropertyKey value
+type InvalidKey = GroupBy<{ data: object }, "data">;

--- a/test-d/group-by.ts
+++ b/test-d/group-by.ts
@@ -17,21 +17,22 @@ type Tomato = {
 };
 
 // Grouping a single type
-expectType<GroupBy<Apple, 'color'>>({
-	green: {} as Apple,
-});
+declare const singleType: GroupBy<Apple, 'color'>;
+expectType<{green: Apple}>(singleType);
 
 // Grouping discriminated unions
-expectType<GroupBy<Apple | Banana | Tomato, 'color'>>({
-	green: {} as Apple,
-	yellow: {} as Banana,
-	red: {} as Tomato,
-});
+declare const groupedByColor: GroupBy<Apple | Banana | Tomato, 'color'>;
+expectType<{
+	green: Apple;
+	yellow: Banana;
+	red: Tomato;
+}>(groupedByColor);
 
-expectType<GroupBy<Apple | Banana | Tomato, 'kind'>>({
-	fruit: {} as Apple | Banana,
-	vegetable: {} as Tomato,
-});
+declare const groupedByKind: GroupBy<Apple | Banana | Tomato, 'kind'>;
+expectType<{
+	fruit: Apple | Banana;
+	vegetable: Tomato;
+}>(groupedByKind);
 
 // Grouping a key that is a union
 type WithUnionKey = {
@@ -39,18 +40,20 @@ type WithUnionKey = {
 	value: number;
 };
 
-expectType<GroupBy<WithUnionKey, 'type'>>({
-	a: {} as WithUnionKey,
-	b: {} as WithUnionKey,
-});
+declare const groupedByUnionKey: GroupBy<WithUnionKey, 'type'>;
+expectType<{
+	a: WithUnionKey;
+	b: WithUnionKey;
+}>(groupedByUnionKey);
 
 // Test with numeric keys
 type WithNumberKey = {id: 1 | 2; name: string};
 
-expectType<GroupBy<WithNumberKey, 'id'>>({
-	1: {} as WithNumberKey,
-	2: {} as WithNumberKey,
-});
+declare const groupedByNumberKey: GroupBy<WithNumberKey, 'id'>;
+expectType<{
+	1: WithNumberKey;
+	2: WithNumberKey;
+}>(groupedByNumberKey);
 
 // Edge cases with any, never, unknown
 expectType<GroupBy<any, never>>({} as Record<string, any>);

--- a/test-d/group-by.ts
+++ b/test-d/group-by.ts
@@ -53,7 +53,7 @@ expectType<GroupBy<WithNumberKey, "id">>({
 });
 
 // Edge cases with any, never, unknown
-expectType<GroupBy<any, never>>({} as {});
+expectType<GroupBy<any, never>>({} as Record<string, any>);
 expectType<GroupBy<never, never>>({} as {});
 expectType<GroupBy<unknown, never>>({} as {});
 


### PR DESCRIPTION
Groups items by the value of a specified key.

This type creates an object where each key is a possible value of the specified property `GroupingKey`, and the corresponding value is the union of all items from the input type `Union` that have that value for property `GroupingKey`.

Use-cases:
- Grouping unions of objects by a discriminant property, such as categorizing different types of items by their type or color.
- Creating type-safe grouped data structures from discriminated unions.

```ts
import type {GroupBy} from 'type-fest';

type Apple = {
	color: 'green';
	kind: 'fruit';
};

type Banana = {
	color: 'yellow';
	kind: 'fruit';
};

type Tomato = {
	color: 'red';
	kind: 'vegetable';
};

type GroupedByColor = GroupBy<Apple | Banana | Tomato, 'color'>;
// {
//   green: Apple;
//   yellow: Banana;
//   red: Tomato;
// }

type GroupedByKind = GroupBy<Apple | Banana | Tomato, 'kind'>;
// {
//   fruit: Apple | Banana;
//   vegetable: Tomato;
// }
```