### PR TITLE
`Proposal`: Recursion internal

### DIFF
--- a/source/internal/index.d.ts
+++ b/source/internal/index.d.ts
@@ -7,6 +7,6 @@ export type * from './string.d.ts';
 export type * from './tuple.d.ts';
 export type * from './type.d.ts';
 export type * from './enforce-optional.d.ts';
-export type * from "./recursion-utils.d.ts"
+export type * from './recursion-utils.d.ts';
 
 export {};

--- a/source/internal/index.d.ts
+++ b/source/internal/index.d.ts
@@ -7,5 +7,6 @@ export type * from './string.d.ts';
 export type * from './tuple.d.ts';
 export type * from './type.d.ts';
 export type * from './enforce-optional.d.ts';
+export type * from "./recursion-utils.d.ts"
 
 export {};

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -53,26 +53,26 @@ export type GetNext1000<CurrentState extends NextAble> =
 export type GetNext10000<CurrentState extends NextAble> = 
     CurrentState extends Constant<any>
     ? CurrentState
-    : GetNext1000<CurrentState> extends infer Res1 extends NextAble
-        ? Res1 extends Constant<any> ? Res1
-        : GetNext1000<Res1> extends infer Res2 extends NextAble
-            ? Res2 extends Constant<any> ? Res2
-            : GetNext1000<Res2> extends infer Res3 extends NextAble
-                ? Res3 extends Constant<any> ? Res3
-                : GetNext1000<Res3> extends infer Res4 extends NextAble
-                    ? Res4 extends Constant<any> ? Res4
-                    : GetNext1000<Res4> extends infer Res5 extends NextAble
-                        ? Res5 extends Constant<any> ? Res5
-                        : GetNext1000<Res5> extends infer Res6 extends NextAble
-                            ? Res6 extends Constant<any> ? Res6
-                            : GetNext1000<Res6> extends infer Res7 extends NextAble
-                                ? Res7 extends Constant<any> ? Res7
-                                : GetNext1000<Res7> extends infer Res8 extends NextAble
-                                    ? Res8 extends Constant<any> ? Res8
-                                    : GetNext1000<Res8> extends infer Res9 extends NextAble
-                                        ? Res9 extends Constant<any> ? Res9
-                                        : GetNext1000<Res9> extends infer Res10 extends NextAble
-                                            ? Res10
+    : GetNext1000<CurrentState> extends infer Result1 extends NextAble
+        ? Result1 extends Constant<any> ? Result1
+        : GetNext1000<Result1> extends infer Result2 extends NextAble
+            ? Result2 extends Constant<any> ? Result2
+            : GetNext1000<Result2> extends infer Result3 extends NextAble
+                ? Result3 extends Constant<any> ? Result3
+                : GetNext1000<Result3> extends infer Result4 extends NextAble
+                    ? Result4 extends Constant<any> ? Result4
+                    : GetNext1000<Result4> extends infer Result5 extends NextAble
+                        ? Result5 extends Constant<any> ? Result5
+                        : GetNext1000<Result5> extends infer Result6 extends NextAble
+                            ? Result6 extends Constant<any> ? Result6
+                            : GetNext1000<Result6> extends infer Result7 extends NextAble
+                                ? Result7 extends Constant<any> ? Result7
+                                : GetNext1000<Result7> extends infer Result8 extends NextAble
+                                    ? Result8 extends Constant<any> ? Result8
+                                    : GetNext1000<Result8> extends infer Result9 extends NextAble
+                                        ? Result9 extends Constant<any> ? Result9
+                                        : GetNext1000<Result9> extends infer Result10 extends NextAble
+                                            ? Result10
                                             : never
                                         : never
                                     : never
@@ -90,26 +90,26 @@ export type GetNext10000<CurrentState extends NextAble> =
 export type GetNext100000<CurrentState extends NextAble> = 
     CurrentState extends Constant<any>
     ? CurrentState
