### PR TITLE
`NonEmptyObject`: Handle index signatures conservatively

### DIFF
--- a/source/non-empty-object.d.ts
+++ b/source/non-empty-object.d.ts
@@ -1,10 +1,13 @@
 import type {HasRequiredKeys} from './has-required-keys.d.ts';
+import type {OmitIndexSignature} from './omit-index-signature.d.ts';
 import type {RequireAtLeastOne} from './require-at-least-one.d.ts';
 
 /**
 Represents an object with at least 1 non-optional key.
 
 This is useful when you need an object where all keys are optional, but there must be at least 1 key.
+
+Note: A type whose only members are index signatures (e.g. `{[key: string]: unknown}`) cannot statically express "at least one dynamic key" in TypeScript. For such types, `NonEmptyObject` fails closed and resolves to `never` rather than silently accepting `{}`.
 
 @example
 ```
@@ -33,6 +36,11 @@ const update2: UpdateRequest<User> = {};
 
 @category Object
 */
-export type NonEmptyObject<T extends object> = HasRequiredKeys<T> extends true ? T : RequireAtLeastOne<T, keyof T>;
+export type NonEmptyObject<T extends object> =
+	keyof OmitIndexSignature<T> extends never
+		? never
+		: HasRequiredKeys<OmitIndexSignature<T>> extends true
+			? T
+			: RequireAtLeastOne<T, keyof OmitIndexSignature<T>>;
 
 export {};

--- a/test-d/non-empty-object.ts
+++ b/test-d/non-empty-object.ts
@@ -27,3 +27,35 @@ expectType<TestType1>(test1);
 expectType<RequireAtLeastOne<TestType2>>(test2);
 expectType<TestType3>(test3);
 expectNever(test4);
+
+// Issue #821, behavior 1: a pure string index signature resolves to `never`.
+type StringIndexOnly = {[key: string]: string | number | undefined};
+declare const stringIndexOnly: NonEmptyObject<StringIndexOnly>;
+expectNever(stringIndexOnly);
+
+// Issue #821, behavior 2: a pure number index signature resolves to `never`.
+type NumberIndexOnly = {[key: number]: unknown};
+declare const numberIndexOnly: NonEmptyObject<NumberIndexOnly>;
+expectNever(numberIndexOnly);
+
+// Issue #821, behavior 3: the exact repro from the issue — assigning `{foo: {}}`
+// to an index-signature-only `NonEmptyObject` is rejected.
+type CommonArguments = {
+	[filter: string]: NonEmptyObject<{[argument: string]: string | number | undefined}>;
+};
+// @ts-expect-error — `{}` is not assignable because the inner type resolves to `never`.
+const _commonArguments: CommonArguments = {foo: {}};
+
+// Issue #821, behavior 4: an index signature combined with a required explicit
+// key still resolves to the original type — the explicit required key anchors
+// non-emptiness.
+type MixedRequired = {[key: string]: string; a: string};
+declare const mixedRequired: NonEmptyObject<MixedRequired>;
+expectType<MixedRequired>(mixedRequired);
+
+// Issue #821, behavior 5: an index signature combined with only optional
+// explicit keys requires at least one of those explicit optional keys (rather
+// than silently degenerating to the input type).
+type MixedOptional = {[key: string]: string | undefined; a?: string};
+declare const mixedOptional: NonEmptyObject<MixedOptional>;
+expectType<RequireAtLeastOne<MixedOptional, 'a'>>(mixedOptional);


### PR DESCRIPTION
Addresses #821.

`NonEmptyObject` currently accepts `{}` for types whose only members are index signatures:

```ts
import type {NonEmptyObject} from 'type-fest';

interface CommonArguments {
	[filter: string]: NonEmptyObject<{[argument: string]: string | number | undefined}>;
}

const args: CommonArguments = {foo: {}}; // ← accepted on main; should fail
```

## Why

A type whose only members are index signatures cannot statically express "at least one dynamic key" in TypeScript. The previous definition fell through to `RequireAtLeastOne<T, keyof T>`, which for `keyof T = string` mapped back to an index signature and trivially accepted `{}`.

## What changed

Re-derive the key set via `OmitIndexSignature` so:

- Pure-index-signature types fail closed and resolve to `never`.
- For mixed types, `HasRequiredKeys` / `RequireAtLeastOne` operate on the explicit-key subset, so index signatures no longer mask non-emptiness enforcement.

## Tests

Added to `test-d/non-empty-object.ts`:

1. Pure string index signature → `never`.
2. Pure number index signature → `never`.
3. Exact #821 repro (`{foo: {}}`) is rejected.
4. Mixed (index signature + required explicit key) still returns the original type.
5. Mixed (index signature + only optional explicit keys) requires at least one of the explicit optional keys.

`npm test` passes locally.
