### PR TITLE
`IfNotAnyOrNever`: Lazily evaluate different conditional branches

### DIFF
--- a/source/all-extend.d.ts
+++ b/source/all-extend.d.ts
@@ -103,8 +103,8 @@ type B = AllExtend<[1?, 2?, 3?], number | undefined>;
 export type AllExtend<TArray extends UnknownArray, Type, Options extends AllExtendOptions = {}> =
 	_AllExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<AllExtendOptions, DefaultAllExtendOptions, Options>>;
 
-type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllExtendOptions>> = IfNotAnyOrNever<TArray,
-	TArray extends readonly [infer First, ...infer Rest]
+type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllExtendOptions>> = IfNotAnyOrNever<TArray, {
+	ifNot: TArray extends readonly [infer First, ...infer Rest]
 		? IsNever<First> extends true
 			? Or<Or<IsNever<Type>, IsAny<Type>>, Not<Options['strictNever']>> extends true
 				// If target `Type` is also `never`, or is `any`, or `strictNever` is disabled, recurse further.
@@ -113,7 +113,9 @@ type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllE
 			: First extends Type
 				? _AllExtend<Rest, Type, Options>
 				: false
-		: true,
-	false, false>;
+		: true;
+	ifAny: false;
+	ifNever: false;
+}>;
 
 export {};

--- a/source/array-reverse.d.ts
+++ b/source/array-reverse.d.ts
@@ -56,7 +56,8 @@ export type ArrayReverse<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, 
 		? _ArrayReverse<TArray> extends infer Result
 			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
 			: never // Should never happen
-		: never}>; // Should never happen
+		: never; // Should never happen
+}>;
 
 type _ArrayReverse<
 	TArray extends UnknownArray,

--- a/source/array-reverse.d.ts
+++ b/source/array-reverse.d.ts
@@ -51,12 +51,12 @@ type E = ArrayReverse<[string?, number?, ...boolean[]]>;
 
 @category Array
 */
-export type ArrayReverse<TArray extends UnknownArray> = IfNotAnyOrNever<TArray,
-	TArray extends unknown // For distributing `TArray`
+export type ArrayReverse<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {
+	ifNot: TArray extends unknown // For distributing `TArray`
 		? _ArrayReverse<TArray> extends infer Result
 			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
 			: never // Should never happen
-		: never>; // Should never happen
+		: never}>; // Should never happen
 
 type _ArrayReverse<
 	TArray extends UnknownArray,

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -51,13 +51,13 @@ const availableTopSciFi = curry(searchBooks)('sci-fi')(4.5)(true);
 
 @category Array
 */
-export type ArrayTail<TArray extends UnknownArray> = IfNotAnyOrNever<TArray,
-	TArray extends UnknownArray // For distributing `TArray`
+export type ArrayTail<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {
+	ifNot: TArray extends UnknownArray // For distributing `TArray`
 		? _ArrayTail<TArray> extends infer Result
 			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
 			: never // Should never happen
-		: never
->;
+		: never;
+}>;
 
 type _ArrayTail<TArray extends UnknownArray> = TArray extends readonly [unknown?, ...infer Tail]
 	? keyof TArray & `${number}` extends never

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -50,7 +50,7 @@ type NumberValueIndices = ConditionalKeys<[string, number?, string?], number | u
 @category Object
 */
 export type ConditionalKeys<Base, Condition> = (Base extends UnknownArray ? TupleToObject<Base> : Base) extends infer _Base // Remove non-numeric keys from arrays
