### PR TITLE
Fix `Schema` to correctly replace `any` and `unknown` fields

### DIFF
--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,4 +1,4 @@
-import {EmptyObject} from './empty-object.js';
+import type {EmptyObject} from './empty-object.d.ts';
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, NonRecursiveType} from './internal/type.d.ts';
 import type {OptionalKeysOf} from './optional-keys-of.d.ts';
@@ -97,7 +97,7 @@ export type Schema<Type, Value, Options extends SchemaOptions = {}> =
 		Value, Value>;
 
 type _Schema<Type, Value, Options extends Required<SchemaOptions>> =
-	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>   
+	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
 		? Value
 		: Type extends UnknownArray
 			? Options['recurseIntoArrays'] extends false

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,6 +1,7 @@
-import type {EmptyObject} from './empty-object.d.ts';
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, NonRecursiveType} from './internal/type.d.ts';
+import type {IsAny} from './is-any.d.ts';
+import type {IsUnknown} from './is-unknown.d.ts';
 import type {OptionalKeysOf} from './optional-keys-of.d.ts';
 import type {Simplify} from './simplify.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
@@ -97,17 +98,17 @@ export type Schema<Type, Value, Options extends SchemaOptions = {}> =
 		Value, Value>;
 
 type _Schema<Type, Value, Options extends Required<SchemaOptions>> =
-	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+	IsAny<Type> extends true
 		? Value
-		: Type extends UnknownArray
-			? Options['recurseIntoArrays'] extends false
+		: IsUnknown<Type> extends true
+			? Value
+			: Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
 				? Value
-				: SchemaHelper<Type, Value, Options>
-			: Type extends EmptyObject
-				? keyof Type extends never
-					? Value
-					: SchemaHelper<Type, Value, Options>
-				: SchemaHelper<Type, Value, Options>;
+				: Type extends UnknownArray
+					? Options['recurseIntoArrays'] extends false
+						? Value
+						: SchemaHelper<Type, Value, Options>
+					: SchemaHelper<Type, Value, Options>;
 
 /**
 Internal helper for {@link _Schema}.

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -1,3 +1,4 @@
+import {EmptyObject} from './empty-object.js';
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, NonRecursiveType} from './internal/type.d.ts';
 import type {OptionalKeysOf} from './optional-keys-of.d.ts';
@@ -96,13 +97,17 @@ export type Schema<Type, Value, Options extends SchemaOptions = {}> =
 		Value, Value>;
 
 type _Schema<Type, Value, Options extends Required<SchemaOptions>> =
-	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>   
 		? Value
 		: Type extends UnknownArray
 			? Options['recurseIntoArrays'] extends false
 				? Value
 				: SchemaHelper<Type, Value, Options>
-			: SchemaHelper<Type, Value, Options>;
+			: Type extends EmptyObject
+				? keyof Type extends never
+					? Value
+					: SchemaHelper<Type, Value, Options>
+				: SchemaHelper<Type, Value, Options>;
 
 /**
 Internal helper for {@link _Schema}.

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -46,7 +46,7 @@ const fooSchema: FooSchema = {
 		readonlyArray: ['A', 'A', 'A'] as const,
 		readonlyTuple: ['A'] as const,
 		regExp: 'A',
-		emptyObject: 'A', 
+		emptyObject: 'A',
 	},
 };
 

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -1,5 +1,5 @@
 import {expectNotAssignable, expectType} from 'tsd';
-import type {EmptyObject, Schema} from '../index.d.ts';
+import type {Schema} from '../index.d.ts';
 
 const foo = {
 	baz: 'fred',
@@ -20,7 +20,8 @@ const foo = {
 		readonlyArray: ['foo'] as readonly string[],
 		readonlyTuple: ['foo'] as const,
 		regExp: /.*/gv,
-		emptyObject: {},
+		unknown: undefined as unknown,
+		any: undefined as any,
 	},
 };
 
@@ -46,7 +47,8 @@ const fooSchema: FooSchema = {
 		readonlyArray: ['A', 'A', 'A'] as const,
 		readonlyTuple: ['A'] as const,
 		regExp: 'A',
-		emptyObject: 'A',
+		unknown: 'A',
+		any: 'A',
 	},
 };
 
@@ -72,7 +74,8 @@ expectType<FooOption>(barSchema.readonlySet);
 expectType<readonly FooOption[]>(barSchema.readonlyArray);
 expectType<readonly [FooOption]>(barSchema.readonlyTuple);
 expectType<FooOption>(barSchema.regExp);
