### PR TITLE
Add `StringToNumber` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -177,6 +177,7 @@ export type {ArrayReverse} from './source/array-reverse.d.ts';
 export type {UnionMember} from './source/union-member.d.ts';
 export type {Absolute} from './source/absolute.d.ts';
 export type {UnionLength} from './source/union-length.d.ts';
+export type {StringToNumber} from './source/string-to-number.d.ts';
 
 // Template literal types
 export type {CamelCase, CamelCaseOptions} from './source/camel-case.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -310,6 +310,7 @@ Click the type names for complete docs.
 - [`Sum`](source/sum.d.ts) - Returns the sum of two numbers.
 - [`Subtract`](source/subtract.d.ts) - Returns the difference between two numbers.
 - [`Absolute`](source/absolute.d.ts) - Returns the absolute value of the specified number or bigint.
+- [`StringToNumber`](source/string-to-number.d.ts) - Converts a numeric string to a number.
 
 ### Change case
 

--- a/source/absolute.d.ts
+++ b/source/absolute.d.ts
@@ -1,4 +1,4 @@
-import type {StringToNumber} from './internal/string.d.ts';
+import type {StringToNumber} from './string-to-number.d.ts';
 
 /**
 Returns the absolute value of the specified number or bigint.

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -6,9 +6,10 @@ import type {Merge} from '../merge.d.ts';
 import type {IsAny} from '../is-any.d.ts';
 import type {If} from '../if.d.ts';
 import type {IsNever} from '../is-never.d.ts';
+import type {StringToNumber} from '../string-to-number.d.ts';
 import type {FilterDefinedKeys, FilterOptionalKeys} from './keys.d.ts';
 import type {MapsSetsOrArrays, NonRecursiveType} from './type.d.ts';
-import type {StringToNumber, ToString} from './string.d.ts';
+import type {ToString} from './string.d.ts';
 
 /**
 Create an object type with the given key `<Key>` and value `<Value>`.

--- a/source/internal/string.d.ts
+++ b/source/internal/string.d.ts
@@ -1,5 +1,4 @@
 import type {TupleOf} from '../tuple-of.d.ts';
-import type {NegativeInfinity, PositiveInfinity} from '../numeric.d.ts';
 import type {Trim} from '../trim.d.ts';
 import type {Whitespace} from './characters.d.ts';
 
@@ -9,42 +8,6 @@ Return a string representation of the given string or number.
 Note: This type is not the return type of the `.toString()` function.
 */
 export type ToString<T> = T extends string | number ? `${T}` : never;
