### PR TITLE
`StringRepeat`: Fix behavior with extremely large/small counts

### DIFF
--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -33,6 +33,8 @@ type DecimalCount = StringRepeat<'foo', 2.5>;
 //=> 'foofoo'
 ```
 
+Note: If the count is large or small enough to be represented in scientific notation (for example, `1e21` or `1e-7`), the result resolves to `string`, since the exact repeated literal cannot be computed.
+
 @category String
 @category Template literal
 */
@@ -43,7 +45,9 @@ export type StringRepeat<S extends string, Count extends number> =
 			? ''
 			: IsNumericLiteral<Count> extends false
 				? string
-				: BuildStringDigitByDigit<S, `${Count}`>;
+				: `${Count}` extends `${string}e${string}`
+					? string
+					: BuildStringDigitByDigit<S, `${Count}`>;
 
 type BuildStringDigitByDigit<S extends string, Count extends string, Accumulator extends string = ''> =
 	Count extends `${infer First extends DigitCharacter}${infer Rest}`

--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -37,7 +37,7 @@ type DecimalCount = StringRepeat<'foo', 2.5>;
 @category Template literal
 */
 export type StringRepeat<S extends string, Count extends number> =
-	Count extends Count // Distribute over `Count` so the checks below apply to each union member individually.
+	Count extends unknown // To distribute `Count`
 		? IsNegative<Count> extends true
 			? never
 			: S extends ''

--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -33,21 +33,23 @@ type DecimalCount = StringRepeat<'foo', 2.5>;
 //=> 'foofoo'
 ```
 
-Note: If the count is large or small enough to be represented in scientific notation (for example, `1e21` or `1e-7`), the result resolves to `string`, since the exact repeated literal cannot be computed.
+Note: If the count is large or small enough that it gets stored in scientific notation internally, then in such cases the result is `string`.
 
 @category String
 @category Template literal
 */
 export type StringRepeat<S extends string, Count extends number> =
-	IsNegative<Count> extends true
-		? never
-		: S extends ''
-			? ''
-			: IsNumericLiteral<Count> extends false
-				? string
-				: `${Count}` extends `${string}e${string}`
+	Count extends Count // Distribute over `Count` so the checks below apply to each union member individually.
+		? IsNegative<Count> extends true
+			? never
+			: S extends ''
+				? ''
+				: IsNumericLiteral<Count> extends false
 					? string
-					: BuildStringDigitByDigit<S, `${Count}`>;
+					: `${Count}` extends `${string}e${string}`
+						? string
+						: BuildStringDigitByDigit<S, `${Count}`>
+		: never;
 
 type BuildStringDigitByDigit<S extends string, Count extends string, Accumulator extends string = ''> =
 	Count extends `${infer First extends DigitCharacter}${infer Rest}`

