### PR TITLE
Split lint into a separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,18 @@ on:
     branches:
       - main
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm install
+      - run: npm run test:linter
+      - run: npm run test:xo
+
   test:
     name: Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
@@ -25,7 +37,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm test
+      - run: npm run test:tsd
+
   types:
     name: TypeScript ${{ matrix.typescript-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,34 +9,23 @@ on:
     branches:
       - main
 jobs:
-  lint:
-    name: Lint
+  test:
+    name: Test ${{ matrix.script }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        script:
+          - tsd
+          - xo
+          - linter
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm install
-      - run: npm run test:linter & npm run test:xo
-
-  test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 24
-          - 22
-          - 20
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run test:tsd
+      - run: npm run test:${{ matrix.script }}
 
   types:
     name: TypeScript ${{ matrix.typescript-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
           node-version: 24
       - run: npm install
       - run: npm run test:${{ matrix.script }}
-
   types:
     name: TypeScript ${{ matrix.typescript-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ jobs:
         with:
           node-version: 24
       - run: npm install
-      - run: npm run test:linter
-      - run: npm run test:xo
+      - run: npm run test:linter & npm run test:xo
 
   test:
     name: Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Split lint into a separate job. This makes troubleshooting way easier, and since lint doesn’t depend on Node.js versions, we don’t need to run it on every Node version.

And running lint in parallel can make the workflow faster. (3mins -> 2mins)

