### PR TITLE
Add `StringToArray` and `StringLength` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,7 @@ export type {ConditionalSimplifyDeep} from './source/conditional-simplify-deep.d
 export type {RemovePrefix, RemovePrefixOptions} from './source/remove-prefix.d.ts';
 export type {RemoveSuffix, RemoveSuffixOptions} from './source/remove-suffix.d.ts';
 export type {StringToArray, StringToArrayOptions} from './source/string-to-array.d.ts';
+export type {StringLength} from './source/string-length.d.ts';
 
 // Miscellaneous
 export type {GlobalThis} from './source/global-this.d.ts';

--- a/index.d.ts
+++ b/index.d.ts
@@ -209,6 +209,7 @@ export type {ConditionalSimplify} from './source/conditional-simplify.d.ts';
 export type {ConditionalSimplifyDeep} from './source/conditional-simplify-deep.d.ts';
 export type {RemovePrefix, RemovePrefixOptions} from './source/remove-prefix.d.ts';
 export type {RemoveSuffix, RemoveSuffixOptions} from './source/remove-suffix.d.ts';
+export type {StringToArray, StringToArrayOptions} from './source/string-to-array.d.ts';
 
 // Miscellaneous
 export type {GlobalThis} from './source/global-this.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -265,6 +265,8 @@ Click the type names for complete docs.
 - [`StringRepeat`](source/string-repeat.d.ts) - Returns a new string which contains the specified number of copies of a given string, just like `String#repeat()`.
 - [`RemovePrefix`](source/remove-prefix.d.ts) - Remove the specified prefix from the start of a string.
 - [`RemoveSuffix`](source/remove-suffix.d.ts) - Remove the specified suffix from the end of a string.
+- [`StringToArray`](source/string-to-array.d.ts) - Returns an array of the characters of the specified string.
+- [`StringLength`](source/string-length.d.ts) - Returns the length of the given string.
 
 ### Array
 

--- a/source/internal/string.d.ts
+++ b/source/internal/string.d.ts
@@ -1,5 +1,6 @@
 import type {TupleOf} from '../tuple-of.d.ts';
 import type {Trim} from '../trim.d.ts';
+import type {StringToArray} from '../string-to-array.d.ts';
 import type {Whitespace} from './characters.d.ts';
 
 /**
@@ -35,26 +36,6 @@ export type StartsWith<S extends string, SearchString extends string> = string e
 	: S extends `${SearchString}${infer T}`
 		? true
 		: false;
-
-/**
-Returns an array of the characters of the string.
-
-@example
-```
-type A = StringToArray<'abcde'>;
-//=> ['a', 'b', 'c', 'd', 'e']
-
-type B = StringToArray<string>;
-//=> never
-```
-
-@category String
-*/
-export type StringToArray<S extends string, Result extends string[] = []> = string extends S
-	? never
-	: S extends `${infer F}${infer R}`
-		? StringToArray<R, [...Result, F]>
-		: Result;
 
 /**
 Returns the length of the given string.

--- a/source/internal/string.d.ts
+++ b/source/internal/string.d.ts
@@ -1,6 +1,6 @@
 import type {TupleOf} from '../tuple-of.d.ts';
 import type {Trim} from '../trim.d.ts';
-import type {StringToArray} from '../string-to-array.d.ts';
+import type {StringLength} from '../string-length.d.ts';
 import type {Whitespace} from './characters.d.ts';
 
 /**

--- a/source/internal/string.d.ts
+++ b/source/internal/string.d.ts
@@ -38,25 +38,6 @@ export type StartsWith<S extends string, SearchString extends string> = string e
 		: false;
 
 /**
-Returns the length of the given string.
-
-@example
-```
-type A = StringLength<'abcde'>;
-//=> 5
-
-type B = StringLength<string>;
-//=> never
-```
-
-@category String
-@category Template literal
-*/
-export type StringLength<S extends string> = string extends S
-	? never
-	: StringToArray<S>['length'];
-
-/**
 Returns a boolean for whether a string is whitespace.
 */
 export type IsWhitespace<T extends string> = T extends Whitespace