-
-/**
-Converts a numeric string to a number.
-
-@example
-```
-type PositiveInt = StringToNumber<'1234'>;
-//=> 1234
-
-type NegativeInt = StringToNumber<'-1234'>;
-//=> -1234
-
-type PositiveFloat = StringToNumber<'1234.56'>;
-//=> 1234.56
-
-type NegativeFloat = StringToNumber<'-1234.56'>;
-//=> -1234.56
-
-type PositiveInfinity = StringToNumber<'Infinity'>;
-//=> Infinity
-
-type NegativeInfinity = StringToNumber<'-Infinity'>;
-//=> -Infinity
-```
-
-@category String
-@category Numeric
-@category Template literal
-*/
-export type StringToNumber<S extends string> = S extends `${infer N extends number}`
-	? N
-	: S extends 'Infinity'
-		? PositiveInfinity
-		: S extends '-Infinity'
-			? NegativeInfinity
-			: never;
 
 /**
 Returns a boolean for whether the given string `S` starts with the given string `SearchString`.

--- a/source/set-non-nullable-deep.d.ts
+++ b/source/set-non-nullable-deep.d.ts
@@ -1,9 +1,10 @@
-import type {NonRecursiveType, StringToNumber} from './internal/index.d.ts';
+import type {NonRecursiveType} from './internal/index.d.ts';
 import type {IsAny} from './is-any.d.ts';
 import type {NonNullableDeep} from './non-nullable-deep.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {SetNonNullable} from './set-non-nullable.d.ts';
 import type {Simplify} from './simplify.d.ts';
+import type {StringToNumber} from './string-to-number.d.ts';
 import type {UnionToTuple} from './union-to-tuple.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 

--- a/source/set-required-deep.d.ts
+++ b/source/set-required-deep.d.ts
@@ -1,11 +1,12 @@
 import type {IsAny} from './is-any.d.ts';
-import type {NonRecursiveType, StringToNumber} from './internal/index.d.ts';
+import type {NonRecursiveType} from './internal/index.d.ts';
 import type {Paths} from './paths.d.ts';
 import type {SetRequired} from './set-required.d.ts';
 import type {SimplifyDeep} from './simplify-deep.d.ts';
 import type {UnionToTuple} from './union-to-tuple.d.ts';
 import type {RequiredDeep} from './required-deep.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
+import type {StringToNumber} from './string-to-number.d.ts';
 
 /**
 Create a type that makes the given keys required, with support for deeply nested key paths, while keeping the remaining keys as is.

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -1,0 +1,58 @@
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
+import type {NegativeInfinity, PositiveInfinity} from './numeric.d.ts';
+import type {Replace} from './replace.d.ts';
+
+/**
+Converts a numeric string to a number.
+
+@example
+```
+import type {StringToNumber} from 'type-fest';
+
+type PositiveInteger = StringToNumber<'1234'>;
+//=> 1234
+
+type NegativeInteger = StringToNumber<'-1234'>;
+//=> -1234
+
+type PositiveFloat = StringToNumber<'1234.56'>;
+//=> 1234.56
+
+type NegativeFloat = StringToNumber<'-1234.56'>;
+//=> -1234.56
+
+type WithSeparators = StringToNumber<'1_234_567.123_456_7'>;
+//=> 1234567.1234567
+```
+
+Note: Due to some quirks in the type system, you may occasionally encounter unexpected results (see [microsoft/TypeScript#57404](https://github.com/microsoft/TypeScript/issues/57404)). For example, `StringToNumber<'-0.0000001'>` returns `number`. However, this type does handle fractional numbers ending in zero (such as `1.50`) and numbers with separators (such as `1_000`).
+
+@category String
+@category Numeric
+@category Template literal
+*/
+export type StringToNumber<S extends string> =
+	IfNotAnyOrNever<S,
+		S extends `_${string}` | `${string}_` | `${string}__${string}` | `${string}._${string}` | `${string}_.${string}`
+			? never
+			: _StringToNumber<Replace<S, '_', '', {all: true}>>,
+		number>;
+
+type _StringToNumber<S extends string> =
+	S extends '-0'
+		? -0
+		: S extends `-0.${infer _Fraction extends 0}` // Matches `-0.0`, `-0.00`, etc.
+			? -0
+			: S extends `${infer N extends number}.0` // Matches `1.0`, `1234.0`, etc.
+				? N
+				: S extends `${infer N}.${infer Fraction}0` // Matches `1.10`, `1234.5600`, etc.
+					? _StringToNumber<`${N}.${Fraction}`>
+					: S extends `${infer N extends number}`
+						? N
+						: S extends 'Infinity'
+							? PositiveInfinity
+							: S extends '-Infinity'
+								? NegativeInfinity
+								: never;
+
+export {};

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -19,6 +19,12 @@ type PositiveFloat = StringToNumber<'1234.56'>;
 
 type NegativeFloat = StringToNumber<'-1234.56'>;
 //=> -1234.56
+
+type PositiveInfinity = StringToNumber<'Infinity'>;
+//=> Infinity
+
+type NegativeInfinity = StringToNumber<'-Infinity'>;
+//=> -Infinity
 ```
 
 Note: Some strings, such as `'1.50'`, `'0b10'`, or `'12_345'`, may look like they can be converted to numbers, but actually they don't have any corresponding number literals. So, in such cases, this type produces `never`. See [type-fest#1446](https://github.com/sindresorhus/type-fest/pull/1446) for more details.

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -27,7 +27,7 @@ type NegativeInfinity = StringToNumber<'-Infinity'>;
 //=> -Infinity
 ```
 
