### PR TITLE
Add NoInfer to IsNullable and IsOptional types

### DIFF
--- a/source/is-nullable.d.ts
+++ b/source/is-nullable.d.ts
@@ -25,6 +25,6 @@ type D = IsNullable<string | null | undefined>;
 @category Type Guard
 @category Utilities
 */
-export type IsNullable<T> = IsAny<T> extends true ? true : Extract<T, null> extends never ? false : true;
+export type IsNullable<T> = IsAny<T> extends true ? true : Extract<NoInfer<T>, null> extends never ? false : true;
 
 export {};

--- a/source/is-optional.d.ts
+++ b/source/is-optional.d.ts
@@ -23,6 +23,6 @@ type D = IsOptional<string | null | undefined>;
 @category Type Guard
 @category Utilities
 */
-export type IsOptional<T> = IsAny<T> extends true ? true : Extract<T, undefined> extends never ? false : true;
+export type IsOptional<T> = IsAny<T> extends true ? true : Extract<NoInfer<T>, undefined> extends never ? false : true;
 
 export {};


### PR DESCRIPTION
This is an independent contribution and is not part of any organized competition or hackathon.

Summary: Adds the built-in TypeScript NoInfer<T> utility type (TS 5.4+) to IsNullable and IsOptional types, following the pattern already established in the IsAny type.

Root Cause: The IsAny type already uses NoInfer<T> to prevent unwanted type widening in the intersection check. The IsNullable and IsOptional types use Extract<T, null> and Extract<T, undefined> respectively, which can benefit from the same NoInfer<T> pattern.

Fix: Wrapped T with NoInfer<T> in the Extract calls for both IsNullable and IsOptional.

Testing: No behavioral change is expected for standard usage. The existing test suites cover both types and verify the same type-level behavior.

Closes #848