-    : GetNext10000<CurrentState> extends infer Res1 extends NextAble
-        ? Res1 extends Constant<any> ? Res1
-        : GetNext10000<Res1> extends infer Res2 extends NextAble
-            ? Res2 extends Constant<any> ? Res2
-            : GetNext10000<Res2> extends infer Res3 extends NextAble
-                ? Res3 extends Constant<any> ? Res3
-                : GetNext10000<Res3> extends infer Res4 extends NextAble
-                    ? Res4 extends Constant<any> ? Res4
-                    : GetNext10000<Res4> extends infer Res5 extends NextAble
-                        ? Res5 extends Constant<any> ? Res5
-                        : GetNext10000<Res5> extends infer Res6 extends NextAble
-                            ? Res6 extends Constant<any> ? Res6
-                            : GetNext10000<Res6> extends infer Res7 extends NextAble
-                                ? Res7 extends Constant<any> ? Res7
-                                : GetNext10000<Res7> extends infer Res8 extends NextAble
-                                    ? Res8 extends Constant<any> ? Res8
-                                    : GetNext10000<Res8> extends infer Res9 extends NextAble
-                                        ? Res9 extends Constant<any> ? Res9
-                                        : GetNext10000<Res9> extends infer Res10 extends NextAble
-                                            ? Res10
+    : GetNext10000<CurrentState> extends infer Result1 extends NextAble
+        ? Result1 extends Constant<any> ? Result1
+        : GetNext10000<Result1> extends infer Result2 extends NextAble
+            ? Result2 extends Constant<any> ? Result2
+            : GetNext10000<Result2> extends infer Result3 extends NextAble
+                ? Result3 extends Constant<any> ? Result3
+                : GetNext10000<Result3> extends infer Result4 extends NextAble
+                    ? Result4 extends Constant<any> ? Result4
+                    : GetNext10000<Result4> extends infer Result5 extends NextAble
+                        ? Result5 extends Constant<any> ? Result5
+                        : GetNext10000<Result5> extends infer Result6 extends NextAble
+                            ? Result6 extends Constant<any> ? Result6
+                            : GetNext10000<Result6> extends infer Result7 extends NextAble
+                                ? Result7 extends Constant<any> ? Result7
+                                : GetNext10000<Result7> extends infer Result8 extends NextAble
+                                    ? Result8 extends Constant<any> ? Result8
+                                    : GetNext10000<Result8> extends infer Result9 extends NextAble
+                                        ? Result9 extends Constant<any> ? Result9
+                                        : GetNext10000<Result9> extends infer Result10 extends NextAble
+                                            ? Result10
                                             : never
                                         : never
                                     : never

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -1,122 +1,110 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 export interface NextAble {
 	next: NextAble;
 }
+/**
+ * using this interface is required here as it stops typescript from creating more intermediate types and use already existing this type
+ */
 
 export interface Constant<T> {
 	next: this;
 	value: T;
 }
-
+/* eslint-enable @typescript-eslint/consistent-type-definitions */
 /**
  * Call ["next"] 10 times
  */
 type GetNext10<CurrentState extends NextAble> =
-	CurrentState["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"];
+	CurrentState['next']['next']['next']['next']['next']['next']['next']['next']['next']['next'];
 
 /**
  * Call ["next"] 100 times
  */
-type GetNext100<CurrentState extends NextAble> = 
-    CurrentState extends Constant<any>
-    ? CurrentState
-    : GetNext10<
-        GetNext10<
-            GetNext10<
-                GetNext10<
-                    GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<CurrentState>>>>>>
-                >
-            >
-        >
-    >;
+type GetNext100<CurrentState extends NextAble> =
+	CurrentState extends Constant<any>
+		? CurrentState
+		: GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<CurrentState>>>>>>>>>>;
 
 /**
  * Call ["next"] 1000 times
  */
-export type GetNext1000<CurrentState extends NextAble> = 
-    CurrentState extends Constant<any>
-    ? CurrentState
-    : GetNext100<
-        GetNext100<
-            GetNext100<
-                GetNext100<
-                    GetNext100<
-                        GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<CurrentState>>>>>
-                    >
-                >
-            >
-        >
-    >;
+export type GetNext1000<CurrentState extends NextAble> =
+	CurrentState extends Constant<any>
+		? CurrentState
+		: GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<CurrentState>>>>>>>>>>;
 
 /**
  * Call ["next"] 10000 times
  */