-	? IfNotAnyOrNever<_Base, _ConditionalKeys<_Base, Condition>, keyof _Base>
+	? IfNotAnyOrNever<_Base, {ifNot: _ConditionalKeys<_Base, Condition>; ifAny: keyof _Base}>
 	: never;
 
 type _ConditionalKeys<Base, Condition> = keyof {

--- a/source/exclude-exactly.d.ts
+++ b/source/exclude-exactly.d.ts
@@ -33,25 +33,25 @@ type TestExcludeExactly3 = ExcludeExactly<{a: string} | {a: string; b: string}, 
 @category Improved Built-in
 */
 export type ExcludeExactly<Union, Delete> =
-	IfNotAnyOrNever<
-		Union,
-		_ExcludeExactly<Union, Delete>,
+	IfNotAnyOrNever<Union, {
+		ifNot: _ExcludeExactly<Union, Delete>;
 		// If `Union` is `any`, then if `Delete` is `any`, return `never`, else return `Union`.
-		If<IsAny<Delete>, never, Union>,
+		ifAny: If<IsAny<Delete>, never, Union>;
 		// If `Union` is `never`, then if `Delete` is `never`, return `never`, else return `Union`.
-		If<IsNever<Delete>, never, Union>
-	>;
+		ifNever: If<IsNever<Delete>, never, Union>;
+	}>;
 
 type _ExcludeExactly<Union, Delete> =
-	IfNotAnyOrNever<Delete,
-		Union extends unknown // For distributing `Union`
+	IfNotAnyOrNever<Delete, {
+		ifNot: Union extends unknown // For distributing `Union`
 			? [Delete extends unknown // For distributing `Delete`
 				? If<IsEqual<Union, Delete>, true, never>
 				: never] extends [never] ? Union : never
-			: never,
+			: never;
 		// If `Delete` is `any` or `never`, then return `Union`,
 		// because `Union` cannot be `any` or `never` here.
-		Union, Union
-	>;
+		ifAny: Union;
+		ifNever: Union;
+	}>;
 
 export {};

--- a/source/exclude-rest-element.d.ts
+++ b/source/exclude-rest-element.d.ts
@@ -27,14 +27,14 @@ type T4 = ExcludeRestElement<[number, string]>;
 @see {@link SplitOnRestElement}
 @category Array
 */
-export type ExcludeRestElement<Array_ extends UnknownArray> = IfNotAnyOrNever<Array_,
-	SplitOnRestElement<Array_> extends infer Result
+export type ExcludeRestElement<Array_ extends UnknownArray> = IfNotAnyOrNever<Array_, {
+	ifNot: SplitOnRestElement<Array_> extends infer Result
 		? Result extends readonly UnknownArray[]
 			? IsArrayReadonly<Array_> extends true
 				? Readonly<[...Result[0], ...Result[2]]>
 				: [...Result[0], ...Result[2]]
 			: never
-		: never
->;
+		: never;
+}>;
 
 export {};

--- a/source/exclusify-union.d.ts
+++ b/source/exclusify-union.d.ts
@@ -125,13 +125,13 @@ type D = ExclusifyUnion<{a?: 1; readonly b: 2} | {d: 4}>;
 @category Object
 @category Union
 */
-export type ExclusifyUnion<Union> = IfNotAnyOrNever<Union,
-	If<IsUnknown<Union>, Union,
+export type ExclusifyUnion<Union> = IfNotAnyOrNever<Union, {
+	ifNot: If<IsUnknown<Union>, Union,
 		Extract<Union, NonRecursiveType | MapsSetsOrArrays> extends infer SkippedMembers
 			? SkippedMembers | _ExclusifyUnion<Exclude<Union, SkippedMembers>>
 			: never
-	>
->;
+	>;
+}>;
 
 type _ExclusifyUnion<Union, UnionCopy = Union> = Union extends unknown // For distributing `Union`
 	? Simplify<

--- a/source/extract-exactly.d.ts
+++ b/source/extract-exactly.d.ts
@@ -32,25 +32,25 @@ type TestExtractExactly3 = ExtractExactly<{a: string} | {a: string; b: string}, 
 @category Improved Built-in
 */
 export type ExtractExactly<Union, Match> =
-	IfNotAnyOrNever<
-		Union,
-		_ExtractExactly<Union, Match>,
+	IfNotAnyOrNever<Union, {
+		ifNot: _ExtractExactly<Union, Match>;
 		// If `Union` is `any`, then if `Match` is `any`, return `any`, else return `never`.
-		If<IsAny<Match>, Union, never>,
+		ifAny: If<IsAny<Match>, Union, never>;
 		// If `Union` is `never`, return `never`, doesn't matter what `Match` is.
-		never
-	>;
+		ifNever: never;
+	}>;
 
 type _ExtractExactly<Union, Match> =
-	IfNotAnyOrNever<Match,
-		Union extends unknown // For distributing `Union`
+	IfNotAnyOrNever<Match, {
+		ifNot: Union extends unknown // For distributing `Union`
 			? [Match extends unknown // For distributing `Match`
 				? If<IsEqual<Union, Match>, true, never>
 				: never] extends [never] ? never : Union
-			: never,
+			: never;
 		// If `Match` is `any` or `never`, then return `never`,
 		// because `Union` cannot be `any` or `never` here.
-		never, never
-	>;
+		ifAny: never;
+		ifNever: never;
+	}>;
 
 export {};

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -111,7 +111,7 @@ type B = CollapseRestElement<[string?, string?, ...number[]]>;
 //=> [string | undefined, string | undefined, number]
 ```
 */
-export type CollapseRestElement<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, _CollapseRestElement<TArray>>;
+export type CollapseRestElement<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {ifNot: _CollapseRestElement<TArray>}>;
 
 type _CollapseRestElement<
 	TArray extends UnknownArray,

--- a/source/internal/numeric.d.ts
+++ b/source/internal/numeric.d.ts
@@ -26,11 +26,13 @@ type E = IsNumberLike<'a'>;
 //=> false
 */
 export type IsNumberLike<N> =
-	IfNotAnyOrNever<N,
-		N extends number | `${number}`
+	IfNotAnyOrNever<N, {
+		ifNot: N extends number | `${number}`
 			? true
-			: false,
-		boolean, false>;
+			: false;
+		ifAny: boolean;
+		ifNever: false;
+	}>;
 
 /**
 Returns the minimum number in the given union of numbers.

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -1,9 +1,7 @@
-import type {If} from '../if.d.ts';
 import type {IsAny} from '../is-any.d.ts';
 import type {IsNever} from '../is-never.d.ts';
 import type {Primitive} from '../primitive.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
-import type {UnionToIntersection} from '../union-to-intersection.d.ts';
 
 /**
 Matches any primitive, `void`, `Date`, or `RegExp` value.
@@ -91,16 +89,15 @@ An if-else-like type that resolves depending on whether the given type is `any` 
 
 @example
 ```
-// When `T` is a NOT `any` or `never` (like `string`) => Returns `IfNotAnyOrNever` branch
-type A = IfNotAnyOrNever<string, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+type A = IfNotAnyOrNever<string, {ifNot: 'VALID'; ifAny: 'IS_ANY'; ifNever: 'IS_NEVER'}>;
 //=> 'VALID'
 
 // When `T` is `any` => Returns `IfAny` branch
-type B = IfNotAnyOrNever<any, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+type B = IfNotAnyOrNever<any, {ifNot: 'VALID'; ifAny: 'IS_ANY'; ifNever: 'IS_NEVER'}>;
 //=> 'IS_ANY'
 
 // When `T` is `never` => Returns `IfNever` branch
-type C = IfNotAnyOrNever<never, 'VALID', 'IS_ANY', 'IS_NEVER'>;
+type C = IfNotAnyOrNever<never, {ifNot: 'VALID'; ifAny: 'IS_ANY'; ifNever: 'IS_NEVER'}>;
 //=> 'IS_NEVER'
 ```
 
@@ -113,7 +110,7 @@ import type {StringRepeat} from 'type-fest';
 type NineHundredNinetyNineSpaces = StringRepeat<' ', 999>;
 
 // The following implementation is not tail recursive
-type TrimLeft<S extends string> = IfNotAnyOrNever<S, S extends ` ${infer R}` ? TrimLeft<R> : S>;
+type TrimLeft<S extends string> = IfNotAnyOrNever<S, {ifNot: S extends ` ${infer R}` ? TrimLeft<R> : S}>;
 
 // Hence, instantiations with long strings will fail
 // @ts-expect-error
@@ -122,7 +119,7 @@ type T1 = TrimLeft<NineHundredNinetyNineSpaces>;
 // Error: Type instantiation is excessively deep and possibly infinite.
 
 // To fix this, move the recursion into a helper type
-type TrimLeftOptimised<S extends string> = IfNotAnyOrNever<S, _TrimLeftOptimised<S>>;
+type TrimLeftOptimised<S extends string> = IfNotAnyOrNever<S, {ifNot: _TrimLeftOptimised<S>}>;
 
 type _TrimLeftOptimised<S extends string> = S extends ` ${infer R}` ? _TrimLeftOptimised<R> : S;
 
@@ -130,8 +127,19 @@ type T2 = TrimLeftOptimised<NineHundredNinetyNineSpaces>;
 //=> ''
 ```
 */
-export type IfNotAnyOrNever<T, IfNotAnyOrNever, IfAny = any, IfNever = never> =
-	If<IsAny<T>, IfAny, If<IsNever<T>, IfNever, IfNotAnyOrNever>>;
+export type IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny?: unknown; ifNever?: unknown}> =
+	_IfNotAnyOrNever<T, Required<Cases> & (
+        'ifAny' extends keyof Cases ? unknown : {ifAny: any}
+    ) & (
+        'ifNever' extends keyof Cases ? unknown : {ifNever: never}
+    )>;
+
+type _IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny: unknown; ifNever: unknown}> =
+	IsAny<T> extends true
+		? Cases['ifAny']
+		: IsNever<T> extends true
+			? Cases['ifNever']
+			: Cases['ifNot'];
 
 /**
 Returns a boolean for whether the given type is `any` or `never`.

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -128,17 +128,14 @@ type T2 = TrimLeftOptimised<NineHundredNinetyNineSpaces>;
 ```
 */
 export type IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny?: unknown; ifNever?: unknown}> =
