### PR TITLE
`Except`: Enhancing parameter‌ types

### DIFF
--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -1,5 +1,6 @@
 import type {ApplyDefaultOptions} from './internal/index.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
+import type {LiteralUnion} from './literal-union.d.ts';
 
 /**
 Filter out keys from an object.
@@ -100,10 +101,10 @@ type PostPayloadFixed = Except<UserData, 'email'>;
 
 @category Object
 */
-export type Except<ObjectType, KeysType extends keyof ObjectType, Options extends ExceptOptions = {}> =
+export type Except<ObjectType, KeysType extends LiteralUnion<keyof ObjectType, PropertyKey>, Options extends ExceptOptions = {}> =
 	_Except<ObjectType, KeysType, ApplyDefaultOptions<ExceptOptions, DefaultExceptOptions, Options>>;
 
-type _Except<ObjectType, KeysType extends keyof ObjectType, Options extends Required<ExceptOptions>> = {
+type _Except<ObjectType, KeysType extends LiteralUnion<keyof ObjectType, PropertyKey>, Options extends Required<ExceptOptions>> = {
 	[KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];
 } & (Options['requireExactProps'] extends true
 	? Partial<Record<KeysType, never>>

--- a/source/except.d.ts
+++ b/source/except.d.ts
@@ -104,7 +104,7 @@ type PostPayloadFixed = Except<UserData, 'email'>;
 export type Except<ObjectType, KeysType extends LiteralUnion<keyof ObjectType, PropertyKey>, Options extends ExceptOptions = {}> =
 	_Except<ObjectType, KeysType, ApplyDefaultOptions<ExceptOptions, DefaultExceptOptions, Options>>;
 
-type _Except<ObjectType, KeysType extends LiteralUnion<keyof ObjectType, PropertyKey>, Options extends Required<ExceptOptions>> = {
+type _Except<ObjectType, KeysType extends PropertyKey, Options extends Required<ExceptOptions>> = {
 	[KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];
 } & (Options['requireExactProps'] extends true
 	? Partial<Record<KeysType, never>>

--- a/test-d/except.ts
+++ b/test-d/except.ts
@@ -28,3 +28,14 @@ type Example = {
 const test: Except<Example, 'bar', {requireExactProps: false}> = {foo: 123, bar: 'asdf'};
 expectType<number>(test.foo);
 expectType<unknown>(test['bar']);
+
+// Test for generic type
+type GenericType<T> = T extends string ? {
+	foo: T;
+	bar: string;
+} : {
+	baz: T;
+};
+type GenericTypeExcept<T> = Except<GenericType<T>, 'foo'>;
+expectType<GenericTypeExcept<string>>({} as {bar: string});
+expectType<GenericTypeExcept<number>>({} as {baz: number});


### PR DESCRIPTION
 - fixed #1421

When the 2nd input param `KeysType` is clearly defined, `keyof ObjectType` can correctly constrain and suggest parameter options. However, when the input type is ambiguous due to generics, `keyof ObjectType` prevents the parameter from passing. `LiteralUnion` can relax the strict input type, and still maintain the parameter suggestions.

If there are ok, I can fix similar problems in other PRs.