### PR TITLE
`RemovePrefix`: Fix `any` prefix behavior in non-strict mode

### DIFF
--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -1,7 +1,9 @@
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, Not} from './internal/type.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsNever} from './is-never.d.ts';
 import type {Or} from './or.d.ts';
+import type {If} from './if.d.ts';
 
 /**
 @see {@link RemovePrefix}
@@ -112,11 +114,10 @@ type D = RemovePrefix<`handle${Capitalize<string>}`, 'handle'>;
 export type RemovePrefix<S extends string, Prefix extends string, Options extends RemovePrefixOptions = {}> =
 	IfNotAnyOrNever<
 		S,
-		IfNotAnyOrNever<
-			Prefix,
-			_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>,
-			string,
-			S
+		If<
+			IsNever<Prefix>,
+			S,
+			_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>
 		>
 	>;
 

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -39,6 +39,7 @@ expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, 'foo
 // Input: Literal, Prefix: Non-literal
 expectType<string>({} as RemovePrefix<'on-click', `${string}-`>);
 expectType<string>({} as RemovePrefix<'hover:flex', string>);
+expectType<string>({} as RemovePrefix<'on-change', any>);
 expectType<'handle-click'>({} as RemovePrefix<'handle-click', Uppercase<string>>);
 expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`>);
 
@@ -46,6 +47,7 @@ expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`>);
 expectType<string>({} as RemovePrefix<`hover:${string}`, `${string}:`>);
 expectType<string>({} as RemovePrefix<`${string}/${number}`, `${string}/`>);
 expectType<string>({} as RemovePrefix<string, string>);
+expectType<string>({} as RemovePrefix<`${any}foo${any}bar`, any>);
 expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}:`>);
 expectType<`${number}:${number}`>({} as RemovePrefix<`${number}:${number}`, `-${string}`>);
 
@@ -87,6 +89,8 @@ expectType<'on:change' | 'change'>({} as RemovePrefix<'on:change' | 'on-change',
 expectType<Uppercase<string> | `id:${Uppercase<string>}` | `${number}` | `id/${number}`>(
 	{} as RemovePrefix<`id:${Uppercase<string>}` | `id/${number}`, `${string}:` | `${string}/`, {strict: false}>,
 );
+expectType<`foo${any}bar`>({} as RemovePrefix<`${any}foo${any}bar`, any, {strict: false}>);
+expectType<`foo${string}bar`>({} as RemovePrefix<`${string}foo${string}bar`, any, {strict: false}>);
 
 // Generic assignability test
 type Assignability<S extends string> = S;

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -39,7 +39,7 @@ expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, 'foo
 // Input: Literal, Prefix: Non-literal
 expectType<string>({} as RemovePrefix<'on-click', `${string}-`>);
 expectType<string>({} as RemovePrefix<'hover:flex', string>);
-expectType<string>({} as RemovePrefix<'on-change', any>);
+expectType<string>({} as RemovePrefix<':foo:bar:baz', any>);
 expectType<'handle-click'>({} as RemovePrefix<'handle-click', Uppercase<string>>);
 expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`>);
 

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -80,6 +80,7 @@ expectType<'on-change'>({} as RemovePrefix<'on-change', never>);
 expectType<'change'>({} as RemovePrefix<'on-change', 'on-', {strict: false}>);
 expectType<'change' | 'hover'>({} as RemovePrefix<'on-change' | 'on-hover', 'on-', {strict: false}>);
 expectType<Capitalize<string>>({} as RemovePrefix<`handle${Capitalize<string>}`, 'handle', {strict: false}>);
+expectType<'foo:bar:baz'>({} as RemovePrefix<':foo:bar:baz', any, {strict: false}>);
 
 expectType<'click'>({} as RemovePrefix<'on-click', `${string}-`, {strict: false}>);
 expectType<'over:flex'>({} as RemovePrefix<'hover:flex', string, {strict: false}>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently, in `RemovePrefix`, even in non-strict mode, strictness is enforced when the prefix is `any`. 

For example, `` RemovePrefix<`${any}foo${any}bar`, any, {strict: false}> `` returns `string`, instead it should return `` `foo${any}bar` ``.