### PR TITLE
Add `ExtractExactly` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,5 +219,6 @@ export type {ExtendsStrict, ExtendsStrictOptions} from './source/extends-strict.
 export type {ExtractStrict} from './source/extract-strict.d.ts';
 export type {ExcludeStrict} from './source/exclude-strict.d.ts';
 export type {ExcludeExactly} from './source/exclude-exactly.d.ts';
+export type {ExtractExactly} from './source/extract-exactly.d.ts';
 
 export {};

--- a/readme.md
+++ b/readme.md
@@ -342,6 +342,7 @@ Click the type names for complete docs.
 - [`ExtractStrict`](source/extract-strict.d.ts) - A stricter version of `Extract<T, U>` that ensures every member of `U` can successfully extract something from `T`.
 - [`ExcludeStrict`](source/exclude-strict.d.ts) - A stricter version of `Exclude<T, U>` that ensures every member of `U` can successfully exclude something from `T`.
 - [`ExcludeExactly`](source/exclude-exactly.d.ts) - A stricter version of `Exclude<T, U>` that excludes types only when they are exactly identical.
+- [`ExtractExactly`](source/extract-exactly.d.ts) - A stricter version of `Extract<T, U>` that extracts types only when they are exactly identical.
 
 ## Declined types
 

--- a/source/extract-exactly.d.ts
+++ b/source/extract-exactly.d.ts
@@ -1,0 +1,56 @@
+import type {IsAny} from './is-any.d.ts';
+import type {If} from './if.d.ts';
+import type {IsEqual} from './is-equal.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
+
+/**
+A stricter version of `Extract<T, U>` that extracts types only when they are exactly identical.
+
+@example
+```
+import type {ExtractExactly} from 'type-fest';
+
+type TestExtract1 = Extract<'a' | 'b' | 'c' | 1 | 2 | 3, string>;
+//=> 'a' | 'b' | 'c'
+
+type TestExtractExactly1 = ExtractExactly<'a' | 'b' | 'c' | 1 | 2 | 3, string>;
+//=> never
+
+type TestExtract2 = Extract<'a' | 'b' | 'c' | 1 | 2 | 3, any>;
+//=> 'a' | 'b' | 'c' | 1 | 2 | 3
+
+type TestExtractExactly2 = ExtractExactly<'a' | 'b' | 'c' | 1 | 2 | 3, any>;
+//=> never
+
+type TestExtract3 = Extract<{a: string} | {a: string; b: string}, {a: string}>;
+//=> {a: string} | {a: string; b: string}
+
+type TestExtractExactly3 = ExtractExactly<{a: string} | {a: string; b: string}, {a: string}>;
+//=> {a: string}
+```
+
+@category Improved Built-in
+*/
+export type ExtractExactly<Union, Match> =
+	IfNotAnyOrNever<
+		Union,
+		_ExtractExactly<Union, Match>,
+		// If `Union` is `any`, then if `Match` is `any`, return `any`, else return `never`.
+		If<IsAny<Match>, Union, never>,
+		// If `Union` is `never`, return `never`, doesn't matter what `Match` is.
+		never
+	>;
+
+type _ExtractExactly<Union, Match> =
+	IfNotAnyOrNever<Match,
+		Union extends unknown // For distributing `Union`
+			? [Match extends unknown // For distributing `Match`
+				? If<IsEqual<Union, Match>, true, never>
+				: never] extends [never] ? never : Union
+			: never,
+		// If `Match` is `any` or `never`, then return `never`,
+		// because `Union` cannot be `any` or `never` here.
+		never, never
+	>;
+
+export {};

--- a/test-d/exclude-exactly.ts
+++ b/test-d/exclude-exactly.ts
@@ -44,8 +44,10 @@ expectType<never>({} as ExcludeExactly<never, unknown>);
 expectType<2>({} as ExcludeExactly<0 | 1 | 2, 0 | 1>);
 expectType<never>({} as ExcludeExactly<0 | 1 | 2, 0 | 1 | 2>);
 expectType<{readonly a?: 0}>({} as ExcludeExactly<
-	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}, {a: 0} | {readonly a: 0} | {a?: 0}
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0},
+	{a: 0} | {readonly a: 0} | {a?: 0}
 >);
 expectType<never>({} as ExcludeExactly<
-	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}, {a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0},
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}
 >);