-	_IfNotAnyOrNever<T, Required<Cases> & (
-		'ifAny' extends keyof Cases ? unknown : {ifAny: any}
-	) & (
-		'ifNever' extends keyof Cases ? unknown : {ifNever: never}
-	)>;
-
-type _IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny: unknown; ifNever: unknown}> =
 	IsAny<T> extends true
-		? Cases['ifAny']
+		? 'ifAny' extends keyof Cases
+			? Cases['ifAny']
+			: any
 		: IsNever<T> extends true
-			? Cases['ifNever']
+			? 'ifNever' extends keyof Cases
+				? Cases['ifNever']
+				: never
 			: Cases['ifNot'];
 
 /**

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -89,6 +89,7 @@ An if-else-like type that resolves depending on whether the given type is `any` 
 
 @example
 ```
+// When `T` is neither `any` nor `never` (like `string`) => Returns `IfNot` branch
 type A = IfNotAnyOrNever<string, {ifNot: 'VALID'; ifAny: 'IS_ANY'; ifNever: 'IS_NEVER'}>;
 //=> 'VALID'
 

--- a/source/internal/type.d.ts
+++ b/source/internal/type.d.ts
@@ -129,10 +129,10 @@ type T2 = TrimLeftOptimised<NineHundredNinetyNineSpaces>;
 */
 export type IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny?: unknown; ifNever?: unknown}> =
 	_IfNotAnyOrNever<T, Required<Cases> & (
-        'ifAny' extends keyof Cases ? unknown : {ifAny: any}
-    ) & (
-        'ifNever' extends keyof Cases ? unknown : {ifNever: never}
-    )>;
+		'ifAny' extends keyof Cases ? unknown : {ifAny: any}
+	) & (
+		'ifNever' extends keyof Cases ? unknown : {ifNever: never}
+	)>;
 
 type _IfNotAnyOrNever<T, Cases extends {ifNot: unknown; ifAny: unknown; ifNever: unknown}> =
 	IsAny<T> extends true

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -114,9 +114,11 @@ type L2 = Length<`${number}`>;
 @category Type Guard
 @category Utilities
 */
