### PR TITLE
Add `RemoveSuffix` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,7 @@ export type {LastArrayElement} from './source/last-array-element.d.ts';
 export type {ConditionalSimplify} from './source/conditional-simplify.d.ts';
 export type {ConditionalSimplifyDeep} from './source/conditional-simplify-deep.d.ts';
 export type {RemovePrefix, RemovePrefixOptions} from './source/remove-prefix.d.ts';
+export type {RemoveSuffix, RemoveSuffixOptions} from './source/remove-suffix.d.ts';
 
 // Miscellaneous
 export type {GlobalThis} from './source/global-this.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -263,6 +263,7 @@ Click the type names for complete docs.
 - [`StringSlice`](source/string-slice.d.ts) - Returns a string slice of a given range, just like `String#slice()`.
 - [`StringRepeat`](source/string-repeat.d.ts) - Returns a new string which contains the specified number of copies of a given string, just like `String#repeat()`.
 - [`RemovePrefix`](source/remove-prefix.d.ts) - Remove the specified prefix from the start of a string.
+- [`RemoveSuffix`](source/remove-suffix.d.ts) - Remove the specified suffix from the end of a string.
 
 ### Array
 

--- a/source/remove-suffix.d.ts
+++ b/source/remove-suffix.d.ts
@@ -1,0 +1,115 @@
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IfNotAnyOrNever, Not} from './internal/type.d.ts';
+import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsNever} from './is-never.d.ts';
+import type {Or} from './or.d.ts';
+import type {If} from './if.d.ts';
+
+/**
+@see {@link RemoveSuffix}
+*/
+export type RemoveSuffixOptions = {
+	/**
+	When enabled, instantiations with non-literal suffixes (e.g., `string`, `Uppercase<string>`, `` `.${string}` ``) simply return `string`, since their precise structure cannot be statically determined.
+
+	Note: Disabling this option can produce misleading results that might not reflect the actual runtime behavior.
+	For example, ``RemoveSuffix<'report.pdf', `.${string}`, {strict: false}>`` returns `'report'`, but at runtime, suffix could be `'.txt'` (which satisfies `` `.${string}` ``) and removing `'.txt'` from `'report.pdf'` would not result in `'report'`.
+
+	So, it is recommended to not disable this option unless you are aware of the implications.
+
+	@default true
+
+	@example
+	```
+	import type {RemoveSuffix} from 'type-fest';
+
+	type A = RemoveSuffix<'report.pdf', `.${string}`, {strict: true}>;
+	//=> string
+
+	type B = RemoveSuffix<'report.pdf', `.${string}`, {strict: false}>;
+	//=> 'report'
+
+	type C = RemoveSuffix<'on-change', string, {strict: true}>;
+	//=> string
+
+	type D = RemoveSuffix<'on-change', string, {strict: false}>;
+	//=> 'o'
+
+	type E = RemoveSuffix<`${number}/${string}`, `/${string}`, {strict: true}>;
+	//=> string
+
+	type F = RemoveSuffix<`${number}/${string}`, `/${string}`, {strict: false}>;
+	//=> `${number}`
+	```
+
+	Note: This option has no effect when only the input string type is non-literal. For example, ``RemoveSuffix<`${string}.pdf`, '.pdf'>`` will always return `string`.
+
+	@example
+	```
+	import type {RemoveSuffix} from 'type-fest';
+
+	type A = RemoveSuffix<`${string}.pdf`, '.pdf', {strict: true}>;
+	//=> string
+
+	type B = RemoveSuffix<`${string}.pdf`, '.pdf', {strict: false}>;
+	//=> string
+
+	type C = RemoveSuffix<`${number}px`, 'px', {strict: true}>;
+	//=> `${number}`
+
+	type D = RemoveSuffix<`${number}px`, 'px', {strict: false}>;
+	//=> `${number}`
+	```
+	*/
+	strict?: boolean;
+};
+
+type DefaultRemoveSuffixOptions = {
+	strict: true;
+};
+
+/**
+Remove the specified suffix from the end of a string.
+
+@example
+```
+import type {RemoveSuffix} from 'type-fest';
+
+type A = RemoveSuffix<'report.pdf', '.pdf'>;
+//=> 'report'
+
+type B = RemoveSuffix<'bg-blue-500' | 'text-green-500' | 'border-slate-500', '-500'>;
+//=> 'bg-blue' | 'border-slate' | 'text-green'
+
+type C = RemoveSuffix<'report.pdf', '.txt'>;
+//=> 'report.pdf'
+
+type D = RemoveSuffix<`api/${string}/analytics`, '/analytics'>;
+//=> `api/${string}`
+```
+
+@see {@link RemoveSuffixOptions}
+
+@category String
+@category Template literal
+*/
+export type RemoveSuffix<S extends string, Suffix extends string, Options extends RemoveSuffixOptions = {}> =
+	IfNotAnyOrNever<
+		S,
+		If<
+			IsNever<Suffix>,
+			S,
+			_RemoveSuffix<S, Suffix, ApplyDefaultOptions<RemoveSuffixOptions, DefaultRemoveSuffixOptions, Options>>
+		>
+	>;
+
+type _RemoveSuffix<S extends string, Suffix extends string, Options extends Required<RemoveSuffixOptions>> =
+	Suffix extends string // For distributing `Suffix`
+		? Or<IsStringLiteral<Suffix>, Not<Options['strict']>> extends true
+			? S extends `${infer Rest}${Suffix}`
+				? Rest
+				: S // Return back `S` when `Suffix` is not present at the end of `S`
+			: string // Fallback to `string` when `Suffix` is non-literal and `strict` is disabled
+		: never;
+
+export {};

