### PR TITLE
Fix TaggedUnion constraint to allow documented generic usage

### DIFF
--- a/source/tagged-union.d.ts
+++ b/source/tagged-union.d.ts
@@ -7,7 +7,7 @@ Use-case: A shorter way to declare tagged unions with multiple members.
 ```
 import type {TaggedUnion} from 'type-fest';
 
-type Tagged<Fields extends Record<string, Record<string, unknown>>> = TaggedUnion<'type', Fields>;
+type Tagged<Fields extends Record<string, unknown>> = TaggedUnion<'type', Fields>;
 
 // The TaggedUnion utility reduces the amount of boilerplate needed to create a tagged union with multiple members, making the code more concise.
 type EventMessage = Tagged<{
@@ -45,7 +45,7 @@ type ManualEventMessage =
 */
 export type TaggedUnion<
 	TagKey extends string,
-	UnionMembers extends Record<string, Record<string, unknown>>,
+	UnionMembers extends Record<string, unknown>,
 > = {
 	[Name in keyof UnionMembers]: {[Key in TagKey]: Name} & UnionMembers[Name];
 }[keyof UnionMembers];

--- a/test-d/tagged-union.ts
+++ b/test-d/tagged-union.ts
@@ -28,3 +28,18 @@ const failsToo = {
 
 expectNotAssignable<Union>(fails);
 expectNotAssignable<Union>(failsToo);
+
+// Issue #1211: `TaggedUnion` should be usable through a generic wrapper whose
+// members are constrained as `Record<string, unknown>`, as shown in the docs.
+type Tagged<Fields extends Record<string, unknown>> = TaggedUnion<'type', Fields>;
+
+type EventMessage = Tagged<{
+	OpenExternalUrl: {url: string; id: number};
+	ToggleBackButtonVisibility: {visible: boolean};
+}>;
+
+expectAssignable<EventMessage>({type: 'OpenExternalUrl', url: 'https://example.com', id: 1});
+expectAssignable<EventMessage>({type: 'ToggleBackButtonVisibility', visible: true});
+
+// The discriminant still narrows the field types correctly.
+expectNotAssignable<EventMessage>({type: 'ToggleBackButtonVisibility', visible: 'yes'});


### PR DESCRIPTION
The documented usage of `TaggedUnion`,

```ts
type Tagged<Fields extends Record<string, unknown>> = TaggedUnion<'type', Fields>;
```

failed to compile with: `Type 'Fields' does not satisfy the constraint 'Record<string, Record<string, unknown>>'.`

The `UnionMembers` parameter required `Record<string, Record<string, unknown>>` — a redundant extra level of `Record`. A wrapper constrained as the natural `Record<string, unknown>` cannot satisfy the nested constraint, so the documented pattern (and any generic passthrough) was rejected.

This loosens the constraint to `Record<string, unknown>`. Per-member field types are still fully enforced by the `& UnionMembers[Name]` intersection in the mapped type, so the existing negative tests continue to pass. Added a test mirroring the documented pattern.

Closes #1211