-export type IsStringLiteral<S> = IfNotAnyOrNever<S,
-	_IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>,
-	false, false>;
+export type IsStringLiteral<S> = IfNotAnyOrNever<S, {
+	ifNot: _IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>;
+	ifAny: false;
+	ifNever: false;
+}>;
 
 export type _IsStringLiteral<S> =
 // If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,

--- a/source/object-merge.d.ts
+++ b/source/object-merge.d.ts
@@ -90,22 +90,27 @@ Note: If you want a simple merge where properties from the second object always 
 @category Object
 */
 export type ObjectMerge<First extends object, Second extends object> =
-	IfNotAnyOrNever<First, IfNotAnyOrNever<Second, First extends unknown // For distributing `First`
-		? Second extends unknown // For distributing `Second`
-			? First extends MapsSetsOrArrays
-				? unknown
-				: Second extends MapsSetsOrArrays
-					? unknown
-					: _ObjectMerge<
-						First,
-						Second,
-						NormalizedLiteralKeys<First>,
-						NormalizedLiteralKeys<Second>,
-						IsExactOptionalPropertyTypesEnabled extends true ? Required<First> : First,
-						IsExactOptionalPropertyTypesEnabled extends true ? Required<Second> : Second
-					>
-			: never // Should never happen
-		: never>, First & Second>; // Should never happen
+	IfNotAnyOrNever<First, {
+		ifNot: IfNotAnyOrNever<Second, {
+			ifNot: First extends unknown // For distributing `First`
+				? Second extends unknown // For distributing `Second`
+					? First extends MapsSetsOrArrays
+						? unknown
+						: Second extends MapsSetsOrArrays
+							? unknown
+							: _ObjectMerge<
+								First,
+								Second,
+								NormalizedLiteralKeys<First>,
+								NormalizedLiteralKeys<Second>,
+								IsExactOptionalPropertyTypesEnabled extends true ? Required<First> : First,
+								IsExactOptionalPropertyTypesEnabled extends true ? Required<Second> : Second
+							>
+					: never // Should never happen
+				: never; // Should never happen
+		}>;
+		ifAny: First & Second;
+	}>;
 
 type _ObjectMerge<
 	First extends object,

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -94,7 +94,7 @@ type D = RemovePrefix<`handle${Capitalize<string>}`, 'handle'>;
 @category Template literal
 */
 export type RemovePrefix<S extends string, Prefix extends string, Options extends RemovePrefixOptions = {}> =
