### PR TITLE
`DelimiterCase`: Fix behavior with non-single character delimiters

### DIFF
--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,7 +1,6 @@
 import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal/index.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
 import type {Merge} from './merge.d.ts';
-import type {RemovePrefix} from './remove-prefix.d.ts';
 import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
 
 export type _DefaultDelimiterCaseOptions = Merge<_DefaultWordsOptions, {splitOnNumbers: false}>;
@@ -17,7 +16,7 @@ type DelimiterCaseFromArray<
 	infer FirstWord extends string,
 	...infer RemainingWords extends string[],
 ]
-	? DelimiterCaseFromArray<RemainingWords, Delimiter, `${OutputString}${
+	? DelimiterCaseFromArray<RemainingWords, Delimiter, OutputString extends '' ? FirstWord : `${OutputString}${
 		StartsWith<FirstWord, AsciiPunctuation> extends true ? '' : Delimiter
 	}${FirstWord}`>
 	: OutputString;
@@ -70,10 +69,10 @@ export type DelimiterCase<
 	? Delimiter extends string // For distributing `Delimiter`
 		? IsStringLiteral<Value> extends false
 			? Value
-			: Lowercase<RemovePrefix<DelimiterCaseFromArray<
+			: Lowercase<DelimiterCaseFromArray<
 				Words<Value, ApplyDefaultOptions<WordsOptions, _DefaultDelimiterCaseOptions, Options>>,
 				Delimiter
-			>, string, {strict: false}>>
+			>>
 		: never
 	: Value;
 

--- a/test-d/delimiter-case.ts
+++ b/test-d/delimiter-case.ts
@@ -148,6 +148,21 @@ expectType<'foo#bar#01'>(withPunctuationSplitAndNumber);
 declare const withPunctuationSplitAndNumberSplit: DelimiterCase<'foo-bar::01', '#', {splitOnPunctuation: true; splitOnNumbers: true}>;
 expectType<'foo#bar#01'>(withPunctuationSplitAndNumberSplit);
 
+declare const startsWithPunctuation: DelimiterCase<'^fooBarBaz', ':'>;
+expectType<'^foo:bar:baz'>(startsWithPunctuation);
+
+declare const startsWithPunctuationSameAsDelimiter: DelimiterCase<'#fooBarBaz', '#'>;
+expectType<'#foo#bar#baz'>(startsWithPunctuationSameAsDelimiter);
+
+declare const emptyStringDelimiter: DelimiterCase<'fooBarBaz', ''>;
+expectType<'foobarbaz'>(emptyStringDelimiter);
+
+declare const moreThanOneLengthDelimiter: DelimiterCase<'fooBarBaz', '__'>;
+expectType<'foo__bar__baz'>(moreThanOneLengthDelimiter);
+
+declare const moreThanOneLengthDelimiter1: DelimiterCase<'fooBarBaz', '-->'>;
+expectType<'foo-->bar-->baz'>(moreThanOneLengthDelimiter1);
+
 declare const anyValue: DelimiterCase<any, '#'>;
 expectType<any>(anyValue);
 

--- a/test-d/delimiter-cased-properties-deep.ts
+++ b/test-d/delimiter-cased-properties-deep.ts
@@ -22,6 +22,21 @@ expectType<{'hello.world1': {'foo.bar': string}}>(withPunctuationSplit);
 declare const withPunctuationSplitAndNumbers: DelimiterCasedPropertiesDeep<{'hello@World1': {'foo::Bar1': string}}, '.', {splitOnPunctuation: true; splitOnNumbers: true}>;
 expectType<{'hello.world.1': {'foo.bar.1': string}}>(withPunctuationSplitAndNumbers);
 
+declare const startsWithPunctuation: DelimiterCasedPropertiesDeep<{'^fooBarBaz': {'^foo_bar_baz': string}}, ':'>;
+expectType<{'^foo:bar:baz': {'^foo:bar:baz': string}}>(startsWithPunctuation);
+
+declare const startsWithPunctuationSameAsDelimiter: DelimiterCasedPropertiesDeep<{'#fooBarBaz': {'#foo_bar_baz': string}}, '#'>;
+expectType<{'#foo#bar#baz': {'#foo#bar#baz': string}}>(startsWithPunctuationSameAsDelimiter);
+
+declare const emptyStringDelimiter: DelimiterCasedPropertiesDeep<{'fooBarBaz': {'foo_bar_baz': string}}, ''>;
+expectType<{'foobarbaz': {'foobarbaz': string}}>(emptyStringDelimiter);
+
+declare const moreThanOneLengthDelimiter: DelimiterCasedPropertiesDeep<{'fooBarBaz': {'foo_bar_baz': string}}, '__'>;
+expectType<{'foo__bar__baz': {'foo__bar__baz': string}}>(moreThanOneLengthDelimiter);
+
+declare const moreThanOneLengthDelimiter1: DelimiterCasedPropertiesDeep<{'fooBarBaz': {'foo_bar_baz': string}}, '-->'>;
+expectType<{'foo-->bar-->baz': {'foo-->bar-->baz': string}}>(moreThanOneLengthDelimiter1);
+
 // Verify example
 type User = {
 	userId: number;

--- a/test-d/delimiter-cased-properties.ts
+++ b/test-d/delimiter-cased-properties.ts
@@ -22,6 +22,21 @@ expectType<{'hello.world1': {'foo::Bar': string}}>(withPunctuationSplit);
 declare const withPunctuationSplitAndNumbers: DelimiterCasedProperties<{'hello@World1': {'foo::Bar': string}}, '.', {splitOnPunctuation: true; splitOnNumbers: true}>;
 expectType<{'hello.world.1': {'foo::Bar': string}}>(withPunctuationSplitAndNumbers);
 
+declare const startsWithPunctuation: DelimiterCasedProperties<{'^fooBarBaz': {'^foo_bar_baz': string}}, ':'>;
+expectType<{'^foo:bar:baz': {'^foo_bar_baz': string}}>(startsWithPunctuation);
+
+declare const startsWithPunctuationSameAsDelimiter: DelimiterCasedProperties<{'#fooBarBaz': {'#foo_bar_baz': string}}, '#'>;
+expectType<{'#foo#bar#baz': {'#foo_bar_baz': string}}>(startsWithPunctuationSameAsDelimiter);
+
+declare const emptyStringDelimiter: DelimiterCasedProperties<{'fooBarBaz': {'foo_bar_baz': string}}, ''>;
+expectType<{'foobarbaz': {'foo_bar_baz': string}}>(emptyStringDelimiter);
+
+declare const moreThanOneLengthDelimiter: DelimiterCasedProperties<{'fooBarBaz': {'foo_bar_baz': string}}, '__'>;
+expectType<{'foo__bar__baz': {'foo_bar_baz': string}}>(moreThanOneLengthDelimiter);
+
+declare const moreThanOneLengthDelimiter1: DelimiterCasedProperties<{'fooBarBaz': {'foo_bar_baz': string}}, '-->'>;
+expectType<{'foo-->bar-->baz': {'foo_bar_baz': string}}>(moreThanOneLengthDelimiter1);
+
 // Verify example
 type User = {
 	userId: number;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently, `DelimiterCase` breaks in the following cases:

1. When `Delimiter` is an empty string.
    ```ts
    type Current = DelimiterCase<'fooBar', ''>;
    //=> 'oobar'
    
    type Fixed = DelimiterCase<'fooBar', ''>;
    //=> 'foobar'
    ```
    
2. When `Delimiter` is of length `>1`.
    ```ts
    type Current = DelimiterCase<'fooBar', '__'>;
    //=> '_foo__bar'
    
    type Fixed = DelimiterCase<'fooBar', '__'>;
    //=> 'foo__bar'
    ```