--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -33,8 +33,6 @@ type DecimalCount = StringRepeat<'foo', 2.5>;
 //=> 'foofoo'
 ```
 
-Note: If the count is large or small enough that it gets stored in scientific notation internally, then in such cases the result is `string`.
-
 @category String
 @category Template literal
 */

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -28,9 +28,9 @@ expectType<StringRepeat<'0', 7.5>>(unknown as '0000000');
 expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 
 // Counts whose string representation is in scientific notation
-expectType<StringRepeat<'a', 1e-7>>(unknown as string);
-expectType<StringRepeat<'a', 2e21>>(unknown as string);
-expectType<StringRepeat<'a', 1e21>>(unknown as string);
+expectType<StringRepeat<'0', 1e-7>>(unknown as string);
+expectType<StringRepeat<'0', 2e21>>(unknown as string);
+expectType<StringRepeat<'0', 1e21>>(unknown as string);
 
 // Union cases
 expectType<StringRepeat<'0' | '1', 5>>(unknown as '00000' | '11111');

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -37,6 +37,8 @@ expectType<StringRepeat<'0', 2e-6>>(unknown as '');
 expectType<StringRepeat<'0', 1e-7>>(unknown as string);
 expectType<StringRepeat<'0', 2e21>>(unknown as string);
 expectType<StringRepeat<'0', 1e21>>(unknown as string);
+expectType<StringRepeat<'0', 1_000_000_000_000_000_000_000>>(unknown as string);
+expectType<StringRepeat<'0', 0.000_000_1>>(unknown as string);
 
 // Union cases
 expectType<StringRepeat<'0' | '1', 5>>(unknown as '00000' | '11111');

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -44,10 +44,6 @@ expectType<StringRepeat<'0', 0.000_000_1>>(unknown as string);
 expectType<StringRepeat<'0' | '1', 5>>(unknown as '00000' | '11111');
 expectType<StringRepeat<'0', 4 | 5>>(unknown as '0000' | '00000');
 expectType<StringRepeat<'0' | '1', 4 | 5>>(unknown as '0000' | '00000' | '1111' | '11111');
-
-// Union counts where at least one member is in scientific notation.
-// The guard distributes over `Count`, so the scientific-notation member resolves to `string`,
-// which then absorbs the other literal members of the union.
 expectType<StringRepeat<'0', 1e-7 | 2>>(unknown as string);
 expectType<StringRepeat<'0', 1e-7 | 2e21>>(unknown as string);
 expectType<StringRepeat<'0', 1e21 | 3>>(unknown as string);

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -27,7 +27,7 @@ expectType<StringRepeat<Uppercase<string>, 2>>(unknown as `${Uppercase<string>}$
 expectType<StringRepeat<'0', 7.5>>(unknown as '0000000');
 expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 
-// Counts represented in scientific notation cannot be expanded precisely, so they resolve to `string`
+// Counts whose string representation is in scientific notation
 expectType<StringRepeat<'a', 1e-7>>(unknown as string);
 expectType<StringRepeat<'a', 2e21>>(unknown as string);
 expectType<StringRepeat<'a', 1e21>>(unknown as string);

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -45,6 +45,13 @@ expectType<StringRepeat<'0' | '1', 5>>(unknown as '00000' | '11111');
 expectType<StringRepeat<'0', 4 | 5>>(unknown as '0000' | '00000');
 expectType<StringRepeat<'0' | '1', 4 | 5>>(unknown as '0000' | '00000' | '1111' | '11111');
 