--- a/source/string-length.d.ts
+++ b/source/string-length.d.ts
@@ -1,0 +1,38 @@
+import type {StringToArray} from './string-to-array.d.ts';
+
+/**
+Returns the length of the given string.
+
+@example
+```
+import type {StringLength} from 'type-fest';
+
+type A = StringLength<'abcde'>;
+//=> 5
+
+type B = StringLength<'abcde' | 'fgh'>;
+//=> 3 | 5
+```
+
+For non-literal strings, the result is `number` because the length of a non-literal string can be any number.
+
+@example
+```
+import type {StringLength} from 'type-fest';
+
+type A = StringLength<string>;
+//=> number
+
+type B = StringLength<Uppercase<string>>;
+//=> number
+
+type C = StringLength<`${string}abc`>;
+//=> number
+```
+
+@category String
+@category Template literal
+*/
+export type StringLength<S extends string> = StringToArray<S>['length'];
+
+export {};

--- a/source/string-slice.d.ts
+++ b/source/string-slice.d.ts
@@ -1,6 +1,6 @@
 import type {Join} from './join.d.ts';
 import type {ArraySlice} from './array-slice.d.ts';
-import type {StringToArray} from './internal/index.d.ts';
+import type {StringToArray} from './string-to-array.d.ts';
 
 /**
 Returns a string slice of a given range, just like `String#slice()`.

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -45,7 +45,7 @@ type DefaultStringToArrayOptions = {
 };
 
 /**
-Returns an array of the characters of the string.
+Returns an array of the characters of the specified string.
 
 @example
 ```

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -11,7 +11,7 @@ export type StringToArrayOptions = {
 	When enabled, non-literal parts of the string (e.g., `string`, `Uppercase<string>`) are mapped as single elements instead of being mapped as rest elements.
 
 	Note: Enabling this option can produce misleading results that might not reflect the actual runtime behavior.
-	For example, `StringToArray<string, {nonLiteralsAsElements: true}>` returns `[string]`, but at runtime, the string could be `'abc'` (which satisfies `string`), and converting it to an array would result in `['a', 'b', 'c']`, which doesn't satisfy `[string]`.
+	For example, `StringToArray<string, {mapNonLiteralsDirectly: true}>` returns `[string]`, but at runtime, the string could be `'abc'` (which satisfies `string`), and converting it to an array would result in `['a', 'b', 'c']`, which doesn't satisfy `[string]`.
 
 	So, it is recommended to not enable this option unless you are aware of the implications.
 
@@ -21,30 +21,30 @@ export type StringToArrayOptions = {
 	```
 	import type {StringToArray} from 'type-fest';
 
-	type A = StringToArray<string, {nonLiteralsAsElements: false}>;
+	type A = StringToArray<string, {mapNonLiteralsDirectly: false}>;
 	//=> string[]
 
-	type B = StringToArray<string, {nonLiteralsAsElements: true}>;
+	type B = StringToArray<string, {mapNonLiteralsDirectly: true}>;
 	//=> [string]
 
-	type C = StringToArray<`on${string}`, {nonLiteralsAsElements: false}>;
+	type C = StringToArray<`on${string}`, {mapNonLiteralsDirectly: false}>;
 	//=> ['o', 'n', ...string[]]
 
-	type D = StringToArray<`on${string}`, {nonLiteralsAsElements: true}>;
+	type D = StringToArray<`on${string}`, {mapNonLiteralsDirectly: true}>;
 	//=> ['o', 'n', string]
 
-	type E = StringToArray<`${string}xyz`, {nonLiteralsAsElements: false}>;
+	type E = StringToArray<`${string}xyz`, {mapNonLiteralsDirectly: false}>;
 	//=> [...string[], 'x', 'y', 'z']
 
-	type F = StringToArray<`${string}xyz`, {nonLiteralsAsElements: true}>;
+	type F = StringToArray<`${string}xyz`, {mapNonLiteralsDirectly: true}>;
 	//=> [string, 'x', 'y', 'z']
 	```
 	*/
