### PR TITLE
`RemovePrefix`: Remove incorrect optimisation and always fallback to `string` for non-literal prefixes

### DIFF
--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -109,7 +109,7 @@ type _RemovePrefix<S extends string, Prefix extends string, Options extends Requ
 			? S extends `${Prefix}${infer Rest}`
 				? Rest
 				: S // Return back `S` when `Prefix` is not present at the start of `S`
-			: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
+			: string // Fallback to `string` when `Prefix` is non-literal and `strict` is enabled
 		: never;
 
 export {};

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -60,24 +60,6 @@ export type RemovePrefixOptions = {
 	type D = RemovePrefix<`id-${number}`, 'id-', {strict: false}>;
 	//=> `${number}`
 	```
-
-	Note: If it can be statically determined that the input string can never start with the specified non-literal prefix, then the input string is returned as-is, regardless of the value of this option.
-	For example, ``RemovePrefix<`${string}/${number}`, `${string}:`>`` returns `` `${string}/${number}` ``, since a string of type `` `${string}/${number}` `` can never start with a prefix of type `` `${string}:` ``.
-	```
-	import type {RemovePrefix} from 'type-fest';
-
-	type A = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: true}>;
-	//=> `${string}/${number}`
-
-	type B = RemovePrefix<`${string}/${number}`, `${string}:`, {strict: false}>;
-	//=> `${string}/${number}`
-
-	type C = RemovePrefix<'on-change', `${number}-`, {strict: true}>;
-	//=> 'on-change'
-
-	type D = RemovePrefix<'on-change', `${number}-`, {strict: false}>;
-	//=> 'on-change'
-	```
 	*/
 	strict?: boolean;
 };
@@ -123,11 +105,11 @@ export type RemovePrefix<S extends string, Prefix extends string, Options extend
 
 type _RemovePrefix<S extends string, Prefix extends string, Options extends Required<RemovePrefixOptions>> =
 	Prefix extends string // For distributing `Prefix`
-		? S extends `${Prefix}${infer Rest}`
-			? Or<IsStringLiteral<Prefix>, Not<Options['strict']>> extends true
+		? Or<IsStringLiteral<Prefix>, Not<Options['strict']>> extends true
+			? S extends `${Prefix}${infer Rest}`
 				? Rest
-				: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
-			: S // Return back `S` when `Prefix` is not present at the start of `S`
+				: S // Return back `S` when `Prefix` is not present at the start of `S`
+			: string // Fallback to `string` when `Prefix` is non-literal and `strict` is disabled
 		: never;
 
 export {};

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -40,16 +40,16 @@ expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, 'foo
 expectType<string>({} as RemovePrefix<'on-click', `${string}-`>);
 expectType<string>({} as RemovePrefix<'hover:flex', string>);
 expectType<string>({} as RemovePrefix<':foo:bar:baz', any>);
-expectType<'handle-click'>({} as RemovePrefix<'handle-click', Uppercase<string>>);
-expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`>);
+expectType<string>({} as RemovePrefix<'handle-click', Uppercase<string>>);
+expectType<string>({} as RemovePrefix<'on-change', `${string}--`>);
 
 // Input: Non-literal, Prefix: Non-literal
 expectType<string>({} as RemovePrefix<`hover:${string}`, `${string}:`>);
 expectType<string>({} as RemovePrefix<`${string}/${number}`, `${string}/`>);
 expectType<string>({} as RemovePrefix<string, string>);
 expectType<string>({} as RemovePrefix<`${any}foo${any}bar`, any>);
-expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}:`>);
-expectType<`${number}:${number}`>({} as RemovePrefix<`${number}:${number}`, `-${string}`>);
+expectType<string>({} as RemovePrefix<`${string}/${number}`, `${string}:`>);
+expectType<string>({} as RemovePrefix<`${number}:${number}`, `-${string}`>);
 
 // Unions
 expectType<'click' | 'hover' | 'change'>({} as RemovePrefix<'on-click' | 'on-hover' | 'on-change', 'on-'>);
@@ -62,7 +62,7 @@ expectType<'change' | 'on-change'>({} as RemovePrefix<'on-change', 'on-' | 'hand
 expectType<'on-change'>({} as RemovePrefix<'on-change', 'off-' | 'handle-'>);
 expectType<string>({} as RemovePrefix<'on-change', `${string}-` | 'on'>);
 
-expectType<'on:change' | 'onChange'>({} as RemovePrefix<'on:change' | 'onChange', `${string}-`>);
+expectType<string>({} as RemovePrefix<'on:change' | 'onChange', `${string}-`>);
 expectType<'name' | 'get-name' | 'age' | 'set-age' | 'other'>(
 	{} as RemovePrefix<'get-name' | 'set-age' | 'other', 'get-' | 'set-'>,
 );

--- a/test-d/remove-prefix.ts
+++ b/test-d/remove-prefix.ts
@@ -85,6 +85,8 @@ expectType<'foo:bar:baz'>({} as RemovePrefix<':foo:bar:baz', any, {strict: false
 expectType<'click'>({} as RemovePrefix<'on-click', `${string}-`, {strict: false}>);
 expectType<'over:flex'>({} as RemovePrefix<'hover:flex', string, {strict: false}>);
 expectType<`${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}/`, {strict: false}>);
+expectType<'on-change'>({} as RemovePrefix<'on-change', `${string}--`, {strict: false}>);
+expectType<`${string}/${number}`>({} as RemovePrefix<`${string}/${number}`, `${string}:`, {strict: false}>);
 expectType<'change' | '-change'>({} as RemovePrefix<'on-change', `${string}-` | 'on', {strict: false}>);
 expectType<'on:change' | 'change'>({} as RemovePrefix<'on:change' | 'on-change', `${string}-`, {strict: false}>);
 expectType<Uppercase<string> | `id:${Uppercase<string>}` | `${number}` | `id/${number}`>(


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

> Note: If it can be statically determined that the input string can never start with the specified non-literal prefix, then the input string is returned as-is, regardless of the value of this option.
For example, ``RemovePrefix<`${string}/${number}`, `${string}:`>`` returns `` `${string}/${number}` ``, since a string of type `` `${string}/${number}` `` can never start with a prefix of type `` `${string}:` ``.

The above note in `RemovePrefix` is actually incorrect, a string of type `` `${string}/${number}` `` _can actually_ start with a prefix of type `` `${string}:` ``.

For example, currently ``RemovePrefix<`on${string}`, `${string}B`>`` returns `` `on${string}` ``, but this wouldn't always align with the runtime behavior, like removing `'onB'` from `'onBounce'` would result in `'ounce'`, which isn't of type `` `on${string}` ``.

Hence, this PR simply removes this optimisation and updates the behavior to always fallback to `string` in `strict` mode if the prefix is a non-literal string type.