-expectType<FooOption>(barSchema.emptyObject);
+expectType<FooOption>(barSchema.unknown);
+expectType<FooOption>(barSchema.any);
 
 type ComplexOption = {
 	type: 'readonly' | 'required' | 'optional';
@@ -106,7 +109,8 @@ const complexFoo: ComplexSchema = {
 		readonlyArray: [createComplexOption('readonly'), createComplexOption('readonly'), createComplexOption('readonly')] as const,
 		readonlyTuple: [createComplexOption('readonly')] as const,
 		regExp: createComplexOption('readonly'),
-		emptyObject: createComplexOption('readonly'),
+		unknown: createComplexOption('readonly'),
+		any: createComplexOption('readonly'),
 	},
 };
 
@@ -130,7 +134,8 @@ expectType<ComplexOption>(complexBarSchema.readonlySet);
 expectType<readonly ComplexOption[]>(complexBarSchema.readonlyArray);
 expectType<readonly [ComplexOption]>(complexBarSchema.readonlyTuple);
 expectType<ComplexOption>(complexBarSchema.regExp);
-expectType<ComplexOption>(complexBarSchema.emptyObject);
+expectType<ComplexOption>(complexBarSchema.unknown);
+expectType<ComplexOption>(complexBarSchema.any);
 
 // With Options and `recurseIntoArrays` set to `false`
 type FooSchemaWithOptionsNoRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: false}>;
@@ -154,7 +159,8 @@ const fooSchemaWithOptionsNoRecurse: FooSchemaWithOptionsNoRecurse = {
 		readonlyArray: 'A',
 		readonlyTuple: 'A',
 		regExp: 'A',
-		emptyObject: 'A',
+		unknown: 'A',
+		any: 'A',
 	},
 };
 
@@ -180,7 +186,8 @@ expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlySet);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyArray);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyTuple);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.regExp);
-expectType<FooOption>(barSchemaWithOptionsNoRecurse.emptyObject);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.unknown);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.any);
 
 // With Options and `recurseIntoArrays` set to `true`
 type FooSchemaWithOptionsRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: true}>;
@@ -204,7 +211,8 @@ const fooSchemaWithOptionsRecurse: FooSchemaWithOptionsRecurse = {
 		readonlyArray: ['A', 'A', 'A'] as const,
 		readonlyTuple: ['A'] as const,
 		regExp: 'A',
-		emptyObject: 'A',
+		unknown: 'A',
+		any: 'A',
 	},
 };
 
@@ -230,7 +238,8 @@ expectType<FooOption>(barSchemaWithOptionsRecurse.readonlySet);
 expectType<readonly FooOption[]>(barSchemaWithOptionsRecurse.readonlyArray);
 expectType<readonly [FooOption]>(barSchemaWithOptionsRecurse.readonlyTuple);
 expectType<FooOption>(barSchemaWithOptionsRecurse.regExp);
-expectType<FooOption>(barSchemaWithOptionsRecurse.emptyObject);
+expectType<FooOption>(barSchemaWithOptionsRecurse.unknown);
+expectType<FooOption>(barSchemaWithOptionsRecurse.any);
 
 // Non recursives
 expectType<number>({} as Schema<string, number>);