+// Union counts where at least one member is in scientific notation.
+// The guard distributes over `Count`, so the scientific-notation member resolves to `string`,
+// which then absorbs the other literal members of the union.
+expectType<StringRepeat<'0', 1e-7 | 2>>(unknown as string);
+expectType<StringRepeat<'0', 1e-7 | 2e21>>(unknown as string);
+expectType<StringRepeat<'0', 1e21 | 3>>(unknown as string);
+
 // Recursion depth at which a non-tail recursive implementation starts to fail.
 const fiftyZeroes = '00000000000000000000000000000000000000000000000000';
 expectType<StringRepeat<'0', 50>>(fiftyZeroes);

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -27,6 +27,12 @@ expectType<StringRepeat<Uppercase<string>, 2>>(unknown as `${Uppercase<string>}$
 expectType<StringRepeat<'0', 7.5>>(unknown as '0000000');
 expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 
+// Counts in scientific notation
+expectType<StringRepeat<'0', 1e2>>(unknown as '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
+expectType<StringRepeat<'0', 3e1>>(unknown as '000000000000000000000000000000');
+expectType<StringRepeat<'0', 1e-5>>(unknown as '');
+expectType<StringRepeat<'0', 5e-7>>(unknown as '');
+
 // Counts whose string representation is in scientific notation
 expectType<StringRepeat<'0', 1e-7>>(unknown as string);
 expectType<StringRepeat<'0', 2e21>>(unknown as string);

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -27,6 +27,12 @@ expectType<StringRepeat<Uppercase<string>, 2>>(unknown as `${Uppercase<string>}$
 expectType<StringRepeat<'0', 7.5>>(unknown as '0000000');
 expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 
+// Counts represented in scientific notation cannot be expanded precisely, so they resolve to `string`
+// (previously these silently produced a wrong literal, e.g. `1e-7` → `'a'`, `2e21` → `'aa'`).
+expectType<StringRepeat<'a', 1e-7>>(unknown as string);
+expectType<StringRepeat<'a', 2e21>>(unknown as string);
+expectType<StringRepeat<'a', 1e21>>(unknown as string);
+
 // Union cases
 expectType<StringRepeat<'0' | '1', 5>>(unknown as '00000' | '11111');
 expectType<StringRepeat<'0', 4 | 5>>(unknown as '0000' | '00000');

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -31,7 +31,7 @@ expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 expectType<StringRepeat<'0', 1e2>>(unknown as '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
 expectType<StringRepeat<'0', 3e1>>(unknown as '000000000000000000000000000000');
 expectType<StringRepeat<'0', 1e-5>>(unknown as '');
-expectType<StringRepeat<'0', 5e-7>>(unknown as '');
+expectType<StringRepeat<'0', 2e-6>>(unknown as '');
 
 // Counts whose string representation is in scientific notation
 expectType<StringRepeat<'0', 1e-7>>(unknown as string);

--- a/test-d/string-repeat.ts
+++ b/test-d/string-repeat.ts
@@ -28,7 +28,6 @@ expectType<StringRepeat<'0', 7.5>>(unknown as '0000000');
 expectType<StringRepeat<'pi', 3.14>>(unknown as 'pipipi');
 
 // Counts represented in scientific notation cannot be expanded precisely, so they resolve to `string`
-// (previously these silently produced a wrong literal, e.g. `1e-7` → `'a'`, `2e21` → `'aa'`).
 expectType<StringRepeat<'a', 1e-7>>(unknown as string);
 expectType<StringRepeat<'a', 2e21>>(unknown as string);
 expectType<StringRepeat<'a', 1e21>>(unknown as string);


### PR DESCRIPTION
When `Count` is large or small enough that TypeScript stringifies it in scientific notation, `StringRepeat` silently returns a **wrong** string literal:

```ts
import type {StringRepeat} from 'type-fest';

type A = StringRepeat<'a', 1e-7>; //=> 'a'   ❌ (1e-7 = 0.0000001, should repeat 0 times)
type B = StringRepeat<'a', 2e21>; //=> 'aa'  ❌ (an astronomically large count)
type C = StringRepeat<'a', 1e21>; //=> 'a'   ❌
```

### Root cause

`BuildStringDigitByDigit` walks `` `${Count}` `` digit by digit and stops at the first non-digit character. That is exactly how the documented "decimal part is ignored" behavior works — for `2.5`, `"2.5"` is consumed up to the `.`, yielding the integer part `2`.

But for scientific notation the leading digits are **not** the integer part of the value:
- `` `${1e-7}` `` is `"1e-7"` → the builder consumes `"1"` and stops at `e`, producing one copy — but the actual integer part of `1e-7` is `0`.
- `` `${2e21}` `` is `"2e+21"` → consumes `"2"`, producing two copies — but the real count is 2,000,000,000,000,000,000,000.

So any count whose string form contains `e` produces a confidently-wrong literal.

### Fix

These counts can't be expanded into a precise literal (they're either effectively `0` or far beyond any representable repetition — `String.prototype.repeat(2e21)` throws `RangeError` at runtime). So when `` `${Count}` `` is in scientific notation, resolve to `string` — the same honest "can't compute precisely" fallback the type already uses for non-literal number counts:

```ts
: IsNumericLiteral<Count> extends false
    ? string
    : `${Count}` extends `${string}e${string}`
        ? string
        : BuildStringDigitByDigit<S, `${Count}`>;
```

No regression: every scientific-notation count was already wrong, and plain-integer / decimal counts are untouched (the existing `7.5` / `3.14` fractional tests still pass). Added `test-d` assertions for `1e-7`, `2e21`, `1e21`.

Full `tsd` suite passes.