### PR TITLE
Refactor: Remove redundant circular check infer workarounds (#1142)

### DIFF
--- a/source/array-reverse.d.ts
+++ b/source/array-reverse.d.ts
@@ -53,9 +53,7 @@ type E = ArrayReverse<[string?, number?, ...boolean[]]>;
 */
 export type ArrayReverse<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {
 	ifNot: TArray extends unknown // For distributing `TArray`
-		? _ArrayReverse<TArray> extends infer Result
-			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
-			: never // Should never happen
+		? If<IsArrayReadonly<TArray>, Readonly<_ArrayReverse<TArray>>, _ArrayReverse<TArray>>
 		: never; // Should never happen
 }>;
 

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -53,9 +53,7 @@ const availableTopSciFi = curry(searchBooks)('sci-fi')(4.5)(true);
 */
 export type ArrayTail<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {
 	ifNot: TArray extends UnknownArray // For distributing `TArray`
-		? _ArrayTail<TArray> extends infer Result
-			? If<IsArrayReadonly<TArray>, Readonly<Result>, Result>
-			: never // Should never happen
+		? If<IsArrayReadonly<TArray>, Readonly<_ArrayTail<TArray>>, _ArrayTail<TArray>>
 		: never;
 }>;
 

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -38,9 +38,7 @@ export type SetRequired<BaseType, Keys extends keyof BaseType> =
 
 type _SetRequired<BaseType, Keys extends keyof BaseType> =
 	BaseType extends UnknownArray
-		? SetArrayRequired<BaseType, Keys> extends infer ResultantArray
-			? If<IsArrayReadonly<BaseType>, Readonly<ResultantArray>, ResultantArray>
-			: never
+		? If<IsArrayReadonly<BaseType>, Readonly<SetArrayRequired<BaseType, Keys>>, SetArrayRequired<BaseType, Keys>>
 		: Simplify<
 		// Pick just the keys that are optional from the base type.
 			Except<BaseType, Keys>

--- a/source/split-on-rest-element.d.ts
+++ b/source/split-on-rest-element.d.ts
@@ -66,13 +66,8 @@ export type SplitOnRestElement<
 > =
 	Array_ extends unknown // For distributing `Array_`
 		? IfNotAnyOrNever<Array_, {
-			ifNot: _SplitOnRestElement<
-				Array_,
-				ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>
-			>;
-		}> extends infer Result extends UnknownArray
-			? If<IsArrayReadonly<Array_>, Readonly<Result>, Result>
-			: never // Should never happen
+			ifNot: If<IsArrayReadonly<Array_>, Readonly<_SplitOnRestElement<Array_, ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>>>, _SplitOnRestElement<Array_, ApplyDefaultOptions<SplitOnRestElementOptions, DefaultSplitOnRestElementOptions, Options>>>;
+		}>
 		: never; // Should never happen
 
 /**

--- a/source/sum.d.ts
+++ b/source/sum.d.ts
@@ -75,8 +75,6 @@ type SumPostChecks<A extends number, B extends number, AreNegative = [IsNegative
 Adds two positive numbers.
 */
 type SumPositives<A extends number, B extends number> =
-	[...TupleOf<A>, ...TupleOf<B>]['length'] extends infer Result extends number
-		? Result
-		: never;
+	[...TupleOf<A>, ...TupleOf<B>]['length'] & number;
 
 export {};


### PR DESCRIPTION
### Description

This PR removes the redundant `extends infer Result` workaround from several types. 

Previously, this pattern was used to bypass circular dependency checks and inference limitations in older versions of TypeScript (e.g. `extends infer Result ? ... : never`). With modern TypeScript's improved conditional type evaluation, these workarounds are no longer necessary and can be safely inlined to simplify the type definitions.

Changes were made to:
- `ArrayReverse`
- `ArrayTail`
- `_SplitOnRestElement`
- `_SetRequired`
- `SumPositives`

*(Note: `UnionToTuple` was intentionally left as-is, as the compiler still requires the explicit nudge there to guarantee an array return type during deep recursion).*

### Linked Issues

Fixes #1142