-export type GetNext10000<CurrentState extends NextAble> = 
-    CurrentState extends Constant<any>
-    ? CurrentState
-    : GetNext1000<CurrentState> extends infer Result1 extends NextAble
-        ? Result1 extends Constant<any> ? Result1
-        : GetNext1000<Result1> extends infer Result2 extends NextAble
-            ? Result2 extends Constant<any> ? Result2
-            : GetNext1000<Result2> extends infer Result3 extends NextAble
-                ? Result3 extends Constant<any> ? Result3
-                : GetNext1000<Result3> extends infer Result4 extends NextAble
-                    ? Result4 extends Constant<any> ? Result4
-                    : GetNext1000<Result4> extends infer Result5 extends NextAble
-                        ? Result5 extends Constant<any> ? Result5
-                        : GetNext1000<Result5> extends infer Result6 extends NextAble
-                            ? Result6 extends Constant<any> ? Result6
-                            : GetNext1000<Result6> extends infer Result7 extends NextAble
-                                ? Result7 extends Constant<any> ? Result7
-                                : GetNext1000<Result7> extends infer Result8 extends NextAble
-                                    ? Result8 extends Constant<any> ? Result8
-                                    : GetNext1000<Result8> extends infer Result9 extends NextAble
-                                        ? Result9 extends Constant<any> ? Result9
-                                        : GetNext1000<Result9> extends infer Result10 extends NextAble
-                                            ? Result10
-                                            : never
-                                        : never
-                                    : never
-                                : never
-                            : never
-                        : never
-                    : never
-                : never
-            : never
-        : never;
+export type GetNext10000<CurrentState extends NextAble> =
+	CurrentState extends Constant<any>
+		? CurrentState
+		: GetNext1000<CurrentState> extends infer Result1 extends NextAble
+			? Result1 extends Constant<any> ? Result1
+				: GetNext1000<Result1> extends infer Result2 extends NextAble
+					? Result2 extends Constant<any> ? Result2
+						: GetNext1000<Result2> extends infer Result3 extends NextAble
+							? Result3 extends Constant<any> ? Result3
+								: GetNext1000<Result3> extends infer Result4 extends NextAble
+									? Result4 extends Constant<any> ? Result4
+										: GetNext1000<Result4> extends infer Result5 extends NextAble
+											? Result5 extends Constant<any> ? Result5
+												: GetNext1000<Result5> extends infer Result6 extends NextAble
+													? Result6 extends Constant<any> ? Result6
+														: GetNext1000<Result6> extends infer Result7 extends NextAble
+															? Result7 extends Constant<any> ? Result7
+																: GetNext1000<Result7> extends infer Result8 extends NextAble
+																	? Result8 extends Constant<any> ? Result8
+																		: GetNext1000<Result8> extends infer Result9 extends NextAble
+																			? Result9 extends Constant<any> ? Result9
+																				: GetNext1000<Result9> extends infer Result10 extends NextAble
+																					? Result10
+																					: never
+																			: never
+																	: never
+															: never
+													: never
+											: never
+									: never
+							: never
+					: never
+			: never;
 
 /**
  * Call ["next"] 100000 times
  */
