### PR TITLE
Simplify ApplyDefaultOptions for supported TypeScript versions

### DIFF
--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -219,13 +219,13 @@ type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOp
 ```
 */
 export type ApplyDefaultOptions<
-    Options extends object,
-    Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
-    SpecifiedOptions extends Options,
+	Options extends object,
+	Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
+	SpecifiedOptions extends Options,
 > =
-    _ApplyDefaultOptions<Options, Defaults, SpecifiedOptions> extends infer Result extends Required<Options>
-        ? Result
-        : never;
+	_ApplyDefaultOptions<Options, Defaults, SpecifiedOptions> extends infer Result extends Required<Options>
+		? Result
+		: never;
 
 type _ApplyDefaultOptions<
 	Options,

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -219,13 +219,11 @@ type Result = ApplyDefaultOptions<PathsOptions, DefaultPathsOptions, SpecifiedOp
 ```
 */
 export type ApplyDefaultOptions<
-	Options extends object,
-	Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
-	SpecifiedOptions extends Options,
+    Options extends object,
+    Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
+    SpecifiedOptions extends Options,
 > =
-	_ApplyDefaultOptions<Options, Defaults, SpecifiedOptions> extends infer Result extends Required<Options> // `extends Required<Options>` ensures that `ApplyDefaultOptions<SomeOption, ...>` is always assignable to `Required<SomeOption>`
-		? Result
-		: never;
+    _ApplyDefaultOptions<Options, Defaults, SpecifiedOptions>;
 
 type _ApplyDefaultOptions<
 	Options,

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -223,7 +223,9 @@ export type ApplyDefaultOptions<
     Defaults extends Simplify<Omit<Required<Options>, RequiredKeysOf<Options>> & Partial<Record<RequiredKeysOf<Options>, never>>>,
     SpecifiedOptions extends Options,
 > =
-    _ApplyDefaultOptions<Options, Defaults, SpecifiedOptions>;
+    _ApplyDefaultOptions<Options, Defaults, SpecifiedOptions> extends infer Result extends Required<Options>
+        ? Result
+        : never;
 
 type _ApplyDefaultOptions<
 	Options,


### PR DESCRIPTION
Closes #1142

Remove the redundant TypeScript compatibility wrapper from `ApplyDefaultOptions` and return `_ApplyDefaultOptions<...>` directly.

This simplifies the type definition now that older TypeScript workaround behavior is no longer needed.