### PR TITLE
Add `Whitespace` and `WordSeparators` public types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,6 +198,8 @@ export type {Join} from './source/join.d.ts';
 export type {Split, SplitOptions} from './source/split.d.ts';
 export type {Words, WordsOptions} from './source/words.d.ts';
 export type {Trim} from './source/trim.d.ts';
+export type {Whitespace} from './source/whitespace.d.ts';
+export type {WordSeparators} from './source/word-separators.d.ts';
 export type {Replace, ReplaceOptions} from './source/replace.d.ts';
 export type {StringRepeat} from './source/string-repeat.d.ts';
 export type {Includes} from './source/includes.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,8 @@ Click the type names for complete docs.
 ### String
 
 - [`Trim`](source/trim.d.ts) - Remove leading and trailing spaces from a string.
+- [`Whitespace`](source/whitespace.d.ts) - A union of all valid [Unicode whitespace characters](https://en.wikipedia.org/wiki/Whitespace_character).
+- [`WordSeparators`](source/word-separators.d.ts) - A union of characters commonly used to separate words in identifiers: hyphens, underscores, and all Unicode whitespace.
 - [`Split`](source/split.d.ts) - Represents an array of strings split using a given character or character set.
 - [`Words`](source/words.d.ts) - Split a string similar to Lodash's `_.words()` function.
 - [`Replace`](source/replace.d.ts) - Represents a string with some or all matches replaced by a replacement.

--- a/source/internal/characters.d.ts
+++ b/source/internal/characters.d.ts
@@ -1,32 +1,5 @@
-export type Whitespace =
-	| '\u{9}' // '\t'
-	| '\u{A}' // '\n'
-	| '\u{B}' // '\v'
-	| '\u{C}' // '\f'
-	| '\u{D}' // '\r'
-	| '\u{20}' // ' '
-	| '\u{85}'
-	| '\u{A0}'
-	| '\u{1680}'
-	| '\u{2000}'
-	| '\u{2001}'
-	| '\u{2002}'
-	| '\u{2003}'
-	| '\u{2004}'
-	| '\u{2005}'
-	| '\u{2006}'
-	| '\u{2007}'
-	| '\u{2008}'
-	| '\u{2009}'
-	| '\u{200A}'
-	| '\u{2028}'
-	| '\u{2029}'
-	| '\u{202F}'
-	| '\u{205F}'
-	| '\u{3000}'
-	| '\u{FEFF}';
-
-export type WordSeparators = '-' | '_' | Whitespace;
+export type {Whitespace} from '../whitespace.d.ts';
+export type {WordSeparators} from '../word-separators.d.ts';
 
 export type AsciiPunctuation =
 	| '!'

--- a/source/whitespace.d.ts
+++ b/source/whitespace.d.ts
@@ -1,0 +1,49 @@
+/**
+A union of all valid [Unicode whitespace characters](https://en.wikipedia.org/wiki/Whitespace_character).
+
+Includes standard ASCII whitespace (`\t`, `\n`, `\r`, `' '`) and various Unicode space separators.
+
+Useful for building string manipulation types that operate on whitespace boundaries.
+
+@example
+```
+import type {Whitespace} from 'type-fest';
+
+type TrimStart<S extends string> = S extends `${Whitespace}${infer Rest}` ? TrimStart<Rest> : S;
+
+type Result = TrimStart<'  \t hello'>;
+//=> 'hello'
+```
+
+@category String
+@category Template literal
+*/
+export type Whitespace =
+	| '\u{9}' // '\t'
+	| '\u{A}' // '\n'
+	| '\u{B}' // '\v'
+	| '\u{C}' // '\f'
+	| '\u{D}' // '\r'
+	| '\u{20}' // ' '
+	| '\u{85}'
+	| '\u{A0}'
+	| '\u{1680}'
+	| '\u{2000}'
+	| '\u{2001}'
+	| '\u{2002}'
+	| '\u{2003}'
+	| '\u{2004}'
+	| '\u{2005}'
+	| '\u{2006}'
+	| '\u{2007}'
+	| '\u{2008}'
+	| '\u{2009}'
+	| '\u{200A}'
+	| '\u{2028}'
+	| '\u{2029}'
+	| '\u{202F}'
+	| '\u{205F}'
+	| '\u{3000}'
+	| '\u{FEFF}';
+
+export {};

--- a/source/word-separators.d.ts
+++ b/source/word-separators.d.ts
@@ -1,0 +1,29 @@
+import type {Whitespace} from './whitespace.d.ts';
+
+/**
+A union of characters commonly used to separate words in identifiers: hyphens, underscores, and all Unicode whitespace.
+
+This mirrors the default word separators used by casing utilities like [`CamelCase`](https://github.com/sindresorhus/type-fest/blob/main/source/camel-case.d.ts).
+
+@example
+```
+import type {WordSeparators} from 'type-fest';
+
+type IsWordSeparator<T extends string> = T extends WordSeparators ? true : false;
+
+type A = IsWordSeparator<'-'>;
+//=> true
+
+type B = IsWordSeparator<'_'>;
+//=> true
+
+type C = IsWordSeparator<'a'>;
+//=> false
+```
+
+@category String
+@category Template literal
+*/
+export type WordSeparators = '-' | '_' | Whitespace;
+
+export {};

--- a/test-d/whitespace.ts
+++ b/test-d/whitespace.ts
@@ -1,0 +1,19 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import type {Whitespace} from '../index.d.ts';
+
+// Standard ASCII whitespace characters should be assignable to Whitespace
+expectAssignable<Whitespace>('\t');
+expectAssignable<Whitespace>('\n');
+expectAssignable<Whitespace>('\r');
+expectAssignable<Whitespace>(' ');
+
+// Non-whitespace characters should not be assignable
+expectNotAssignable<Whitespace>('a');
+expectNotAssignable<Whitespace>('.');
+
+// Whitespace can be used to build string manipulation types
+type TrimStart<S extends string> = S extends `${Whitespace}${infer Rest}` ? TrimStart<Rest> : S;
+
+expectAssignable<TrimStart<'  hello'>>('hello' as const);
+expectAssignable<TrimStart<'\t\n foo'>>('foo' as const);
+expectAssignable<TrimStart<'no-trim'>>('no-trim' as const);

--- a/test-d/word-separators.ts
+++ b/test-d/word-separators.ts
@@ -1,0 +1,24 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import type {WordSeparators} from '../index.d.ts';
+
+// Hyphens and underscores are word separators
+expectAssignable<WordSeparators>('-');
+expectAssignable<WordSeparators>('_');
+
+// Whitespace is also a word separator
+expectAssignable<WordSeparators>(' ');
+expectAssignable<WordSeparators>('\t');
+expectAssignable<WordSeparators>('\n');
+
+// Other characters are not word separators
+expectNotAssignable<WordSeparators>('a');
+expectNotAssignable<WordSeparators>('.');
+
+// WordSeparators can be used to split an identifier into words
+type Split<S extends string> = S extends `${infer Head}${WordSeparators}${infer Tail}`
+	? [Head, ...Split<Tail>]
+	: [S];
+
+expectAssignable<Split<'hello_world'>>(['hello', 'world'] as const);
+expectAssignable<Split<'foo-bar-baz'>>(['foo', 'bar', 'baz'] as const);
+expectAssignable<Split<'no separator'>>(['no', 'separator'] as const);


### PR DESCRIPTION
## Summary

Exposes two previously internal types from `source/internal/characters.d.ts` as part of the public API.

### `Whitespace`
A union of all 26 Unicode whitespace characters (`\t`, `\n`, `\r`, `' '`, and more). Useful for building custom `TrimStart`/`TrimEnd` template literal types.

### `WordSeparators`
A union of `'-' | '_' | Whitespace`. Mirrors the word separators used internally by `CamelCase`, `Words`, etc., letting users build their own casing/splitting utilities.

## Changes
- `source/whitespace.d.ts` — new public type with full JSDoc + `@example`
- `source/word-separators.d.ts` — new public type with full JSDoc + `@example`
- `test-d/whitespace.ts` — tsd tests (assignability, non-assignability, template literal usage)
- `test-d/word-separators.ts` — tsd tests
- `source/internal/characters.d.ts` — re-exports from new files to avoid duplication
- `index.d.ts` — exports both new types
- `readme.md` — adds both entries under the String section

All 38 tests pass.