-Note: Some strings, such as `'1.50'`, `'0b10'`, or `'12_345'`, may look like they can be converted to numbers, but actually they don't have any corresponding number literals. So, in such cases, this type produces `never`. See [type-fest#1446](https://github.com/sindresorhus/type-fest/pull/1446) for more details.
+Note: Some strings, such as `'1.50'`, `'0b10'`, or `'12_345'`, may look like they can be converted to numbers, but they don't actually have corresponding numeric literals. So, in such cases, this type produces `never`. See [type-fest#1446](https://github.com/sindresorhus/type-fest/pull/1446) for more details.
 
 @example
 ```

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -49,7 +49,7 @@ type NumericSeparators = StringToNumber<'12_345'>;
 */
 export type StringToNumber<S extends string> = IfNotAnyOrNever<S, _StringToNumber<S>, number>;
 
-export type _StringToNumber<S extends string> =
+type _StringToNumber<S extends string> =
 	S extends `${infer N extends number}`
 		? number extends N
 			? `${number}` extends S

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -1,6 +1,5 @@
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
 import type {NegativeInfinity, PositiveInfinity} from './numeric.d.ts';
-import type {Replace} from './replace.d.ts';
 
 /**
 Converts a numeric string to a number.
@@ -20,39 +19,43 @@ type PositiveFloat = StringToNumber<'1234.56'>;
 
 type NegativeFloat = StringToNumber<'-1234.56'>;
 //=> -1234.56
-
-type WithSeparators = StringToNumber<'1_234_567.123_456_7'>;
-//=> 1234567.1234567
 ```
 
