### PR TITLE
test: add IsEqual test cases for number vs bigint

### DIFF
--- a/test-d/is-equal.ts
+++ b/test-d/is-equal.ts
@@ -8,8 +8,7 @@ expectType<true>({} as IsEqual<'foo', 'foo'>);
 expectType<false>({} as IsEqual<true, false>);
 expectType<true>({} as IsEqual<false, false>);
 
-// Test for Issue https://github.com/sindresorhus/type-fest/issues/1442
-// number and bigint are distinct types in TypeScript and JavaScript (===)
+// Number and bigint are distinct types.
 expectType<false>({} as IsEqual<100, 100n>);
 expectType<false>({} as IsEqual<number, bigint>);
 expectType<false>({} as IsEqual<42, 42n>);

--- a/test-d/is-equal.ts
+++ b/test-d/is-equal.ts
@@ -11,8 +11,6 @@ expectType<true>({} as IsEqual<false, false>);
 // Number and bigint are distinct types.
 expectType<false>({} as IsEqual<100, 100n>);
 expectType<false>({} as IsEqual<number, bigint>);
-expectType<false>({} as IsEqual<42, 42n>);
-expectType<true>({} as IsEqual<42, 42>);
 expectType<true>({} as IsEqual<42n, 42n>);
 
 expectType<false>({} as IsEqual<any, number>);

--- a/test-d/is-equal.ts
+++ b/test-d/is-equal.ts
@@ -8,6 +8,11 @@ expectType<true>({} as IsEqual<'foo', 'foo'>);
 expectType<false>({} as IsEqual<true, false>);
 expectType<true>({} as IsEqual<false, false>);
 
+// Test for Issue https://github.com/sindresorhus/type-fest/issues/1442
+// number and bigint are distinct types in TypeScript and JavaScript (===)
+expectType<false>({} as IsEqual<100, 100n>);
+expectType<false>({} as IsEqual<number, bigint>);
+
 expectType<false>({} as IsEqual<any, number>);
 expectType<false>({} as IsEqual<'', never>);
 expectType<true>({} as IsEqual<any, any>);

--- a/test-d/is-equal.ts
+++ b/test-d/is-equal.ts
@@ -12,6 +12,9 @@ expectType<true>({} as IsEqual<false, false>);
 // number and bigint are distinct types in TypeScript and JavaScript (===)
 expectType<false>({} as IsEqual<100, 100n>);
 expectType<false>({} as IsEqual<number, bigint>);
+expectType<false>({} as IsEqual<42, 42n>);
+expectType<true>({} as IsEqual<42, 42>);
+expectType<true>({} as IsEqual<42n, 42n>);
 
 expectType<false>({} as IsEqual<any, number>);
 expectType<false>({} as IsEqual<'', never>);


### PR DESCRIPTION
### Problem

Issue #1442 raised a question about whether `IsEqual<100, 100n>` should be `true` or `false`. After investigation, the current behavior (`false`) is correct because `number` and `bigint` are distinct types in TypeScript and use strict equality (`===`) in JavaScript.

### Changes

- Added test cases validating that `IsEqual` correctly distinguishes between `number` and `bigint` types
- Added tests for bigint literal self-equality

Closes #1442