### PR TITLE
Export internal types: FirstArrayElement, UnknownArrayOrTuple

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -146,6 +146,8 @@ export type {ArraySlice} from './source/array-slice.d.ts';
 export type {ArraySplice} from './source/array-splice.d.ts';
 export type {ArrayTail} from './source/array-tail.d.ts';
 export type {ArrayElement} from './source/array-element.d.ts';
+export type {FirstArrayElement} from './source/internal/array.d.ts';
+export type {UnknownArrayOrTuple} from './source/internal/array.d.ts';
 export type {ArrayLength} from './source/array-length.d.ts';
 export type {SetFieldType, SetFieldTypeOptions} from './source/set-field-type.d.ts';
 export type {Paths, PathsOptions} from './source/paths.d.ts';


### PR DESCRIPTION
## Summary
Exports internal types from `type-fest/source/internal` to make them publicly accessible. This fixes issue #676.

## Changes
- Export `FirstArrayElement` from `./source/internal/array.d.ts`
- Export `UnknownArrayOrTuple` from `./source/internal/array.d.ts`

These types are useful for users who need to work with array/tuple types, similar to the existing `ArrayElement` export.

## Related
Closes #676

## Testing
- `npm run test:tsc` passes