--- a/source/remove-suffix.d.ts
+++ b/source/remove-suffix.d.ts
@@ -109,7 +109,7 @@ type _RemoveSuffix<S extends string, Suffix extends string, Options extends Requ
 			? S extends `${infer Rest}${Suffix}`
 				? Rest
 				: S // Return back `S` when `Suffix` is not present at the end of `S`
-			: string // Fallback to `string` when `Suffix` is non-literal and `strict` is disabled
+			: string // Fallback to `string` when `Suffix` is non-literal and `strict` is enabled
 		: never;
 
 export {};

--- a/test-d/remove-suffix.ts
+++ b/test-d/remove-suffix.ts
@@ -1,0 +1,100 @@
+import {expectType} from 'tsd';
+import type {RemoveSuffix} from '../source/remove-suffix.d.ts';
+
+expectType<'report'>({} as RemoveSuffix<'report.pdf', '.pdf'>);
+expectType<'handle'>({} as RemoveSuffix<'handleClick', 'Click'>);
+expectType<'50'>({} as RemoveSuffix<'50px', 'px'>);
+expectType<'whitespace'>({} as RemoveSuffix<'whitespace ', ' '>);
+
+// Suffix not present
+expectType<''>({} as RemoveSuffix<'', 'foo'>);
+expectType<'report.pdf'>({} as RemoveSuffix<'report.pdf', '.txt'>);
+
+// Empty suffix
+expectType<'baz'>({} as RemoveSuffix<'baz', ''>);
+
+// Suffix completely matches the input string
+expectType<''>({} as RemoveSuffix<'click', 'click'>);
+
+// Suffix partially matches the input string
+expectType<'foobar'>({} as RemoveSuffix<'foobar', 'barbaz'>);
+expectType<'hello'>({} as RemoveSuffix<'hello', 'helloworld'>);
+
+// Multiple occurrences of suffix (should only remove from end)
+expectType<'foo-bar-bar'>({} as RemoveSuffix<'foo-bar-bar-bar', '-bar'>);
+expectType<'foofoo'>({} as RemoveSuffix<'foofoofoo', 'foo'>);
+
+// === Non-literals ===
+
+// Input: Non-literal, Suffix: Literal
+expectType<string>({} as RemoveSuffix<`${string}.ts`, '.ts'>);
+expectType<Capitalize<string>>({} as RemoveSuffix<`${Capitalize<string>}Action`, 'Action'>);
+expectType<`${number}`>({} as RemoveSuffix<`${number}rem`, 'rem'>);
+expectType<`--${string}`>({} as RemoveSuffix<`--${string}--`, '--'>);
+expectType<`${string}--disabled`>({} as RemoveSuffix<`${string}--disabled--loading`, '--loading'>);
+expectType<`${string}_user`>({} as RemoveSuffix<`${string}_user`, '_admin'>);
+expectType<string>({} as RemoveSuffix<string, 'Action'>);
+expectType<`${string}/${number}`>({} as RemoveSuffix<`${string}/${number}`, 'foo'>);
+
+// Input: Literal, Suffix: Non-literal
+expectType<string>({} as RemoveSuffix<'report.pdf', `.${string}`>);
+expectType<string>({} as RemoveSuffix<'100s', string>);
+expectType<string>({} as RemoveSuffix<'foo:bar:baz:', any>);
+expectType<string>({} as RemoveSuffix<'report.pdf', Uppercase<string>>);
+expectType<string>({} as RemoveSuffix<'user-id', `--${string}`>);
+
+// Input: Non-literal, Suffix: Non-literal
+expectType<string>({} as RemoveSuffix<`${string}--disabled`, `--${string}`>);
+expectType<string>({} as RemoveSuffix<`${number}/${string}`, `/${string}`>);
+expectType<string>({} as RemoveSuffix<string, string>);
+expectType<string>({} as RemoveSuffix<`foo${any}bar${any}`, any>);
+expectType<string>({} as RemoveSuffix<`${number}/${string}`, `:${string}`>);
+expectType<string>({} as RemoveSuffix<`${number}:${number}`, `${string}-`>);
+
+// Unions
+expectType<'foo' | 'bar' | 'baz'>({} as RemoveSuffix<'foo.ts' | 'bar.ts' | 'baz.ts', '.ts'>);
+expectType<'foo' | 'bar' | 'baz.js'>({} as RemoveSuffix<'foo.ts' | 'bar.ts' | 'baz.js', '.ts'>);
+expectType<Uppercase<string> | `${number}`>({} as RemoveSuffix<`${Uppercase<string>}Action` | `${number}Action`, 'Action'>);
+expectType<string>({} as RemoveSuffix<`${string}--disabled` | `${string}--loading`, `--${string}`>);
+
+expectType<'foo.' | 'foo'>({} as RemoveSuffix<'foo.png', 'png' | '.png'>);
+expectType<'foo' | 'foo.png'>({} as RemoveSuffix<'foo.png', '.png' | '.jpeg'>);
+expectType<'user' | 'user-id'>({} as RemoveSuffix<'user-id', '-id' | '-handle'>);
+expectType<'user-id'>({} as RemoveSuffix<'user-id', '-name' | '-age'>);
+expectType<string>({} as RemoveSuffix<'user-id', `-${string}` | 'id'>);
+
+expectType<string>({} as RemoveSuffix<'click_button' | 'clickButton', `:${string}`>);
+expectType<'index.html' | 'styles.css' | 'styles' | 'main.js' | 'main'>(
+	{} as RemoveSuffix<'index.html' | 'styles.css' | 'main.js', '.css' | '.js'>,
+);
+expectType<string>({} as RemoveSuffix<`${Lowercase<string>}.end` | `${number}/end`, `.${string}` | `/${string}`>);
+
+// Boundary types
+expectType<any>({} as RemoveSuffix<any, 'foo'>);
+expectType<never>({} as RemoveSuffix<never, 'foo'>);
+expectType<string>({} as RemoveSuffix<'report.pdf', any>);
+expectType<'report.pdf'>({} as RemoveSuffix<'report.pdf', never>);
+
+// === strict: false ===
+
+// No effect if `Suffix` is a literal
+expectType<'report'>({} as RemoveSuffix<'report.pdf', '.pdf', {strict: false}>);
+expectType<'foo' | 'bar'>({} as RemoveSuffix<'foo.js' | 'bar.js', '.js', {strict: false}>);
+expectType<Capitalize<string>>({} as RemoveSuffix<`${Capitalize<string>}Action`, 'Action', {strict: false}>);
+
+expectType<'report'>({} as RemoveSuffix<'report.pdf', `.${string}`, {strict: false}>);
+expectType<'r'>({} as RemoveSuffix<'report.pdf', string, {strict: false}>);
+expectType<`${number}`>({} as RemoveSuffix<`${number}/${string}`, `/${string}`, {strict: false}>);
+expectType<'report.pdf'>({} as RemoveSuffix<'report.pdf', `..${string}` | 'name', {strict: false}>);
+expectType<`${number}/${string}`>({} as RemoveSuffix<`${number}/${string}`, `:${string}`, {strict: false}>);
+expectType<'report' | 'report.'>({} as RemoveSuffix<'report.pdf', `.${string}` | 'pdf', {strict: false}>);
+expectType<'flex' | 'btn'>({} as RemoveSuffix<'flex' | 'btn__disabled', `__${string}`, {strict: false}>);
+expectType<Uppercase<string> | `${Uppercase<string>}:id` | `${number}` | `${number}/id`>(
+	{} as RemoveSuffix<`${Uppercase<string>}:id` | `${number}/id`, `:${string}` | `/${string}`, {strict: false}>,
+);
+
+// Generic assignability test
+type Assignability<S extends string> = S;
+// Output of `RemoveSuffix` should be assignable to `string`.
+type Test1<S extends string, Suffix extends string> = Assignability<RemoveSuffix<S, Suffix>>;
+type Test2<S extends Uppercase<string>, Suffix extends '-' | '/' | '#'> = Assignability<RemoveSuffix<S, Suffix>>;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1433 

> [!NOTE]
> There's a subtle difference in behavior b/w `RemovePrefix` and `RemoveSuffix` in **non-strict mode with non-literal prefixes/suffixes**:
> - `RemovePrefix` removes the shortest matching prefix (lazy).
> - `RemoveSuffix` removes the longest matching suffix (greedy).
> ```ts
> type A = RemovePrefix<'foo-bar-baz-qux', `${string}-`, {strict: false}>;
> //=> 'bar-baz-qux'
> 
> type B = RemoveSuffix<'foo-bar-baz-qux', `-${string}`, {strict: false}>;
> //=> 'foo'
>
> type C = RemovePrefix<'on-change', string, {strict: false}>;
> //=> 'n-change'
> 
> type D = RemoveSuffix<'on-change', string, {strict: false}>;
> //=> 'o'
> ```
>I guess this is fine for now because this is specific to non-strict mode.