### PR TITLE
Add `Unbind` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,6 +172,7 @@ export type {IsOptional} from './source/is-optional.d.ts';
 export type {IsNullable} from './source/is-nullable.d.ts';
 export type {TupleOf} from './source/tuple-of.d.ts';
 export type {ExclusifyUnion} from './source/exclusify-union.d.ts';
+export type {Unbind} from './source/unbind.d.ts';
 export type {ArrayReverse} from './source/array-reverse.d.ts';
 export type {UnionMember} from './source/union-member.d.ts';
 export type {Absolute} from './source/absolute.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ Click the type names for complete docs.
 - [`ConditionalSimplify`](source/conditional-simplify.d.ts) - Simplifies a type while including and/or excluding certain types from being simplified.
 - [`ConditionalSimplifyDeep`](source/conditional-simplify-deep.d.ts) - Recursively simplifies a type while including and/or excluding certain types from being simplified.
 - [`ExclusifyUnion`](source/exclusify-union.d.ts) - Ensure mutual exclusivity in object unions by adding other members’ keys as `?: never`.
+- [`Unbind`](source/unbind.d.ts) - Collapse a union into a single object type by merging all members.
 - [`Optional`](source/optional.d.ts) - Create a type that represents either the value or `undefined`, while stripping `null` from the type.
 - [`UnionMember`](source/union-member.d.ts) - Returns an arbitrary member of a union type.
 - [`UnionLength`](source/union-length.d.ts) - Returns the length of a union type.

--- a/source/unbind.d.ts
+++ b/source/unbind.d.ts
@@ -1,7 +1,7 @@
 import type {ExclusifyUnion} from './exclusify-union.d.ts';
 
 /**
-Collapse a union type into a single object type by merging all members.
+Collapse a union into a single object type by merging all members.
 
 Each property becomes:
 - A union of all possible values across the union members
@@ -25,7 +25,7 @@ type Failure = {
 };
 
 type Result = Unbind<Success | Failure>;
-//=> {
+// {
 // 	kind: 'success' | 'error';
 // 	data?: string;
 // 	error?: Error;

--- a/source/unbind.d.ts
+++ b/source/unbind.d.ts
@@ -1,0 +1,40 @@
+import type {ExclusifyUnion} from './exclusify-union.d.ts';
+
+/**
+Collapse a union type into a single object type by merging all members.
+
+Each property becomes:
+- A union of all possible values across the union members
+- Optional if it does not exist in every member
+
+This removes the relationships between union members, producing
+a loose object shape where properties are independent.
+
+@example
+```
+import type {Unbind} from 'type-fest';
+
+type Success = {
+	kind: 'success';
+	data: string;
+};
+
+type Failure = {
+	kind: 'error';
+	error: Error;
+};
+
+type Result = Unbind<Success | Failure>;
+//=> {
+// 	kind: 'success' | 'error';
+// 	data?: string;
+// 	error?: Error;
+// }
+```
+
+@category Object
+@category Union
+*/
+export type Unbind<Union> = Omit<ExclusifyUnion<Union>, never>;
+
+export {};

--- a/test-d/unbind.ts
+++ b/test-d/unbind.ts
@@ -1,0 +1,41 @@
+import {expectType} from 'tsd';
+import type {Unbind} from '../index.d.ts';
+
+type Success = {
+	kind: 'success';
+	data: string;
+};
+
+type Failure = {
+	kind: 'error';
+	error: Error;
+};
+
+declare const result: Unbind<Success | Failure>;
+expectType<{
+	kind: 'success' | 'error';
+	data?: string;
+	error?: Error;
+}>(result);
+
+type A = {a: string};
+type B = {b: number};
+
+declare const ab: Unbind<A | B>;
+expectType<{
+	a?: string;
+	b?: number;
+}>(ab);
+
+type Common = {a: string} | {a: number; b: boolean};
+
+declare const common: Unbind<Common>;
+expectType<{
+	a: string | number;
+	b?: boolean;
+}>(common);
+
+// Edge cases
+expectType<Unbind<any>>({} as Record<PropertyKey, any>);
+expectType<Unbind<never>>({} as Record<PropertyKey, never>);
+expectType<Unbind<unknown>>({});


### PR DESCRIPTION
Collapse a union type into a single object type by merging all members.

Each property becomes:
- A union of all possible values across the union members
- Optional if it does not exist in every member

This removes the relationships between union members, producing
a loose object shape where properties are independent.

```ts
import type {Unbind} from 'type-fest';

type Success = {
	kind: 'success';
	data: string;
};

type Failure = {
	kind: 'error';
	error: Error;
};

type Result = Unbind<Success | Failure>;
//=> {
// 	kind: 'success' | 'error';
// 	data?: string;
// 	error?: Error;
// }
```