### PR TITLE
`DelimiterCase`: Fix behavior with union delimiters

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -13,17 +13,14 @@ type DelimiterCaseFromArray<
 	Words extends string[],
 	Delimiter extends string,
 	OutputString extends string = '',
-> =
-	Delimiter extends string // For distributing `Delimiter`
-		? Words extends [
-			infer FirstWord extends string,
-			...infer RemainingWords extends string[],
-		]
-			? DelimiterCaseFromArray<RemainingWords, Delimiter, `${OutputString}${
-				StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
-			}${FirstWord}`>
-			: OutputString
-		: never;
+> = Words extends [
+	infer FirstWord extends string,
+	...infer RemainingWords extends string[],
+]
+	? DelimiterCaseFromArray<RemainingWords, Delimiter, `${OutputString}${
+		StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
+	}${FirstWord}`>
+	: OutputString;
 
 /**
 Convert a string literal to a custom string delimiter casing.
@@ -70,12 +67,14 @@ export type DelimiterCase<
 	Delimiter extends string,
 	Options extends WordsOptions = {},
 > = Value extends string
-	? IsStringLiteral<Value> extends false
-		? Value
-		: Lowercase<RemovePrefix<DelimiterCaseFromArray<
-			Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
-			Delimiter
-		>, string, {strict: false}>>
+	? Delimiter extends string // For distributing `Delimiter`
+		? IsStringLiteral<Value> extends false
+			? Value
+			: Lowercase<RemovePrefix<DelimiterCaseFromArray<
+				Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
+				Delimiter
+			>, string, {strict: false}>>
+		: Value
 	: Value;
 
 export {};

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -13,14 +13,17 @@ type DelimiterCaseFromArray<
 	Words extends string[],
 	Delimiter extends string,
 	OutputString extends string = '',
-> = Words extends [
-	infer FirstWord extends string,
-	...infer RemainingWords extends string[],
-]
-	? DelimiterCaseFromArray<RemainingWords, Delimiter, `${OutputString}${
-		StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
-	}${FirstWord}`>
-	: OutputString;
+> =
+	Delimiter extends string // For distributing `Delimiter`
+		? Words extends [
+			infer FirstWord extends string,
+			...infer RemainingWords extends string[],
+		]
+			? DelimiterCaseFromArray<RemainingWords, Delimiter, `${OutputString}${
+				StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
+			}${FirstWord}`>
+			: OutputString
+		: never;
 
 /**
 Convert a string literal to a custom string delimiter casing.

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,6 +1,5 @@
 import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal/index.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
-import type {IsNever} from './is-never.d.ts';
 import type {Merge} from './merge.d.ts';
 import type {RemovePrefix} from './remove-prefix.d.ts';
 import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
@@ -68,16 +67,14 @@ export type DelimiterCase<
 	Delimiter extends string,
 	Options extends WordsOptions = {},
 > = Value extends string
-	? IsNever<Delimiter> extends true
-		? Value
-		: Delimiter extends string // For distributing `Delimiter`
-			? IsStringLiteral<Value> extends false
-				? Value
-				: Lowercase<RemovePrefix<DelimiterCaseFromArray<
-					Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
-					Delimiter
-				>, string, {strict: false}>>
-			: never
+	? Delimiter extends string // For distributing `Delimiter`
+		? IsStringLiteral<Value> extends false
+			? Value
+			: Lowercase<RemovePrefix<DelimiterCaseFromArray<
+				Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
+				Delimiter
+			>, string, {strict: false}>>
+		: never
 	: Value;
 
 export {};

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,5 +1,6 @@
 import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal/index.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsNever} from './is-never.d.ts';
 import type {Merge} from './merge.d.ts';
 import type {RemovePrefix} from './remove-prefix.d.ts';
 import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
@@ -67,14 +68,16 @@ export type DelimiterCase<
 	Delimiter extends string,
 	Options extends WordsOptions = {},
 > = Value extends string
-	? Delimiter extends string // For distributing `Delimiter`
-		? IsStringLiteral<Value> extends false
-			? Value
-			: Lowercase<RemovePrefix<DelimiterCaseFromArray<
-				Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
-				Delimiter
-			>, string, {strict: false}>>
-		: Value
+	? IsNever<Delimiter> extends true
+		? Value
+		: Delimiter extends string // For distributing `Delimiter`
+			? IsStringLiteral<Value> extends false
+				? Value
+				: Lowercase<RemovePrefix<DelimiterCaseFromArray<
+					Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
+					Delimiter
+				>, string, {strict: false}>>
+			: never
 	: Value;
 
 export {};

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -170,7 +170,7 @@ declare const anyDelimiter: DelimiterCase<'fooBar', any>;
 expectType<`foo${Lowercase<any>}bar`>(anyDelimiter);
 
 declare const neverDelimiter: DelimiterCase<'fooBar', never>;
-expectType<'fooBar'>(neverDelimiter);
+expectType<never>(neverDelimiter);
 
 // Verifying example
 type OddCasedProperties<T> = {

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -103,11 +103,11 @@ expectType<'foo22#bar'>(
 declare const unionValue: DelimiterCase<'fooBar' | 'barBaz', '#'>;
 expectType<'foo#bar' | 'bar#baz'>(unionValue);
 
-declare const unionDelimiter: DelimiterCase<'fooBar', '#' | '$'>;
-expectType<'foo#bar' | 'foo$bar'>(unionDelimiter);
+declare const unionDelimiter: DelimiterCase<'fooBarBaz', '#' | '$'>;
+expectType<'foo#bar#baz' | 'foo$bar$baz'>(unionDelimiter);
 
-declare const unionValueAndDelimiter: DelimiterCase<'fooBar' | 'barBaz', '#' | '$'>;
-expectType<'foo#bar' | 'bar#baz' | 'foo$bar' | 'bar$baz'>(unionValueAndDelimiter);
+declare const unionValueAndDelimiter: DelimiterCase<'fooBarBaz' | 'barBazFoo', '#' | '$'>;
+expectType<'foo#bar#baz' | 'bar#baz#foo' | 'foo$bar$baz' | 'bar$baz$foo'>(unionValueAndDelimiter);
 
 const stringPart: DelimiterCase<`foo${string}`, '#'> = 'fooSomeString';
 expectType<`foo${string}`>(stringPart);

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -148,6 +148,30 @@ expectType<'foo#bar#01'>(withPunctuationSplitAndNumber);
 declare const withPunctuationSplitAndNumberSplit: DelimiterCase<'foo-bar::01', '#', {splitOnPunctuation: true; splitOnNumbers: true}>;
 expectType<'foo#bar#01'>(withPunctuationSplitAndNumberSplit);
 
+declare const anyValue: DelimiterCase<any, '#'>;
+expectType<any>(anyValue);
+
+declare const anyValue1: DelimiterCase<any, any>;
+expectType<any>(anyValue1);
+
+declare const anyValue2: DelimiterCase<any, never>;
+expectType<any>(anyValue2);
+
+declare const neverValue: DelimiterCase<never, '#'>;
+expectType<never>(neverValue);
+
+declare const neverValue1: DelimiterCase<never, any>;
+expectType<never>(neverValue1);
+
+declare const neverValue2: DelimiterCase<never, never>;
+expectType<never>(neverValue2);
+
+declare const anyDelimiter: DelimiterCase<'fooBar', any>;
+expectType<`foo${Lowercase<any>}bar`>(anyDelimiter);
+
+declare const neverDelimiter: DelimiterCase<'fooBar', never>;
+expectType<'fooBar'>(neverDelimiter);
+
 // Verifying example
 type OddCasedProperties<T> = {
 	[K in keyof T as DelimiterCase<K, '#'>]: T[K];


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently, `DelimiterCase` doesn't distribute properly over the specified `Delimiter`, resulting in strings that contain multiple delimiters.

Current behavior:
```ts
type T = DelimiterCase<'fooBarBaz', '#' | '$'>
//=> "foo#bar#baz" | "foo#bar$baz" | "foo$bar#baz" | "foo$bar$baz"
```

Fixed behavior:
```ts
type T = DelimiterCase<'fooBarBaz', '#' | '$'>
//=> "foo#bar#baz" | "foo$bar$baz"
```