-	nonLiteralsAsElements?: boolean;
+	mapNonLiteralsDirectly?: boolean;
 };
 
 type DefaultStringToArrayOptions = {
-	nonLiteralsAsElements: false;
+	mapNonLiteralsDirectly: false;
 };
 
 /**
@@ -66,7 +66,7 @@ type C = StringToArray<string>;
 type D = StringToArray<`foo${string}bar`>;
 //=> ['f', 'o', 'o', ...string[], 'b', 'a', 'r']
 
-type E = StringToArray<`foo${string}bar`, {nonLiteralsAsElements: true}>;
+type E = StringToArray<`foo${string}bar`, {mapNonLiteralsDirectly: true}>;
 //=> ['f', 'o', 'o', string, 'b', 'a', 'r']
 ```
 
@@ -83,12 +83,12 @@ export type StringToArray<S extends string, Options extends StringToArrayOptions
 
 type _StringToArray<S extends string, Options extends Required<StringToArrayOptions>, Accumulator extends string[] = []> =
 	S extends `${infer First}${infer Rest}`
-		? Or<IsStringLiteral<First>, Options['nonLiteralsAsElements']> extends true
+		? Or<IsStringLiteral<First>, Options['mapNonLiteralsDirectly']> extends true
 			? _StringToArray<Rest, Options, [...Accumulator, First]>
 			: _StringToArray<Rest, Options, [...Accumulator, ...First[]]>
 		: S extends ''
 			? Accumulator
-			: Options['nonLiteralsAsElements'] extends true
+			: Options['mapNonLiteralsDirectly'] extends true
 				? [...Accumulator, S]
 				: [...Accumulator, ...S[]];
 

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -3,6 +3,9 @@ import type {IfNotAnyOrNever} from './internal/type.d.ts';
 import type {IsStringLiteral} from './is-literal.d.ts';
 import type {Or} from './or.d.ts';
 
+/**
+@see {@link StringToArray}
+*/
 export type StringToArrayOptions = {
 	/**
 	When enabled, non-literal parts of the string (e.g., `string`, `Uppercase<string>`) are mapped as single elements instead of being mapped as rest elements.
@@ -57,6 +60,8 @@ type A = StringToArray<'abcde'>;
 type B = StringToArray<''>;
 //=> []
 ```
+
+@see {@link StringToArrayOptions}
 
 @category String
 */

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -8,7 +8,7 @@ import type {Or} from './or.d.ts';
 */
 export type StringToArrayOptions = {
 	/**
-	When enabled, non-literal parts of the string (e.g., `string`, `Uppercase<string>`) are mapped as single elements instead of being mapped as rest elements.
+	When enabled, non-literal parts of the string (e.g., `string`, `Uppercase<string>`) are mapped as single elements instead of being mapped as a rest element.
 
 	Note: Enabling this option can produce misleading results that might not reflect the actual runtime behavior.
 	For example, `StringToArray<string, {mapNonLiteralsDirectly: true}>` returns `[string]`, but at runtime, the string could be `'abc'` (which satisfies `string`), and converting it to an array would result in `['a', 'b', 'c']`, which doesn't satisfy `[string]`.

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -1,0 +1,81 @@
+import type {ApplyDefaultOptions} from './internal/object.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
+import type {IsStringLiteral} from './is-literal.d.ts';
+import type {Or} from './or.d.ts';
+
+export type StringToArrayOptions = {
+	/**
+	When enabled, non-literal parts of the string (e.g., `string`, `Uppercase<string>`) are mapped as single elements instead of being mapped as rest elements.
+
+	Note: Enabling this option can produce misleading results that might not reflect the actual runtime behavior.
+	For example, `StringToArray<string, {nonLiteralsAsElements: true}>` returns `[string]`, but at runtime, the string could be `'abc'` (which satisfies `string`), and converting it to an array would result in `['a', 'b', 'c']`, which doesn't satisfy `[string]`.
+
+	So, it is recommended to not enable this option unless you are aware of the implications.
+
+	@default false
+
+	@example
+	```
+	import type {StringToArray} from 'type-fest';
+
+	type A = StringToArray<string, {nonLiteralsAsElements: false}>;
+	//=> string[]
+
+	type B = StringToArray<string, {nonLiteralsAsElements: true}>;
+	//=> [string]
+
+	type C = StringToArray<`on${string}`, {nonLiteralsAsElements: false}>;
+	//=> ['o', 'n', ...string[]]
+
+	type D = StringToArray<`on${string}`, {nonLiteralsAsElements: true}>;
+	//=> ['o', 'n', string]
+
+	type E = StringToArray<`${string}xyz`, {nonLiteralsAsElements: false}>;
+	//=> [...string[], 'x', 'y', 'z']
+
+	type F = StringToArray<`${string}xyz`, {nonLiteralsAsElements: true}>;
+	//=> [string, 'x', 'y', 'z']
+	```
+	*/
+	nonLiteralsAsElements?: boolean;
+};
+
+type DefaultStringToArrayOptions = {
+	nonLiteralsAsElements: false;
+};
+
+/**
+Returns an array of the characters of the string.
+
+@example
+```
+import type {StringToArray} from 'type-fest';
+
+type A = StringToArray<'abcde'>;
+//=> ['a', 'b', 'c', 'd', 'e']
+
+type B = StringToArray<''>;
+//=> []
+```
+
+@category String
+*/
+export type StringToArray<S extends string, Options extends StringToArrayOptions = {}> =
+	IfNotAnyOrNever<
+		S,
+		_StringToArray<S, ApplyDefaultOptions<StringToArrayOptions, DefaultStringToArrayOptions, Options>>,
+		unknown[]
+	>;
+
+type _StringToArray<S extends string, Options extends Required<StringToArrayOptions>, Accumulator extends string[] = []> =
+	S extends `${infer First}${infer Rest}`
+		? Or<IsStringLiteral<First>, Options['nonLiteralsAsElements']> extends true
+			? _StringToArray<Rest, Options, [...Accumulator, First]>
+			: _StringToArray<Rest, Options, [...Accumulator, ...First[]]>
+		: S extends ''
+			? Accumulator
+			: Options['nonLiteralsAsElements'] extends true
+				? [...Accumulator, S]
+				: [...Accumulator, ...S[]];
+
+export {};

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -59,6 +59,15 @@ type A = StringToArray<'abcde'>;
 
 type B = StringToArray<''>;
 //=> []
+
+type C = StringToArray<string>;
+//=> string[]
+
+type D = StringToArray<`foo${string}bar`>;
+//=> ['f', 'o', 'o', ...string[], 'b', 'a', 'r']
+
+type E = StringToArray<`foo${string}bar`, {nonLiteralsAsElements: true}>;
+//=> ['f', 'o', 'o', string, 'b', 'a', 'r']
 ```
 
 @see {@link StringToArrayOptions}

--- a/test-d/string-length.ts
+++ b/test-d/string-length.ts
@@ -1,0 +1,27 @@
+import {expectType} from 'tsd';
+import type {StringLength} from '../source/string-length.d.ts';
+
+// Empty string
+expectType<0>({} as StringLength<''>);
+
+// Literals
+expectType<1>({} as StringLength<'a'>);
+expectType<5>({} as StringLength<'abcde'>);
+expectType<3>({} as StringLength<'012'>);
+
+// Non-literals
+expectType<number>({} as StringLength<string>);
+expectType<number>({} as StringLength<Uppercase<string>>);
+expectType<number>({} as StringLength<`${string}abc`>);
+expectType<number>({} as StringLength<`abc${string}`>);
+expectType<number>({} as StringLength<`abc${string}def`>);
+expectType<number>({} as StringLength<`abc${string}def${string}ij`>);
+
+// Unions
+expectType<3 | 5>({} as StringLength<'abcde' | 'fgh'>);
+expectType<number>({} as StringLength<'abc' | Uppercase<string>>);
+expectType<number>({} as StringLength<`ab${string}` | `${number}`>);
+
+// Boundary cases
+expectType<never>({} as StringLength<never>);
+expectType<number>({} as StringLength<any>);

--- a/test-d/string-length.ts
+++ b/test-d/string-length.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import type {StringLength} from '../source/string-length.d.ts';
+import type {StringRepeat} from '../source/string-repeat.d.ts';
 
 // Empty string
 expectType<0>({} as StringLength<''>);
@@ -21,6 +22,10 @@ expectType<number>({} as StringLength<`abc${string}def${string}ij`>);
 expectType<3 | 5>({} as StringLength<'abcde' | 'fgh'>);
 expectType<number>({} as StringLength<'abc' | Uppercase<string>>);
 expectType<number>({} as StringLength<`ab${string}` | `${number}`>);
+
+// Long strings
+expectType<200>({} as StringLength<StringRepeat<'a', 200>>);
+expectType<900>({} as StringLength<StringRepeat<'a', 900>>);
 
 // Boundary cases
 expectType<never>({} as StringLength<never>);

--- a/test-d/string-to-array.ts
+++ b/test-d/string-to-array.ts
@@ -33,7 +33,7 @@ expectType<['a', 'b', ...Array<Capitalize<string> | 'c' | 'd' | Uppercase<string
 	{} as StringToArray<`ab${Capitalize<string>}cd${Uppercase<string>}`>,
 );
 
-// --- `nonLiteralsAsElements: false` ---
+// --- `nonLiteralsAsElements: true` ---
 expectType<[string]>({} as StringToArrayElementNonLiterals<string>);
 expectType<[Lowercase<string>]>({} as StringToArrayElementNonLiterals<Lowercase<string>>);
 expectType<[Uppercase<string>]>({} as StringToArrayElementNonLiterals<Uppercase<string>>);

--- a/test-d/string-to-array.ts
+++ b/test-d/string-to-array.ts
@@ -1,0 +1,67 @@
+import {expectType} from 'tsd';
+import type {StringToArray} from '../source/string-to-array.d.ts';
+
+type StringToArrayElementNonLiterals<S extends string> = StringToArray<S, {nonLiteralsAsElements: true}>;
+
+// Empty string
+expectType<[]>({} as StringToArray<''>);
+expectType<[]>({} as StringToArrayElementNonLiterals<''>);
+
+// Literals
+expectType<['a']>({} as StringToArray<'a'>);
+expectType<['a', 'b', 'c', 'd', 'e']>({} as StringToArray<'abcde'>);
+expectType<['0', '1', '2']>({} as StringToArray<'012'>);
+expectType<['f', 'o', 'o', 'b', 'a', 'r']>({} as StringToArrayElementNonLiterals<'foobar'>);
+
+// Non-literals
+expectType<string[]>({} as StringToArray<string>);
+expectType<Array<Lowercase<string>>>({} as StringToArray<Lowercase<string>>);
+expectType<Array<Uppercase<string>>>({} as StringToArray<Uppercase<string>>);
+
+expectType<[...string[], 'a', 'b', 'c']>({} as StringToArray<`${string}abc`>);
+expectType<['a', 'b', 'c', ...string[]]>({} as StringToArray<`abc${string}`>);
+expectType<['a', 'b', 'c', ...string[], 'd', 'e', 'f']>({} as StringToArray<`abc${string}def`>);
+
+expectType<['a', 'b', 'c', ...string[]]>({} as StringToArray<`abc${string}def${string}`>);
+expectType<['a', ...string[], 'c']>({} as StringToArray<`a${string}b${string}c`>);
+expectType<['a', ...Array<Capitalize<string> | 'b' | Uppercase<string>>, 'c']>(
+	{} as StringToArray<`a${Capitalize<string>}b${Uppercase<string>}c`>,
+);
+expectType<['a', 'b', ...Array<Capitalize<string> | 'c' | 'd' | Uppercase<string>>]>(
+	{} as StringToArray<`ab${Capitalize<string>}cd${Uppercase<string>}`>,
+);
+
+// --- `nonLiteralsAsElements: false` ---
+expectType<[string]>({} as StringToArrayElementNonLiterals<string>);
+expectType<[Lowercase<string>]>({} as StringToArrayElementNonLiterals<Lowercase<string>>);
+expectType<[Uppercase<string>]>({} as StringToArrayElementNonLiterals<Uppercase<string>>);
+
+expectType<[string, 'a', 'b', 'c']>({} as StringToArrayElementNonLiterals<`${string}abc`>);
+expectType<['a', 'b', 'c', string]>({} as StringToArrayElementNonLiterals<`abc${string}`>);
+expectType<['a', 'b', 'c', string, 'd', 'e', 'f']>({} as StringToArrayElementNonLiterals<`abc${string}def`>);
+
+expectType<['a', 'b', 'c', string, 'd', 'e', 'f', string]>(
+	{} as StringToArrayElementNonLiterals<`abc${string}def${string}`>,
+);
+expectType<['a', string, 'b', string, 'c']>({} as StringToArrayElementNonLiterals<`a${string}b${string}c`>);
+expectType<['a', Capitalize<string>, 'b', Uppercase<string>, 'c']>(
+	{} as StringToArrayElementNonLiterals<`a${Capitalize<string>}b${Uppercase<string>}c`>,
+);
+expectType<['a', 'b', Capitalize<string>, 'c', 'd', Uppercase<string>]>(
+	{} as StringToArrayElementNonLiterals<`ab${Capitalize<string>}cd${Uppercase<string>}`>,
+);
+
+// Unions
+expectType<['a', 'b', 'c'] | ['d', 'e', 'f']>({} as StringToArray<'abc' | 'def'>);
+expectType<['a', 'b', 'c'] | Array<Uppercase<string>>>({} as StringToArray<'abc' | Uppercase<string>>);
+expectType<['a', 'b', ...string[]] | Array<`${number}`>>({} as StringToArray<`ab${string}` | `${number}`>);
+
+expectType<['a', 'b', 'c'] | ['d', 'e', 'f']>({} as StringToArrayElementNonLiterals<'abc' | 'def'>);
+expectType<['a', 'b', 'c'] | [Uppercase<string>]>({} as StringToArrayElementNonLiterals<'abc' | Uppercase<string>>);
+expectType<['a', 'b', string] | [`${number}`]>({} as StringToArrayElementNonLiterals<`ab${string}` | `${number}`>);
+
+// Boundary cases
+expectType<never>({} as StringToArray<never>);
+expectType<unknown[]>({} as StringToArray<any>);
+expectType<never>({} as StringToArrayElementNonLiterals<never>);
+expectType<unknown[]>({} as StringToArrayElementNonLiterals<any>);

--- a/test-d/string-to-array.ts
+++ b/test-d/string-to-array.ts
@@ -3,7 +3,7 @@ import type {StringToArray} from '../source/string-to-array.d.ts';
 import type {StringRepeat} from '../source/string-repeat.d.ts';
 import type {TupleOf} from '../source/tuple-of.d.ts';
 
-type StringToArrayElementNonLiterals<S extends string> = StringToArray<S, {nonLiteralsAsElements: true}>;
+type StringToArrayElementNonLiterals<S extends string> = StringToArray<S, {mapNonLiteralsDirectly: true}>;
 
 // Empty string
 expectType<[]>({} as StringToArray<''>);
@@ -33,7 +33,7 @@ expectType<['a', 'b', ...Array<Capitalize<string> | 'c' | 'd' | Uppercase<string
 	{} as StringToArray<`ab${Capitalize<string>}cd${Uppercase<string>}`>,
 );
 
-// --- `nonLiteralsAsElements: true` ---
+// --- `mapNonLiteralsDirectly: true` ---
 expectType<[string]>({} as StringToArrayElementNonLiterals<string>);
 expectType<[Lowercase<string>]>({} as StringToArrayElementNonLiterals<Lowercase<string>>);
 expectType<[Uppercase<string>]>({} as StringToArrayElementNonLiterals<Uppercase<string>>);

--- a/test-d/string-to-array.ts
+++ b/test-d/string-to-array.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
 import type {StringToArray} from '../source/string-to-array.d.ts';
+import type {StringRepeat} from '../source/string-repeat.d.ts';
+import type {TupleOf} from '../source/tuple-of.d.ts';
 
 type StringToArrayElementNonLiterals<S extends string> = StringToArray<S, {nonLiteralsAsElements: true}>;
 
@@ -59,6 +61,10 @@ expectType<['a', 'b', ...string[]] | Array<`${number}`>>({} as StringToArray<`ab
 expectType<['a', 'b', 'c'] | ['d', 'e', 'f']>({} as StringToArrayElementNonLiterals<'abc' | 'def'>);
 expectType<['a', 'b', 'c'] | [Uppercase<string>]>({} as StringToArrayElementNonLiterals<'abc' | Uppercase<string>>);
 expectType<['a', 'b', string] | [`${number}`]>({} as StringToArrayElementNonLiterals<`ab${string}` | `${number}`>);
+
+// Long strings
+expectType<TupleOf<200, 'a'>>({} as StringToArray<StringRepeat<'a', 200>>);
+expectType<TupleOf<900, 'a'>>({} as StringToArray<StringRepeat<'a', 900>>);
 
 // Boundary cases
 expectType<never>({} as StringToArray<never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Exposes the internal `StringToArray` and `StringLength` types with better handling around non-literal strings.

<br>

If there are multiple non-literal parts in the input string, the resulting array type properly maps them into a **single** rest element, since TS tuple types can only have a single rest element. For example:

```ts
type A = StringToArray<`abc${string}def${string}`>;
//=> ['a', 'b', 'c', ...string[]]

type B = StringToArray<`a${Capitalize<string>}b${Uppercase<string>}c`>;
//=> ['a', ...Array<Capitalize<string> | 'b' | Uppercase<string>>, 'c']
```

Consider example `B`:
-  After processing the character `b`, the resulting tuple would be `['a', ...Array<Capitalize<string>>, 'b']`.
- When processing `Uppercase<string>`, TS realises that the tuple cannot contain a second rest element. As a result, TS automatically merges everything from the last rest element to the current rest element. And, TS does this automatically, no special handling is required for it, refer:

  ```ts
  type Test<T extends string[], U extends string[]> = [...T, ...U];
  type T = Test<['a', ...Array<Capitalize<string>>, 'b'], [...Array<Uppercase<string>>, 'c']>;
  //=> ['a', ...Array<Capitalize<string> | 'b' | Uppercase<string>>, 'c']
  ```

<br>

> [!NOTE]
> Types such as `StringSlice` and `PositiveNumericStringGt` depend on these two types, so their behavior with _non-literal_ strings may change with this update. This shouldn't be a problem, since those types already produce incorrect results with non-literal strings. Effectively, this change replaces one incorrect behavior with another:
>
> ```ts
> type Updated = StringSlice<`abc${Uppercase<string>}de`, 2, 4>;
> //=> `c${Uppercase<string>}` | 'cd' | 'ce'
>
> type Current = StringSlice<`abc${Uppercase<string>}de`, 2, 4>;
> //=> `c${Uppercase<string>}`
> ```
>_The answer here should have been `` `c${Uppercase<string>}` | 'cd' ``._