-	IfNotAnyOrNever<S,	{
+	IfNotAnyOrNever<S, {
 		ifNot: If<
 			IsNever<Prefix>,
 			S,

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -94,14 +94,13 @@ type D = RemovePrefix<`handle${Capitalize<string>}`, 'handle'>;
 @category Template literal
 */
 export type RemovePrefix<S extends string, Prefix extends string, Options extends RemovePrefixOptions = {}> =
-	IfNotAnyOrNever<
-		S,
-		If<
+	IfNotAnyOrNever<S,	{
+		ifNot: If<
 			IsNever<Prefix>,
 			S,
 			_RemovePrefix<S, Prefix, ApplyDefaultOptions<RemovePrefixOptions, DefaultRemovePrefixOptions, Options>>
-		>
-	>;
+		>;
+	}>;
 
 type _RemovePrefix<S extends string, Prefix extends string, Options extends Required<RemovePrefixOptions>> =
 	Prefix extends string // For distributing `Prefix`

--- a/source/remove-suffix.d.ts
+++ b/source/remove-suffix.d.ts
@@ -94,14 +94,13 @@ type D = RemoveSuffix<`api/${string}/analytics`, '/analytics'>;
 @category Template literal
 */
 export type RemoveSuffix<S extends string, Suffix extends string, Options extends RemoveSuffixOptions = {}> =
-	IfNotAnyOrNever<
-		S,
-		If<
+	IfNotAnyOrNever<S, {
+		ifNot: If<
 			IsNever<Suffix>,
 			S,
 			_RemoveSuffix<S, Suffix, ApplyDefaultOptions<RemoveSuffixOptions, DefaultRemoveSuffixOptions, Options>>
-		>
-	>;
+		>;
+	}>;
 
 type _RemoveSuffix<S extends string, Suffix extends string, Options extends Required<RemoveSuffixOptions>> =
 	Suffix extends string // For distributing `Suffix`

--- a/source/require-all-or-none.d.ts
+++ b/source/require-all-or-none.d.ts
@@ -40,11 +40,11 @@ const responder2: RequireAllOrNone<Responder, 'text' | 'json'> = {
 @category Object
 */
 export type RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
-	IfNotAnyOrNever<ObjectType,
-		If<IsNever<KeysType>,
+	IfNotAnyOrNever<ObjectType, {
+		ifNot: If<IsNever<KeysType>,
 			ObjectType,
-			_RequireAllOrNone<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>
-		>>;
+			_RequireAllOrNone<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>>;
+	}>;
 
 type _RequireAllOrNone<ObjectType, KeysType extends keyof ObjectType> = (
 	| RequireAll<ObjectType, KeysType>

--- a/source/require-at-least-one.d.ts
+++ b/source/require-at-least-one.d.ts
@@ -29,11 +29,11 @@ export type RequireAtLeastOne<
 	ObjectType,
 	KeysType extends keyof ObjectType = keyof ObjectType,
 > =
-	IfNotAnyOrNever<ObjectType,
-		If<IsNever<KeysType>,
+	IfNotAnyOrNever<ObjectType, {
+		ifNot: If<IsNever<KeysType>,
 			never,
-			_RequireAtLeastOne<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>
-		>>;
+			_RequireAtLeastOne<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>>;
+	}>;
 
 type _RequireAtLeastOne<
 	ObjectType,

--- a/source/require-exactly-one.d.ts
+++ b/source/require-exactly-one.d.ts
@@ -33,11 +33,11 @@ const responder: RequireExactlyOne<Responder, 'text' | 'json'> = {
 @category Object
 */
 export type RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
-	IfNotAnyOrNever<ObjectType,
-		If<IsNever<KeysType>,
+	IfNotAnyOrNever<ObjectType, {
+		ifNot: If<IsNever<KeysType>,
 			never,
-			_RequireExactlyOne<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>
-		>>;
+			_RequireExactlyOne<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>>;
+	}>;
 
 type _RequireExactlyOne<ObjectType, KeysType extends keyof ObjectType> =
 	{[Key in KeysType]: (

--- a/source/require-one-or-none.d.ts
+++ b/source/require-one-or-none.d.ts
@@ -35,11 +35,11 @@ const responder3: Responder = {
 @category Object
 */
 export type RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType = keyof ObjectType> =
-	IfNotAnyOrNever<ObjectType,
-		If<IsNever<KeysType>,
+	IfNotAnyOrNever<ObjectType, {
+		ifNot: If<IsNever<KeysType>,
 			ObjectType,
-			_RequireOneOrNone<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>
-		>>;
+			_RequireOneOrNone<ObjectType, If<IsAny<KeysType>, keyof ObjectType, KeysType>>>;
+	}>;
 
 type _RequireOneOrNone<ObjectType, KeysType extends keyof ObjectType> = (
 	| RequireExactlyOne<ObjectType, KeysType>

--- a/source/schema.d.ts
+++ b/source/schema.d.ts
@@ -91,9 +91,11 @@ const userMaskSettings: UserMask = {
 @category Object
 */
 export type Schema<Type, Value, Options extends SchemaOptions = {}> =
-	IfNotAnyOrNever<Type,
-		_Schema<Type, Value, ApplyDefaultOptions<SchemaOptions, DefaultSchemaOptions, Options>>,
-		Value, Value>;
+	IfNotAnyOrNever<Type, {
+		ifNot: _Schema<Type, Value, ApplyDefaultOptions<SchemaOptions, DefaultSchemaOptions, Options>>;
+		ifAny: Value;
+		ifNever: Value;
+	}>;
 
 type _Schema<Type, Value, Options extends Required<SchemaOptions>> =
 	Type extends NonRecursiveType | Map<unknown, unknown> | Set<unknown> | ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>

--- a/source/some-extend.d.ts
+++ b/source/some-extend.d.ts
@@ -97,8 +97,8 @@ type B = SomeExtend<[1?, 2?, '3'?], string | undefined>;
 export type SomeExtend<TArray extends UnknownArray, Type, Options extends SomeExtendOptions = {}> =
 	_SomeExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<SomeExtendOptions, DefaultSomeExtendOptions, Options>>;
 
-type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<SomeExtendOptions>> = IfNotAnyOrNever<TArray,
-	TArray extends readonly [infer First, ...infer Rest]
+type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<SomeExtendOptions>> = IfNotAnyOrNever<TArray, {
+	ifNot: TArray extends readonly [infer First, ...infer Rest]
 		? IsNever<First> extends true
 			? Or<Or<IsNever<Type>, IsAny<Type>>, Not<Options['strictNever']>> extends true
 				// If target `Type` is also `never`, or is `any`, or `strictNever` is disabled, return `true`.
@@ -107,7 +107,9 @@ type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<Som
 			: First extends Type
 				? true
 				: _SomeExtend<Rest, Type, Options>
-		: false,
-	false, false>;
+		: false;
+	ifAny: false;
+	ifNever: false;
+}>;
 
 export {};

--- a/source/split-on-rest-element.d.ts
+++ b/source/split-on-rest-element.d.ts
@@ -69,7 +69,8 @@ export type SplitOnRestElement<
 			ifNot: _SplitOnRestElement<
 				Array_,
 				ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>
-			>}> extends infer Result extends UnknownArray
+			>;
+		}> extends infer Result extends UnknownArray
 			? If<IsArrayReadonly<Array_>, Readonly<Result>, Result>
 			: never // Should never happen
 		: never; // Should never happen

--- a/source/split-on-rest-element.d.ts
+++ b/source/split-on-rest-element.d.ts
@@ -65,10 +65,11 @@ export type SplitOnRestElement<
 	Options extends SplitOnRestElementOptions = {},
 > =
 	Array_ extends unknown // For distributing `Array_`
-		? IfNotAnyOrNever<Array_, _SplitOnRestElement<
-			Array_,
-			ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>
-		>> extends infer Result extends UnknownArray
+		? IfNotAnyOrNever<Array_, {
+			ifNot: _SplitOnRestElement<
+				Array_,
+				ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>
+			>}> extends infer Result extends UnknownArray
 			? If<IsArrayReadonly<Array_>, Readonly<Result>, Result>
 			: never // Should never happen
 		: never; // Should never happen

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -77,8 +77,10 @@ type E = StringToArray<`foo${string}bar`, {mapNonLiteralsDirectly: true}>;
 export type StringToArray<S extends string, Options extends StringToArrayOptions = {}> =
 	IfNotAnyOrNever<
 		S,
-		_StringToArray<S, ApplyDefaultOptions<StringToArrayOptions, DefaultStringToArrayOptions, Options>>,
-		unknown[]
+		{
+			ifNot: _StringToArray<S, ApplyDefaultOptions<StringToArrayOptions, DefaultStringToArrayOptions, Options>>;
+			ifAny: unknown[];
+		}
 	>;
 
 type _StringToArray<S extends string, Options extends Required<StringToArrayOptions>, Accumulator extends string[] = []> =

--- a/source/string-to-number.d.ts
+++ b/source/string-to-number.d.ts
@@ -47,7 +47,7 @@ type NumericSeparators = StringToNumber<'12_345'>;
 @category Numeric
 @category Template literal
 */
-export type StringToNumber<S extends string> = IfNotAnyOrNever<S, _StringToNumber<S>, number>;
+export type StringToNumber<S extends string> = IfNotAnyOrNever<S, {ifNot: _StringToNumber<S>; ifAny: number}>;
 
 type _StringToNumber<S extends string> =
 	S extends `${infer N extends number}`

--- a/source/tuple-of.d.ts
+++ b/source/tuple-of.d.ts
@@ -78,9 +78,11 @@ Note: If you need a readonly tuple, simply wrap this type with `Readonly`, for e
 
 @category Array
 */
-export type TupleOf<Length extends number, Fill = unknown> = IfNotAnyOrNever<Length,
-	_TupleOf<If<IsNegative<Length>, 0, Length>, Fill>,
-	Fill[], []>;
+export type TupleOf<Length extends number, Fill = unknown> = IfNotAnyOrNever<Length, {
+	ifNot: _TupleOf<If<IsNegative<Length>, 0, Length>, Fill>;
+	ifAny: Fill[];
+	ifNever: [];
+}>;
 
 type _TupleOf<Length extends number, Fill> = number extends Length
 	? Fill[]

--- a/test-d/internal/if-not-any-or-never.ts
+++ b/test-d/internal/if-not-any-or-never.ts
@@ -24,3 +24,25 @@ type CrashIfAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if `T`
 // @ts-expect-error
 type T1 = CrashIfAny<any>;
 type T2 = CrashIfAnyWrapper<any>;
+
+type CrashIfNeverWrapper<T> = IfNotAnyOrNever<T, {ifNot: CrashIfNever<T>}>;
+
+type CrashIfNever<T, Acc extends unknown[] = []> = [never] extends [T] // Check if `T` is `never`
+	? CrashIfNever<T, [...Acc, unknown]>
+	: never;
+
+// `CrashIfNever<never>` errors with a recursion depth error, but `CrashIfNeverWrapper<never>` shouldn't.
+// @ts-expect-error
+type T3 = CrashIfNever<never>;
+type T4 = CrashIfNeverWrapper<never>;
+
+type CrashIfNotAnyWrapper<T> = IfNotAnyOrNever<T, {ifNot: never; ifAny: CrashIfNotAny<T>}>;
+
+type CrashIfNotAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if `T` is `any`
+	? never
+	: CrashIfNotAny<T, [...Acc, unknown]>;
+
+// `CrashIfNotAny<string>` errors with a recursion depth error, but `CrashIfNotAnyWrapper<string>` shouldn't.
+// @ts-expect-error
+type T5 = CrashIfNotAny<string>;
+type T6 = CrashIfNotAnyWrapper<string>;

--- a/test-d/internal/if-not-any-or-never.ts
+++ b/test-d/internal/if-not-any-or-never.ts
@@ -1,12 +1,26 @@
 import {expectType} from 'tsd';
 import type {IfNotAnyOrNever} from '../../source/internal/index.d.ts';
 
-expectType<any>({} as IfNotAnyOrNever<any, string>);
-expectType<never>({} as IfNotAnyOrNever<never, string>);
-expectType<number>({} as IfNotAnyOrNever<any, string, number>);
-expectType<number>({} as IfNotAnyOrNever<any, string, number, boolean>);
-expectType<never>({} as IfNotAnyOrNever<never, string, number>);
-expectType<boolean>({} as IfNotAnyOrNever<never, string, number, boolean>);
-expectType<number>({} as IfNotAnyOrNever<string, number>);
-expectType<number>({} as IfNotAnyOrNever<string | number, number, boolean>);
-expectType<number>({} as IfNotAnyOrNever<object, number, boolean, string>);
+expectType<any>({} as IfNotAnyOrNever<any, {ifNot: string}>);
+expectType<never>({} as IfNotAnyOrNever<never, {ifNot: string}>);
+expectType<number>({} as IfNotAnyOrNever<any, {ifNot: string; ifAny: number}>);
+expectType<any>({} as IfNotAnyOrNever<any, {ifNot: string; ifNever: number}>);
+expectType<number>({} as IfNotAnyOrNever<any, {ifNot: string; ifAny: number; ifNever: boolean}>);
+expectType<never>({} as IfNotAnyOrNever<never, {ifNot: string; ifAny: number}>);
+expectType<number>({} as IfNotAnyOrNever<never, {ifNot: string; ifNever: number}>);
+expectType<boolean>({} as IfNotAnyOrNever<never, {ifNot: string; ifAny: number; ifNever: boolean}>);
+expectType<number>({} as IfNotAnyOrNever<string, {ifNot: number}>);
+expectType<number>({} as IfNotAnyOrNever<string | number, {ifNot: number; ifAny: boolean}>);
+expectType<number>({} as IfNotAnyOrNever<string | number, {ifNot: number; ifNever: boolean}>);
+expectType<number>({} as IfNotAnyOrNever<object, {ifNot: number; ifAny: boolean; ifNever: string}>);
+
+type CrashIfAnyWrapper<T> = IfNotAnyOrNever<T, {ifNot: CrashIfAny<T>}>;
+
+type CrashIfAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if `T` is `any`
+	? CrashIfAny<T, [...Acc, unknown]>
+	: never;
+
+// `CrashIfAny<any>` errors with a recursion depth error, but `CrashIfAnyWrapper<any>` shouldn't.
+// @ts-expect-error
+type T1 = CrashIfAny<any>;
+type T2 = CrashIfAnyWrapper<any>;

--- a/test-d/internal/if-not-any-or-never.ts
+++ b/test-d/internal/if-not-any-or-never.ts
@@ -46,3 +46,14 @@ type CrashIfNotAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if 
 // @ts-expect-error
 type T5 = CrashIfNotAny<string>;
 type T6 = CrashIfNotAnyWrapper<string>;
+
+type CrashIfNotNeverWrapper<T> = IfNotAnyOrNever<T, {ifNot: never; ifNever: CrashIfNotNever<T>}>;
+
+type CrashIfNotNever<T, Acc extends unknown[] = []> = [T] extends [never] // Check if `T` is `never`
+	? never
+	: CrashIfNotNever<T, [...Acc, unknown]>;
+
+// `CrashIfNotNever<string>` errors with a recursion depth error, but `CrashIfNotNeverWrapper<string>` shouldn't.
+// @ts-expect-error
+type T7 = CrashIfNotNever<string>;
+type T8 = CrashIfNotNeverWrapper<string>;

--- a/test-d/internal/if-not-any-or-never.ts
+++ b/test-d/internal/if-not-any-or-never.ts
@@ -27,7 +27,7 @@ type T2 = CrashIfAnyWrapper<any>;
 
 type CrashIfNeverWrapper<T> = IfNotAnyOrNever<T, {ifNot: CrashIfNever<T>}>;
 
-type CrashIfNever<T, Acc extends unknown[] = []> = [never] extends [T] // Check if `T` is `never`
+type CrashIfNever<T, Acc extends unknown[] = []> = [T] extends [never] // Check if `T` is `never`
 	? CrashIfNever<T, [...Acc, unknown]>
 	: never;
 

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -131,7 +131,7 @@ expectType<{array: [
 	{a: 1; b: 2}, // 2
 	{b: 2}, // 3
 	...Array<{a: 1; b: 2}>,
-]}>(recurseIntoArray3);
+];}>(recurseIntoArray3);
 
 declare const tuple: OmitDeep<{array: BaseType['tuples']}, 'array.0'>;
 expectType<{array: [unknown, 'bar']}>(tuple);

--- a/test-d/omit-deep.ts
+++ b/test-d/omit-deep.ts
@@ -131,7 +131,7 @@ expectType<{array: [
 	{a: 1; b: 2}, // 2
 	{b: 2}, // 3
 	...Array<{a: 1; b: 2}>,
-];}>(recurseIntoArray3);
+]}>(recurseIntoArray3);
 
 declare const tuple: OmitDeep<{array: BaseType['tuples']}, 'array.0'>;
 expectType<{array: [unknown, 'bar']}>(tuple);

--- a/xo.config.js
+++ b/xo.config.js
@@ -34,6 +34,7 @@ const xoConfig = [
 			'@stylistic/function-paren-newline': 'off',
 			'@stylistic/object-curly-newline': 'off',
 			'@stylistic/curly-newline': 'off',
+			'@stylistic/member-delimiter-style': ['error', {multilineDetection: 'last-member'}],
 			'@stylistic/operator-linebreak': ['error', 'before', {overrides: {'=': 'after'}}],
 			'n/file-extension-in-import': 'off',
 			'object-curly-newline': [

--- a/xo.config.js
+++ b/xo.config.js
@@ -34,7 +34,6 @@ const xoConfig = [
 			'@stylistic/function-paren-newline': 'off',
 			'@stylistic/object-curly-newline': 'off',
 			'@stylistic/curly-newline': 'off',
-			'@stylistic/member-delimiter-style': ['error', {multilineDetection: 'last-member'}],
 			'@stylistic/operator-linebreak': ['error', 'before', {overrides: {'=': 'after'}}],
 			'n/file-extension-in-import': 'off',
 			'object-curly-newline': [


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Consider the following example:
```ts
type CrashIfAnyWrapper<T> = IfNotAnyOrNever<T, CrashIfAny<T>, 'any handled', 'never handled'>;

type CrashIfAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if `T` is `any`
	? CrashIfAny<T, [...Acc, unknown]>
	: never;

// @ts-expect-error
type T1 = CrashIfAny<any>;

type T2 = CrashIfAnyWrapper<any>; // Should not error, but errors!
```

`CrashIfAny` is a type that fails when instantiated with `any`. To fix this, we try wrapping it in `IfNotAnyOrNever` to handle the `any` case explicitly, but this currently doesn't prevent the error. This happens because when we write `IfNotAnyOrNever<T, CrashIfAny<T>, 'any handled'>`, `CrashIfAny` is instantiated with `T` even if its value isn't going to be used.

<br>

Couldn't really find a great fix for this, but accepting the values for different cases in an object seems to fix this issue. It seems to make the compiler not do the instantiation until the value is actually accessed.

```ts
type CrashIfAnyWrapper<T> = IfNotAnyOrNever<T, {ifNot: CrashIfAny<T>; ifAny: 'any handled'; ifNever: 'never handled'}>;

type CrashIfAny<T, Acc extends unknown[] = []> = 0 extends 1 & T // Check if `T` is `any`
	? CrashIfAny<T, [...Acc, unknown]>
	: never;

// @ts-expect-error
type T1 = CrashIfAny<any>;

type T2 = CrashIfAnyWrapper<any>; // Works!
```