-Note: Due to some quirks in the type system, you may occasionally encounter unexpected results (see [microsoft/TypeScript#57404](https://github.com/microsoft/TypeScript/issues/57404)). For example, `StringToNumber<'-0.0000001'>` returns `number`. However, this type does handle fractional numbers ending in zero (such as `1.50`) and numbers with separators (such as `1_000`).
+Note: Some strings, such as `'1.50'`, `'0b10'`, or `'12_345'`, may look like they can be converted to numbers, but actually they don't have any corresponding number literals. So, in such cases, this type produces `never`. See [type-fest#1446](https://github.com/sindresorhus/type-fest/pull/1446) for more details.
+
+@example
+```
+import type {StringToNumber} from 'type-fest';
+
+type FractionalsEndingInZero = StringToNumber<'1.50'>;
+//=> never
+
+type NonDecimalBases = StringToNumber<'0b10' | '0o10' | '0x10'>;
+//=> never
+
+type NumericSeparators = StringToNumber<'12_345'>;
+//=> never
+```
 
 @category String
 @category Numeric
 @category Template literal
 */
-export type StringToNumber<S extends string> =
-	IfNotAnyOrNever<S,
-		S extends `_${string}` | `${string}_` | `${string}__${string}` | `${string}._${string}` | `${string}_.${string}`
-			? never
-			: _StringToNumber<Replace<S, '_', '', {all: true}>>,
-		number>;
+export type StringToNumber<S extends string> = IfNotAnyOrNever<S, _StringToNumber<S>, number>;
 
-type _StringToNumber<S extends string> =
-	S extends '-0'
-		? -0
-		: S extends `-0.${infer _Fraction extends 0}` // Matches `-0.0`, `-0.00`, etc.
-			? -0
-			: S extends `${infer N extends number}.0` // Matches `1.0`, `1234.0`, etc.
+export type _StringToNumber<S extends string> =
+	S extends `${infer N extends number}`
+		? number extends N
+			? `${number}` extends S
 				? N
-				: S extends `${infer N}.${infer Fraction}0` // Matches `1.10`, `1234.5600`, etc.
-					? _StringToNumber<`${N}.${Fraction}`>
-					: S extends `${infer N extends number}`
-						? N
-						: S extends 'Infinity'
-							? PositiveInfinity
-							: S extends '-Infinity'
-								? NegativeInfinity
-								: never;
+				: never
+			: N
+		: string extends S
+			? number
+			: S extends 'Infinity'
+				? PositiveInfinity
+				: S extends '-Infinity'
+					? NegativeInfinity
+					: never;
 
 export {};

--- a/test-d/object-merge.ts
+++ b/test-d/object-merge.ts
@@ -197,6 +197,7 @@ expectType<{[x: string]: number | string; a?: number | string}>(
 // String/number key overwrites corresponding number/string key
 expectType<{0: string; 1: string}>({} as ObjectMerge<{'0': number}, {0: string; 1: string}>);
 expectType<{'0': string; '1': string}>({} as ObjectMerge<{0?: number}, {'0': string; '1': string}>);
+expectType<{1.5: number; '1.50': string}>({} as ObjectMerge<{1.5: number}, {'1.50': string}>);
 // String/number key with number/string index signature
 expectType<{[x: string]: number | string; 0: string}>({} as ObjectMerge<{[x: string]: number}, {0: string}>);
 expectType<{[x: number]: number | string; '0': string}>({} as ObjectMerge<{[x: number]: number}, {'0': string}>);

--- a/test-d/string-to-number.ts
+++ b/test-d/string-to-number.ts
@@ -1,0 +1,91 @@
+import {expectType} from 'tsd';
+import type {StringToNumber} from '../source/string-to-number.d.ts';
+import type {NegativeInfinity, PositiveInfinity} from '../source/numeric.d.ts';
+
+// Zero
+expectType<0>({} as StringToNumber<'0'>);
+expectType<-0>({} as StringToNumber<'-0'>);
+expectType<0>({} as StringToNumber<'0.0'>);
+expectType<-0>({} as StringToNumber<'-0.0'>);
+expectType<0>({} as StringToNumber<'0.0000'>);
+expectType<-0>({} as StringToNumber<'-0.0000'>);
+
+// Positive integers
+expectType<1>({} as StringToNumber<'1'>);
+expectType<10>({} as StringToNumber<'10'>);
+expectType<1234>({} as StringToNumber<'1234'>);
+expectType<5000>({} as StringToNumber<'5000'>);
+
+// Negative integers
+expectType<-5>({} as StringToNumber<'-5'>);
+expectType<-20>({} as StringToNumber<'-20'>);
+expectType<-567>({} as StringToNumber<'-567'>);
+expectType<-900>({} as StringToNumber<'-900'>);
+
+// Positive floats
+expectType<0.1>({} as StringToNumber<'0.1'>);
+expectType<10.55>({} as StringToNumber<'10.55'>);
+expectType<1234.56>({} as StringToNumber<'1234.56'>);
+
+// Negative floats
+expectType<-0.9>({} as StringToNumber<'-0.9'>);
+expectType<-3.14>({} as StringToNumber<'-3.14'>);
+expectType<-56.123>({} as StringToNumber<'-56.123'>);
+
+// Floats with trailing zeroes
+expectType<1>({} as StringToNumber<'1.0'>);
+expectType<-0.01>({} as StringToNumber<'-0.010'>);
+expectType<10.5>({} as StringToNumber<'10.500'>);
+expectType<32.0203>({} as StringToNumber<'32.02030'>);
+expectType<-100>({} as StringToNumber<'-100.00'>);
+expectType<-1234.056>({} as StringToNumber<'-1234.05600'>);
+
+// Starting with `-0.` and ending with zeroes
+expectType<-0.025>({} as StringToNumber<'-0.0250'>);
+expectType<-0.203>({} as StringToNumber<'-0.2030'>);
+expectType<-0.1>({} as StringToNumber<'-0.100'>);
+
+// Separators
+expectType<12_345>({} as StringToNumber<'12_345'>);
+expectType<1_234_567_890>({} as StringToNumber<'1_234_567_890'>);
+expectType<-3_456_789>({} as StringToNumber<'-3_456_789'>);
+expectType<12_345.123_45>({} as StringToNumber<'12_345.123_45'>);
+expectType<-12.345_678_9>({} as StringToNumber<'-12.345_678_9'>);
+expectType<98_765.4321>({} as StringToNumber<'98_765.432_10'>);
+expectType<-12.3>({} as StringToNumber<'-12.300_000'>);
+expectType<0.123_456_789>({} as StringToNumber<'0.123_456_789'>);
+expectType<-0.001>({} as StringToNumber<'-0.001_000_00'>);
+
+// Invalid separators
+expectType<never>({} as StringToNumber<'_15'>);
+expectType<never>({} as StringToNumber<'15_'>);
+expectType<never>({} as StringToNumber<'_15_'>);
+expectType<never>({} as StringToNumber<'_0.125'>);
+expectType<never>({} as StringToNumber<'0.125_'>);
+expectType<never>({} as StringToNumber<'6__6'>);
+expectType<never>({} as StringToNumber<'123_45__67'>);
+expectType<never>({} as StringToNumber<'3._14'>);
+expectType<never>({} as StringToNumber<'3_.14'>);
+
+// Special cases
+expectType<number>({} as StringToNumber<`${number}`>);
+
+// Non numeric strings
+expectType<never>({} as StringToNumber<'two'>);
+expectType<never>({} as StringToNumber<'1.2.30'>);
+expectType<never>({} as StringToNumber<'..5'>);
+expectType<never>({} as StringToNumber<string>);
+expectType<never>({} as StringToNumber<Uppercase<string>>);
+expectType<never>({} as StringToNumber<`${number}.${number}`>);
+
+// Unions
+expectType<1 | -1>({} as StringToNumber<'1' | '-1' | 'one'>);
+expectType<1 | 2 | -3 | 1.25 | -0.65 | 10_000_000>({} as StringToNumber<'1' | '2' | '-3' | '1.25' | '-0.650' | '10_000_000'>);
+
+// Infinity
+expectType<PositiveInfinity>({} as StringToNumber<'Infinity'>);
+expectType<NegativeInfinity>({} as StringToNumber<'-Infinity'>);
+
+// Boundary cases
+expectType<never>({} as StringToNumber<never>);
+expectType<number>({} as StringToNumber<any>);

--- a/test-d/string-to-number.ts
+++ b/test-d/string-to-number.ts
@@ -4,11 +4,6 @@ import type {NegativeInfinity, PositiveInfinity} from '../source/numeric.d.ts';
 
 // Zero
 expectType<0>({} as StringToNumber<'0'>);
-expectType<-0>({} as StringToNumber<'-0'>);
-expectType<0>({} as StringToNumber<'0.0'>);
-expectType<-0>({} as StringToNumber<'-0.0'>);
-expectType<0>({} as StringToNumber<'0.0000'>);
-expectType<-0>({} as StringToNumber<'-0.0000'>);
 
 // Positive integers
 expectType<1>({} as StringToNumber<'1'>);
@@ -32,59 +27,30 @@ expectType<-0.9>({} as StringToNumber<'-0.9'>);
 expectType<-3.14>({} as StringToNumber<'-3.14'>);
 expectType<-56.123>({} as StringToNumber<'-56.123'>);
 
-// Floats with trailing zeroes
-expectType<1>({} as StringToNumber<'1.0'>);
-expectType<-0.01>({} as StringToNumber<'-0.010'>);
-expectType<10.5>({} as StringToNumber<'10.500'>);
-expectType<32.0203>({} as StringToNumber<'32.02030'>);
-expectType<-100>({} as StringToNumber<'-100.00'>);
-expectType<-1234.056>({} as StringToNumber<'-1234.05600'>);
+// Infinity
+expectType<PositiveInfinity>({} as StringToNumber<'Infinity'>);
+expectType<NegativeInfinity>({} as StringToNumber<'-Infinity'>);
 
-// Starting with `-0.` and ending with zeroes
-expectType<-0.025>({} as StringToNumber<'-0.0250'>);
-expectType<-0.203>({} as StringToNumber<'-0.2030'>);
-expectType<-0.1>({} as StringToNumber<'-0.100'>);
-
-// Separators
-expectType<12_345>({} as StringToNumber<'12_345'>);
-expectType<1_234_567_890>({} as StringToNumber<'1_234_567_890'>);
-expectType<-3_456_789>({} as StringToNumber<'-3_456_789'>);
-expectType<12_345.123_45>({} as StringToNumber<'12_345.123_45'>);
-expectType<-12.345_678_9>({} as StringToNumber<'-12.345_678_9'>);
-expectType<98_765.4321>({} as StringToNumber<'98_765.432_10'>);
-expectType<-12.3>({} as StringToNumber<'-12.300_000'>);
-expectType<0.123_456_789>({} as StringToNumber<'0.123_456_789'>);
-expectType<-0.001>({} as StringToNumber<'-0.001_000_00'>);
-
-// Invalid separators
-expectType<never>({} as StringToNumber<'_15'>);
-expectType<never>({} as StringToNumber<'15_'>);
-expectType<never>({} as StringToNumber<'_15_'>);
-expectType<never>({} as StringToNumber<'_0.125'>);
-expectType<never>({} as StringToNumber<'0.125_'>);
-expectType<never>({} as StringToNumber<'6__6'>);
-expectType<never>({} as StringToNumber<'123_45__67'>);
-expectType<never>({} as StringToNumber<'3._14'>);
-expectType<never>({} as StringToNumber<'3_.14'>);
-
-// Special cases
-expectType<number>({} as StringToNumber<`${number}`>);
+// Unions
+expectType<1 | -1>({} as StringToNumber<'1' | '-1' | 'one'>);
+expectType<1 | 2 | -3 | 1.25>({} as StringToNumber<'1' | '2' | '-3' | '1.25' | '-0.650' | '10_000_000'>);
 
 // Non numeric strings
 expectType<never>({} as StringToNumber<'two'>);
 expectType<never>({} as StringToNumber<'1.2.30'>);
 expectType<never>({} as StringToNumber<'..5'>);
-expectType<never>({} as StringToNumber<string>);
 expectType<never>({} as StringToNumber<Uppercase<string>>);
 expectType<never>({} as StringToNumber<`${number}.${number}`>);
 
-// Unions
-expectType<1 | -1>({} as StringToNumber<'1' | '-1' | 'one'>);
-expectType<1 | 2 | -3 | 1.25 | -0.65 | 10_000_000>({} as StringToNumber<'1' | '2' | '-3' | '1.25' | '-0.650' | '10_000_000'>);
+expectType<never>({} as StringToNumber<'-0'>);
+expectType<never>({} as StringToNumber<'0.0'>);
+expectType<never>({} as StringToNumber<'1.0'>);
+expectType<never>({} as StringToNumber<'-3.50'>);
+expectType<never>({} as StringToNumber<'12_345'>);
 
-// Infinity
-expectType<PositiveInfinity>({} as StringToNumber<'Infinity'>);
-expectType<NegativeInfinity>({} as StringToNumber<'-Infinity'>);
+// Special cases
+expectType<number>({} as StringToNumber<`${number}`>);
+expectType<number>({} as StringToNumber<string>);
 
 // Boundary cases
 expectType<never>({} as StringToNumber<never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Exposes the internal `StringToNumber` type ~~with some improvements around edge cases~~.

I initially had added support for handling two out of the many cases mentioned in [https://github.com/microsoft/TypeScript/issues/57404](https://github.com/microsoft/TypeScript/issues/57404).

* Fractionals ending in `0` were handled, so `StringToNumber<'1.50'>` would have returned `1.5`.
* Literals with separators were handled, so `StringToNumber<'123_45'>` would have returned `12345`.

But I think that's not correct. There's actually _no_ number equivalent for strings like `'1.50'`, or `'123_45'` as mentioned in https://github.com/microsoft/TypeScript/issues/57404#issuecomment-2138494542.

Here's a quick breakdown of why I think those should _not_ be supported.

# Context

```ts
type ToNumber<T extends string> = T extends `${infer N extends number}`
  ? N
  : never;

```

When you instantiate a type like `ToNumber` with strings such as `'1.50'`, `'0b10'`, or `'1e2'`, you'd get back the generic `number` type rather than a specific number literal.

This happens because TS enforces a **round-trip constraint** when inferring number literals from string literals. Meaning, the inferred number literal, when converted back to a string, must exactly match the original string.

For example, `ToNumber<'123'>` returns `123`. If you convert `123` back to a string (`` `${123}` ``), it produces `'123'`, perfectly matching the original input.

However, for a string like `'1.50'`, this round-trip fails. There is *no* number literal whose string form is exactly `'1.50'`. TS cannot return `1.50` because its string representation is `'1.5'`, which doesn't match `'1.50'`. Similarly, it cannot return `1.5`, because `1.5` also stringifies to `'1.5'`, failing the round-trip constraint.

In other words, there are no number literals whose string representation can be `'1.50'`, `'0b10'`, or `'1e2'`. For reference, the string representation of `1.50` is `'1.5'`, `0b10` is `'2'`, and `1e2` is `'100'`:

```ts
type A = `${1.50}`; //=> "1.5"
type B = `${0b10}`; //=> "2"
type C = `${1e2}`; //=> "100"

```

# Why is this behavior correct?

Let's consider the following example:

```ts
const doubles =  {'1.5': 2, '2.50': 5};

doubles[1.5]; // ✅ Works, yields `2` at runtime
doubles[2.5]; // ❌ Errors, yields `undefined` at runtime
//      ~~~
// Property '2.5' does not exist on type '{ '1.5': number; '2.50': number; }'.

```

When you access an object using a number index, JS implicitly converts that number to a string before performing the lookup. And since `(2.5).toString()` is `'2.5'`, which doesn't match `'2.50'`, the result is `undefined` and not `5`.

In other words, there is *no* number index that can be used to access the key `'2.50'`.

So, if we use `StringToNumber` to normalize keys (like we already do in `NormalizeKeys`), we'd end up getting incorrect keys. For example, if `Paths<{'2.50': 5}>` returned `'2.50' | 2.5`, it would be incorrect because `2.5` isn't a valid path.

Note: `'Infinity'` handling in `StringToNumber` is fine because `toString` of `Infinity` is indeed `'Infinity'`.

# Caveat

There is, however, one caveat in TS's default inference behavior that feels a bit off.

If you try to infer a number from a string like `'1.50'`, TS doesn't simply deny the inference and return `never`, it instead returns `number`. I am _not_ really sure why it behaves like this, but this feels incorrect. Since there is _no_ number equivalent for `'1.50'`, it should behave _just_ like an invalid string (e.g., `'foo'`). Interestingly, for strings with numeric separators like `'123_45'`, TS denies the inference and returns `never`.

Also, if `Paths<{'2.50': 5}>` were to return `'2.50' | number`, that would be _even_ worse.

And, because of this, `ObjectMerge<{1.5: number}, {'1.50': string}>` currently returns `{'1.50': string}`, instead it should have returned `{1.5: number; '1.50': string}`.

# Conclusion

So, these are the _only_ changes to `StringToNumber` that this PR introduces:

| Input | Current | Updated |
|-------|---------|---------|
| `'1.50' \| '0b10' \| '12_345'` | `number` | `never` |
| `string` | `never` | `number` |
| `any` | `Infinity \| -Infinity` | `number` |