-export type GetNext100000<CurrentState extends NextAble> = 
-    CurrentState extends Constant<any>
-    ? CurrentState
-    : GetNext10000<CurrentState> extends infer Result1 extends NextAble
-        ? Result1 extends Constant<any> ? Result1
-        : GetNext10000<Result1> extends infer Result2 extends NextAble
-            ? Result2 extends Constant<any> ? Result2
-            : GetNext10000<Result2> extends infer Result3 extends NextAble
-                ? Result3 extends Constant<any> ? Result3
-                : GetNext10000<Result3> extends infer Result4 extends NextAble
-                    ? Result4 extends Constant<any> ? Result4
-                    : GetNext10000<Result4> extends infer Result5 extends NextAble
-                        ? Result5 extends Constant<any> ? Result5
-                        : GetNext10000<Result5> extends infer Result6 extends NextAble
-                            ? Result6 extends Constant<any> ? Result6
-                            : GetNext10000<Result6> extends infer Result7 extends NextAble
-                                ? Result7 extends Constant<any> ? Result7
-                                : GetNext10000<Result7> extends infer Result8 extends NextAble
-                                    ? Result8 extends Constant<any> ? Result8
-                                    : GetNext10000<Result8> extends infer Result9 extends NextAble
-                                        ? Result9 extends Constant<any> ? Result9
-                                        : GetNext10000<Result9> extends infer Result10 extends NextAble
-                                            ? Result10
-                                            : never
-                                        : never
-                                    : never
-                                : never
-                            : never
-                        : never
-                    : never
-                : never
-            : never
-        : never;
+export type GetNext100000<CurrentState extends NextAble> =
+	CurrentState extends Constant<any>
+		? CurrentState
+		: GetNext10000<CurrentState> extends infer Result1 extends NextAble
+			? Result1 extends Constant<any> ? Result1
+				: GetNext10000<Result1> extends infer Result2 extends NextAble
+					? Result2 extends Constant<any> ? Result2
+						: GetNext10000<Result2> extends infer Result3 extends NextAble
+							? Result3 extends Constant<any> ? Result3
+								: GetNext10000<Result3> extends infer Result4 extends NextAble
+									? Result4 extends Constant<any> ? Result4
+										: GetNext10000<Result4> extends infer Result5 extends NextAble
+											? Result5 extends Constant<any> ? Result5
+												: GetNext10000<Result5> extends infer Result6 extends NextAble
+													? Result6 extends Constant<any> ? Result6
+														: GetNext10000<Result6> extends infer Result7 extends NextAble
+															? Result7 extends Constant<any> ? Result7
+																: GetNext10000<Result7> extends infer Result8 extends NextAble
+																	? Result8 extends Constant<any> ? Result8
+																		: GetNext10000<Result8> extends infer Result9 extends NextAble
+																			? Result9 extends Constant<any> ? Result9
+																				: GetNext10000<Result9> extends infer Result10 extends NextAble
+																					? Result10
+																					: never
+																			: never
+																	: never
+															: never
+													: never
+											: never
+									: never
+							: never
+					: never
+			: never;
+
+export {};

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -1,0 +1,94 @@
+export interface NextAble {
+	next: NextAble;
+}
+
+export interface Constant<T> {
+	next: this;
+	value: T;
+}
+
+/**
+ * Call ["next"] 10 times
+ */
+type GetNext10<T extends NextAble> =
+	T["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"];
+
+/**
+ * Call ["next"] 100 times
+ */
+type GetNext100<T extends NextAble> = GetNext10<
+	GetNext10<
+		GetNext10<
+			GetNext10<
+				GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<T>>>>>>
+			>
+		>
+	>
+>;
+
+/**
+ * Call ["next"] 1000 times
+ */
+export type GetNext1000<T extends NextAble> = GetNext100<
+	GetNext100<
+		GetNext100<
+			GetNext100<
+				GetNext100<
+					GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<T>>>>>
+				>
+			>
+		>
+	>
+>;
+
+/**
+ * Call ["next"] 10000 times
+ */
+export type GetNext10000<T extends NextAble> = 
+    GetNext1000<T> extends infer Res1 extends NextAble
+        ? GetNext1000<Res1> extends infer Res2 extends NextAble
+            ? GetNext1000<Res2> extends infer Res3 extends NextAble
+                ? GetNext1000<Res3> extends infer Res4 extends NextAble
+                    ? GetNext1000<Res4> extends infer Res5 extends NextAble
+                        ? GetNext1000<Res5> extends infer Res6 extends NextAble
+                            ? GetNext1000<Res6> extends infer Res7 extends NextAble
+                                ? GetNext1000<Res7> extends infer Res8 extends NextAble
+                                    ? GetNext1000<Res8> extends infer Res9 extends NextAble
+                                        ? GetNext1000<Res9> extends infer Res10 extends NextAble
+                                            ? Res10
+                                            : never
+                                        : never
+                                    : never
+                                : never
+                            : never
+                        : never
+                    : never
+                : never
+            : never
+        : never;
+
+/**
+ * Call ["next"] 100000 times
+ */
+export type GetNext100000<T extends NextAble> = 
+    GetNext10000<T> extends infer Res1 extends NextAble
+        ? GetNext10000<Res1> extends infer Res2 extends NextAble
+            ? GetNext10000<Res2> extends infer Res3 extends NextAble
+                ? GetNext10000<Res3> extends infer Res4 extends NextAble
+                    ? GetNext10000<Res4> extends infer Res5 extends NextAble
+                        ? GetNext10000<Res5> extends infer Res6 extends NextAble
+                            ? GetNext10000<Res6> extends infer Res7 extends NextAble
+                                ? GetNext10000<Res7> extends infer Res8 extends NextAble
+                                    ? GetNext10000<Res8> extends infer Res9 extends NextAble
+                                        ? GetNext10000<Res9> extends infer Res10 extends NextAble
+                                            ? Res10
+                                            : never
+                                        : never
+                                    : never
+                                : never
+                            : never
+                        : never
+                    : never
+                : never
+            : never
+        : never;

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -3,7 +3,7 @@ export interface NextAble {
 	next: NextAble;
 }
 /**
- * using this interface is required here as it stops typescript from creating more intermediate types and use already existing this type
+ * Using this interface is required here as it stops typescript from creating more intermediate types and use already existing this type
  */
 
 export interface Constant<T> {

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -3,7 +3,7 @@ export interface NextAble {
 	next: NextAble;
 }
 /**
- * Using this interface is required here as it stops typescript from creating more intermediate types and use already existing this type
+ * Using interface is required here as it stops typescript from creating more intermediate types and use already existing this type
  */
 
 export interface Constant<T> {

--- a/source/internal/recursion-utils.d.ts
+++ b/source/internal/recursion-utils.d.ts
@@ -10,51 +10,68 @@ export interface Constant<T> {
 /**
  * Call ["next"] 10 times
  */
-type GetNext10<T extends NextAble> =
-	T["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"];
+type GetNext10<CurrentState extends NextAble> =
+	CurrentState["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"]["next"];
 
 /**
  * Call ["next"] 100 times
  */
-type GetNext100<T extends NextAble> = GetNext10<
-	GetNext10<
-		GetNext10<
-			GetNext10<
-				GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<T>>>>>>
-			>
-		>
-	>
->;
+type GetNext100<CurrentState extends NextAble> = 
+    CurrentState extends Constant<any>
+    ? CurrentState
+    : GetNext10<
+        GetNext10<
+            GetNext10<
+                GetNext10<
+                    GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<GetNext10<CurrentState>>>>>>
+                >
+            >
+        >
+    >;
 
 /**
  * Call ["next"] 1000 times
  */
-export type GetNext1000<T extends NextAble> = GetNext100<
-	GetNext100<
-		GetNext100<
-			GetNext100<
-				GetNext100<
-					GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<T>>>>>
-				>
-			>
-		>
-	>
->;
+export type GetNext1000<CurrentState extends NextAble> = 
+    CurrentState extends Constant<any>
+    ? CurrentState
+    : GetNext100<
+        GetNext100<
+            GetNext100<
+                GetNext100<
+                    GetNext100<
+                        GetNext100<GetNext100<GetNext100<GetNext100<GetNext100<CurrentState>>>>>
+                    >
+                >
+            >
+        >
+    >;
 
 /**
  * Call ["next"] 10000 times
  */
-export type GetNext10000<T extends NextAble> = 
-    GetNext1000<T> extends infer Res1 extends NextAble
-        ? GetNext1000<Res1> extends infer Res2 extends NextAble
-            ? GetNext1000<Res2> extends infer Res3 extends NextAble
-                ? GetNext1000<Res3> extends infer Res4 extends NextAble
-                    ? GetNext1000<Res4> extends infer Res5 extends NextAble
-                        ? GetNext1000<Res5> extends infer Res6 extends NextAble
-                            ? GetNext1000<Res6> extends infer Res7 extends NextAble
-                                ? GetNext1000<Res7> extends infer Res8 extends NextAble
-                                    ? GetNext1000<Res8> extends infer Res9 extends NextAble
-                                        ? GetNext1000<Res9> extends infer Res10 extends NextAble
+export type GetNext10000<CurrentState extends NextAble> = 
+    CurrentState extends Constant<any>
+    ? CurrentState
+    : GetNext1000<CurrentState> extends infer Res1 extends NextAble
+        ? Res1 extends Constant<any> ? Res1
+        : GetNext1000<Res1> extends infer Res2 extends NextAble
+            ? Res2 extends Constant<any> ? Res2
+            : GetNext1000<Res2> extends infer Res3 extends NextAble
+                ? Res3 extends Constant<any> ? Res3
+                : GetNext1000<Res3> extends infer Res4 extends NextAble
+                    ? Res4 extends Constant<any> ? Res4
+                    : GetNext1000<Res4> extends infer Res5 extends NextAble
+                        ? Res5 extends Constant<any> ? Res5
+                        : GetNext1000<Res5> extends infer Res6 extends NextAble
+                            ? Res6 extends Constant<any> ? Res6
+                            : GetNext1000<Res6> extends infer Res7 extends NextAble
+                                ? Res7 extends Constant<any> ? Res7
+                                : GetNext1000<Res7> extends infer Res8 extends NextAble
+                                    ? Res8 extends Constant<any> ? Res8
+                                    : GetNext1000<Res8> extends infer Res9 extends NextAble
+                                        ? Res9 extends Constant<any> ? Res9
+                                        : GetNext1000<Res9> extends infer Res10 extends NextAble
                                             ? Res10
                                             : never
                                         : never
@@ -70,17 +87,28 @@ export type GetNext10000<T extends NextAble> =
 /**
  * Call ["next"] 100000 times
  */
-export type GetNext100000<T extends NextAble> = 
-    GetNext10000<T> extends infer Res1 extends NextAble
-        ? GetNext10000<Res1> extends infer Res2 extends NextAble
-            ? GetNext10000<Res2> extends infer Res3 extends NextAble
-                ? GetNext10000<Res3> extends infer Res4 extends NextAble
-                    ? GetNext10000<Res4> extends infer Res5 extends NextAble
-                        ? GetNext10000<Res5> extends infer Res6 extends NextAble
-                            ? GetNext10000<Res6> extends infer Res7 extends NextAble
-                                ? GetNext10000<Res7> extends infer Res8 extends NextAble
-                                    ? GetNext10000<Res8> extends infer Res9 extends NextAble
-                                        ? GetNext10000<Res9> extends infer Res10 extends NextAble
+export type GetNext100000<CurrentState extends NextAble> = 
+    CurrentState extends Constant<any>
+    ? CurrentState
+    : GetNext10000<CurrentState> extends infer Res1 extends NextAble
+        ? Res1 extends Constant<any> ? Res1
+        : GetNext10000<Res1> extends infer Res2 extends NextAble
+            ? Res2 extends Constant<any> ? Res2
+            : GetNext10000<Res2> extends infer Res3 extends NextAble
+                ? Res3 extends Constant<any> ? Res3
+                : GetNext10000<Res3> extends infer Res4 extends NextAble
+                    ? Res4 extends Constant<any> ? Res4
+                    : GetNext10000<Res4> extends infer Res5 extends NextAble
+                        ? Res5 extends Constant<any> ? Res5
+                        : GetNext10000<Res5> extends infer Res6 extends NextAble
+                            ? Res6 extends Constant<any> ? Res6
+                            : GetNext10000<Res6> extends infer Res7 extends NextAble
+                                ? Res7 extends Constant<any> ? Res7
+                                : GetNext10000<Res7> extends infer Res8 extends NextAble
+                                    ? Res8 extends Constant<any> ? Res8
+                                    : GetNext10000<Res8> extends infer Res9 extends NextAble
+                                        ? Res9 extends Constant<any> ? Res9
+                                        : GetNext10000<Res9> extends infer Res10 extends NextAble
                                             ? Res10
                                             : never
                                         : never


### PR DESCRIPTION
Closes #1448

> [!NOTE]
> its a helper to allow types that use recursive tail call optimisation get past 1000 depth that usually causes a `TS(2589)`, for types that are intended to work with less 1000 depth or small data it might be good to just use traditional tail call optimisation. 


<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