@@ -325,3 +334,8 @@ expectType<number>({} as Schema<[string, string, string], number, {recurseIntoAr
 expectType<{a: number; b: number} | number>({} as Schema<{a: string[]; b: string} | [string, string, string], number, {recurseIntoArrays: false}>);
 expectType<{a: 'a'; b: 'a'}>({} as Schema<{a: number[]; b: [string, string]}, 'a', {recurseIntoArrays: false}>);
 expectType<{a: {b: {c: {d: {e: string[]}}}}}>({} as Schema<{a: {b: {c: {d: string[]}}}}, {e: string[]}, {recurseIntoArrays: false}>);
+
+// `any` and `unknown` are treated as leaf values
+expectType<{a: number}>({} as Schema<{a: unknown}, number>);
+expectType<{a: number}>({} as Schema<{a: any}, number>);
+expectType<number>({} as Schema<unknown, number>);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -1,5 +1,5 @@
 import {expectNotAssignable, expectType} from 'tsd';
-import type {Schema} from '../index.d.ts';
+import type {EmptyObject, Schema} from '../index.d.ts';
 
 const foo = {
 	baz: 'fred',
@@ -20,6 +20,7 @@ const foo = {
 		readonlyArray: ['foo'] as readonly string[],
 		readonlyTuple: ['foo'] as const,
 		regExp: /.*/gv,
+		emptyObject: {},
 	},
 };
 
@@ -45,6 +46,7 @@ const fooSchema: FooSchema = {
 		readonlyArray: ['A', 'A', 'A'] as const,
 		readonlyTuple: ['A'] as const,
 		regExp: 'A',
+		emptyObject: 'A', 
 	},
 };
 
@@ -70,6 +72,7 @@ expectType<FooOption>(barSchema.readonlySet);
 expectType<readonly FooOption[]>(barSchema.readonlyArray);
 expectType<readonly [FooOption]>(barSchema.readonlyTuple);
 expectType<FooOption>(barSchema.regExp);
+expectType<FooOption>(barSchema.emptyObject);
 
 type ComplexOption = {
 	type: 'readonly' | 'required' | 'optional';
@@ -103,6 +106,7 @@ const complexFoo: ComplexSchema = {
 		readonlyArray: [createComplexOption('readonly'), createComplexOption('readonly'), createComplexOption('readonly')] as const,
 		readonlyTuple: [createComplexOption('readonly')] as const,
 		regExp: createComplexOption('readonly'),
+		emptyObject: createComplexOption('readonly'),
 	},
 };
 
@@ -126,6 +130,7 @@ expectType<ComplexOption>(complexBarSchema.readonlySet);
 expectType<readonly ComplexOption[]>(complexBarSchema.readonlyArray);
 expectType<readonly [ComplexOption]>(complexBarSchema.readonlyTuple);
 expectType<ComplexOption>(complexBarSchema.regExp);
+expectType<ComplexOption>(complexBarSchema.emptyObject);
 
 // With Options and `recurseIntoArrays` set to `false`
 type FooSchemaWithOptionsNoRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: false}>;
@@ -149,6 +154,7 @@ const fooSchemaWithOptionsNoRecurse: FooSchemaWithOptionsNoRecurse = {
 		readonlyArray: 'A',
 		readonlyTuple: 'A',
 		regExp: 'A',
+		emptyObject: 'A',
 	},
 };
 
@@ -174,6 +180,7 @@ expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlySet);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyArray);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.readonlyTuple);
 expectType<FooOption>(barSchemaWithOptionsNoRecurse.regExp);
+expectType<FooOption>(barSchemaWithOptionsNoRecurse.emptyObject);
 
 // With Options and `recurseIntoArrays` set to `true`
 type FooSchemaWithOptionsRecurse = Schema<typeof foo, FooOption, {recurseIntoArrays: true}>;
@@ -197,6 +204,7 @@ const fooSchemaWithOptionsRecurse: FooSchemaWithOptionsRecurse = {
 		readonlyArray: ['A', 'A', 'A'] as const,
 		readonlyTuple: ['A'] as const,
 		regExp: 'A',
+		emptyObject: 'A',
 	},
 };
 
@@ -222,6 +230,7 @@ expectType<FooOption>(barSchemaWithOptionsRecurse.readonlySet);
 expectType<readonly FooOption[]>(barSchemaWithOptionsRecurse.readonlyArray);
 expectType<readonly [FooOption]>(barSchemaWithOptionsRecurse.readonlyTuple);
 expectType<FooOption>(barSchemaWithOptionsRecurse.regExp);
+expectType<FooOption>(barSchemaWithOptionsRecurse.emptyObject);
 
 // Non recursives
 expectType<number>({} as Schema<string, number>);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -340,3 +340,4 @@ expectType<{a: {b: {c: {d: {e: string[]}}}}}>({} as Schema<{a: {b: {c: {d: strin
 expectType<{a: number}>({} as Schema<{a: unknown}, number>);
 expectType<{a: number}>({} as Schema<{a: any}, number>);
 expectType<number>({} as Schema<unknown, number>);
+expectType<number>({} as Schema<any, number>);

--- a/test-d/schema.ts
+++ b/test-d/schema.ts
@@ -21,6 +21,7 @@ const foo = {
 		readonlyTuple: ['foo'] as const,
 		regExp: /.*/gv,
 		unknown: undefined as unknown,
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		any: undefined as any,
 	},
 };


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/type-fest/issues/1458
