### PR TITLE
Allow adding `-Infinity` as a twoslash type in JSDoc codeblocks

### DIFF
--- a/lint-rules/validate-jsdoc-codeblocks.js
+++ b/lint-rules/validate-jsdoc-codeblocks.js
@@ -250,6 +250,10 @@ function normalizeType(type, onlySortNumbers = false) {
 		ts.ScriptTarget.Latest,
 	);
 
+	if (sourceFile.parseDiagnostics.length > 0) {
+		return type.trim();
+	}
+
 	const typeNode = sourceFile.statements[0].declarationList.declarations[0].type;
 
 	const print = node => ts.createPrinter().printNode(ts.EmitHint.Unspecified, node, sourceFile);

--- a/lint-rules/validate-jsdoc-codeblocks.test.js
+++ b/lint-rules/validate-jsdoc-codeblocks.test.js
@@ -1384,6 +1384,38 @@ ruleTester.run('validate-jsdoc-codeblocks', validateJSDocCodeblocksRule, {
 			`,
 		},
 
+		{
+			code: dedenter`
+				/**
+				\`\`\`ts
+				interface Foo {
+					a: string;
+				}
+
+				type T = [Foo, Foo, Foo];
+				//=> [  Foo,   Foo, Foo ]
+				\`\`\`
+				*/
+				export type T0 = string;
+			`,
+			errors: [
+				incorrectTwoslashFormatErrorAt({line: 8, textBeforeStart: '', target: '//=> [  Foo,   Foo, Foo ]'}),
+			],
+			output: dedenter`
+				/**
+				\`\`\`ts
+				interface Foo {
+					a: string;
+				}
+
+				type T = [Foo, Foo, Foo];
+				//=> [Foo, Foo, Foo]
+				\`\`\`
+				*/
+				export type T0 = string;
+			`,
+		},
+
 		// === Twoslash type errors ===
 
 		// Incorrect type

--- a/lint-rules/validate-jsdoc-codeblocks.test.js
+++ b/lint-rules/validate-jsdoc-codeblocks.test.js
@@ -878,6 +878,14 @@ ruleTester.run('validate-jsdoc-codeblocks', validateJSDocCodeblocksRule, {
 			options: [{verbosityLevels: [1, 2]}],
 		},
 
+		exportTypeAndOption(jsdoc(fence(dedenter`
+			type PosInf = 1e999;
+			//=> Infinity
+
+			type NegInf = -1e999;
+			//=> -Infinity
+		`))),
+
 		// === Different types of quick info ===
 		// Function
 		exportTypeAndOption(jsdoc(fence(dedenter`


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently, we cannot have `-Infinity` as a twoslash type because our twoslash validator lint rule doesn't allow that.

<img width="1057" height="220" alt="image" src="https://github.com/user-attachments/assets/781be19c-98ee-4bb6-a539-a9879be9442f" />


This happens because `-Infinity` is not a recognised type, so it gets lost when we invoke `ts.createSourceFile` using it.

Note: This problem doesn't happen with `Infinity` because that gets interpreted as an identifier.