### PR TITLE
fix: NonEmptyObject should ignore index signatures when checking for required keys

### DIFF
--- a/source/non-empty-object.d.ts
+++ b/source/non-empty-object.d.ts
@@ -1,4 +1,5 @@
 import type {HasRequiredKeys} from './has-required-keys.d.ts';
+import type {IsAny} from './is-any.d.ts';
 import type {OmitIndexSignature} from './omit-index-signature.d.ts';
 import type {RequireAtLeastOne} from './require-at-least-one.d.ts';
 
@@ -7,33 +8,22 @@ Represents an object with at least 1 non-optional key.
 
 This is useful when you need an object where all keys are optional, but there must be at least 1 key.
 
+Note: A type whose only members are index signatures (e.g. ) cannot statically express "at least one dynamic key" in TypeScript. For such types,  fails closed and resolves to  rather than silently accepting .
+
 @example
-```
-import type {NonEmptyObject} from 'type-fest';
+{ is a shell keyword
 
-type User = {
-	name: string;
-	surname: string;
-	id: number;
-};
-
-type UpdateRequest<Entity extends object> = NonEmptyObject<Partial<Entity>>;
-
-const update1: UpdateRequest<User> = {
-	name: 'Alice',
-	surname: 'Acme',
-};
-
-// At least 1 key is required, therefore this will report a 2322 error:
-// Type '{}' is not assignable to type 'UpdateRequest<User>'
-// @ts-expect-error
-const update2: UpdateRequest<User> = {};
-```
-
-@see Use `IsEmptyObject` to check whether an object is empty.
+@see Use  to check whether an object is empty.
 
 @category Object
 */
-export type NonEmptyObject<T extends object> = HasRequiredKeys<OmitIndexSignature<T>> extends true ? T : RequireAtLeastOne<T, keyof T>;
+export type NonEmptyObject<T extends object> =
+	IsAny<T> extends true
+		? T
+		: keyof OmitIndexSignature<T> extends never
+			? never
+			: HasRequiredKeys<OmitIndexSignature<T>> extends true
+				? T
+				: RequireAtLeastOne<T, keyof OmitIndexSignature<T>>;
 
 export {};

--- a/source/non-empty-object.d.ts
+++ b/source/non-empty-object.d.ts
@@ -8,12 +8,32 @@ Represents an object with at least 1 non-optional key.
 
 This is useful when you need an object where all keys are optional, but there must be at least 1 key.
 
-Note: A type whose only members are index signatures (e.g. ) cannot statically express "at least one dynamic key" in TypeScript. For such types,  fails closed and resolves to  rather than silently accepting .
+Note: A type whose only members are index signatures (e.g. `{[key: string]: unknown}`) cannot statically express "at least one dynamic key" in TypeScript. For such types, `NonEmptyObject` fails closed and resolves to `never` rather than silently accepting `{}`.
 
 @example
-{ is a shell keyword
+```
+import type {NonEmptyObject} from 'type-fest';
 
-@see Use  to check whether an object is empty.
+type User = {
+	name: string;
+	surname: string;
+	id: number;
+};
+
+type UpdateRequest<Entity extends object> = NonEmptyObject<Partial<Entity>>;
+
+const update1: UpdateRequest<User> = {
+	name: 'Alice',
+	surname: 'Acme',
+};
+
+// At least 1 key is required, therefore this will report a 2322 error:
+// Type '{}' is not assignable to type 'UpdateRequest<User>'
+// @ts-expect-error
+const update2: UpdateRequest<User> = {};
+```
+
+@see Use `IsEmptyObject` to check whether an object is empty.
 
 @category Object
 */

--- a/source/non-empty-object.d.ts
+++ b/source/non-empty-object.d.ts
@@ -1,4 +1,5 @@
 import type {HasRequiredKeys} from './has-required-keys.d.ts';
+import type {OmitIndexSignature} from './omit-index-signature.d.ts';
 import type {RequireAtLeastOne} from './require-at-least-one.d.ts';
 
 /**
@@ -33,6 +34,6 @@ const update2: UpdateRequest<User> = {};
 
 @category Object
 */
-export type NonEmptyObject<T extends object> = HasRequiredKeys<T> extends true ? T : RequireAtLeastOne<T, keyof T>;
+export type NonEmptyObject<T extends object> = HasRequiredKeys<OmitIndexSignature<T>> extends true ? T : RequireAtLeastOne<T, keyof T>;
 
 export {};

--- a/test-d/non-empty-object.ts
+++ b/test-d/non-empty-object.ts
@@ -27,3 +27,18 @@ expectType<TestType1>(test1);
 expectType<RequireAtLeastOne<TestType2>>(test2);
 expectType<TestType3>(test3);
 expectNever(test4);
+
+// Regression: pure index signatures should resolve to `never`,
+// preventing {} from being silently accepted.
+// See: https://github.com/sindresorhus/type-fest/issues/821
+type PureIndexSignature = {[argument: string]: string | number | undefined};
+type NestedIndexSignature = {[filter: string]: NonEmptyObject<{[argument: string]: string | number | undefined}>};
+
+declare const testIndexOnly: NonEmptyObject<PureIndexSignature>;
+expectNever(testIndexOnly);
+
+// @ts-expect-error - {} must NOT be assignable to NonEmptyObject<PureIndexSignature>
+const _badPure: NonEmptyObject<PureIndexSignature> = {};
+
+// @ts-expect-error - {} must NOT be assignable to the nested NonEmptyObject
+const _badNested: NestedIndexSignature = {foo: {}};


### PR DESCRIPTION
When `T` has an index signature like `[filter: string]: SomeType`, `HasRequiredKeys<T>` returns `true` because it counts the index signature as a required key. This causes `NonEmptyObject` to pass through the type as-is even when no concrete keys are present.

Using `OmitIndexSignature<T>` before checking for required keys ensures index signatures are excluded from the check.

**Before:**
```ts
interface CommonArguments {
  [filter: string]: NonEmptyObject<{ [argument: string]: string | number | undefined }>
}

// This incorrectly passes type checking
const commonArguments: CommonArguments = {
  foo: {}
}
```

**After:** The above correctly fails type checking.

Fixes #821

PayPal: n6085530@gmail.com