--- a/test-d/exclude-exactly.ts
+++ b/test-d/exclude-exactly.ts
@@ -43,6 +43,8 @@ expectType<never>({} as ExcludeExactly<never, unknown>);
 // Unions
 expectType<2>({} as ExcludeExactly<0 | 1 | 2, 0 | 1>);
 expectType<never>({} as ExcludeExactly<0 | 1 | 2, 0 | 1 | 2>);
+expectType<2 | null>({} as ExcludeExactly<'1' | 2 | true | null, '1' | boolean | undefined>);
+expectType<'' | null | false>({} as ExcludeExactly<0 | '' | null | undefined | false, 0 | string | undefined>);
 expectType<{readonly a?: 0}>({} as ExcludeExactly<
 	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0},
 	{a: 0} | {readonly a: 0} | {a?: 0}

--- a/test-d/extract-exactly.ts
+++ b/test-d/extract-exactly.ts
@@ -1,0 +1,55 @@
+import {expectType} from 'tsd';
+import type {ExtractExactly} from '../index.d.ts';
+
+expectType<never>({} as ExtractExactly<number, '1'>);
+expectType<number>({} as ExtractExactly<number, number>);
+expectType<never>({} as ExtractExactly<0, number>);
+expectType<never>({} as ExtractExactly<string, '1'>);
+expectType<string>({} as ExtractExactly<string, string>);
+expectType<never>({} as ExtractExactly<'0', string>);
+
+expectType<{readonly a: 0}>({} as ExtractExactly<{a: 0} | {readonly a: 0}, {readonly a: 0}>);
+expectType<{a: 0}>({} as ExtractExactly<{a: 0} | {readonly a: 0}, {a: 0}>);
+expectType<{readonly a: 0}>({} as ExtractExactly<{readonly a: 0}, {readonly a: 0}>);
+
+// `never` extracts nothing
+expectType<never>({} as ExtractExactly<0 | 1 | 2, never>);
+expectType<never>({} as ExtractExactly<never, never>);
+expectType<never>({} as ExtractExactly<any, never>);
+expectType<never>({} as ExtractExactly<unknown, never>);
+
+// Extracting from `unknown`/`any`
+expectType<never>({} as ExtractExactly<unknown, string>);
+expectType<never>({} as ExtractExactly<[unknown], [number]>);
+expectType<never>({} as ExtractExactly<unknown[], number[]>);
+expectType<never>({} as ExtractExactly<{a: unknown}, {a: number}>);
+expectType<number[]>({} as ExtractExactly<number[] | unknown[], number[]>);
+expectType<never>({} as ExtractExactly<any, string>);
+expectType<never>({} as ExtractExactly<[any], [number]>);
+expectType<never>({} as ExtractExactly<any[], number[]>);
+expectType<never>({} as ExtractExactly<{a: any}, {a: number}>);
+expectType<number[]>({} as ExtractExactly<number[] | any[], number[]>);
+
+// Extracting `unknown`/`any`
+expectType<unknown>({} as ExtractExactly<unknown, unknown>);
+expectType<any>({} as ExtractExactly<any, any>);
+expectType<never>({} as ExtractExactly<unknown, any>);
+expectType<never>({} as ExtractExactly<any, unknown>);
+expectType<never>({} as ExtractExactly<string | number, unknown>);
+expectType<never>({} as ExtractExactly<string | number, any>);
+expectType<never>({} as ExtractExactly<never, any>);
+expectType<never>({} as ExtractExactly<never, unknown>);
+
+// Unions
+expectType<0 | 1>({} as ExtractExactly<0 | 1 | 2, 0 | 1>);
+expectType<0 | 1 | 2>({} as ExtractExactly<0 | 1 | 2, 0 | 1 | 2>);
+expectType<'1' | true>({} as ExtractExactly<'1' | 2 | true | null, '1' | boolean | undefined>);
+expectType<0 | undefined>({} as ExtractExactly<0 | '' | null | undefined | false, 0 | string | undefined>);
+expectType<{a: 0} | {readonly a: 0} | {a?: 0}>({} as ExtractExactly<
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0},
+	{a: 0} | {readonly a: 0} | {a?: 0}
+>);
+expectType<{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}>({} as ExtractExactly<
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0},
+	{a: 0} | {readonly a: 0} | {a?: 0} | {readonly a?: 0}
+>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR adds a new `ExtractExactly` type.