### PR TITLE
`IsLiteral*`: Fix behavior with unions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,13 +127,11 @@ export type {UnionToTuple} from './source/union-to-tuple.d.ts';
 export type {IntRange} from './source/int-range.d.ts';
 export type {IntClosedRange} from './source/int-closed-range.d.ts';
 export type {IsEqual} from './source/is-equal.d.ts';
-export type {
-	IsLiteral,
-	IsStringLiteral,
-	IsNumericLiteral,
-	IsBooleanLiteral,
-	IsSymbolLiteral,
-} from './source/is-literal.d.ts';
+export type {IsLiteral} from './source/is-literal.d.ts';
+export type {IsStringLiteral} from './source/is-string-literal.d.ts';
+export type {IsNumericLiteral} from './source/is-numeric-literal.d.ts';
+export type {IsBooleanLiteral} from './source/is-boolean-literal.d.ts';
+export type {IsSymbolLiteral} from './source/is-symbol-literal.d.ts';
 export type {IsAny} from './source/is-any.d.ts';
 export type {IfAny} from './source/if-any.d.ts';
 export type {IsNever} from './source/is-never.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -215,10 +215,10 @@ Click the type names for complete docs.
 
 - [`If`](source/if.d.ts) - An if-else-like type that resolves depending on whether the given `boolean` type is `true` or `false`.
 - [`IsLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsStringLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsNumericLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsBooleanLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-- [`IsSymbolLiteral`](source/is-literal.d.ts) - Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsStringLiteral`](source/is-string-literal.d.ts) - Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsNumericLiteral`](source/is-numeric-literal.d.ts) - Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsBooleanLiteral`](source/is-boolean-literal.d.ts) - Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+- [`IsSymbolLiteral`](source/is-symbol-literal.d.ts) - Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
 - [`IsAny`](source/is-any.d.ts) - Returns a boolean for whether the given type is `any`.
 - [`IsNever`](source/is-never.d.ts) - Returns a boolean for whether the given type is `never`.
 - [`IsUnknown`](source/is-unknown.d.ts) - Returns a boolean for whether the given type is `unknown`.

--- a/source/delimiter-case.d.ts
+++ b/source/delimiter-case.d.ts
@@ -1,5 +1,5 @@
 import type {ApplyDefaultOptions, AsciiPunctuation, StartsWith} from './internal/index.d.ts';
-import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
 import type {Merge} from './merge.d.ts';
 import type {_DefaultWordsOptions, Words, WordsOptions} from './words.d.ts';
 

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -7,8 +7,9 @@ import type {IsAny} from '../is-any.d.ts';
 import type {If} from '../if.d.ts';
 import type {IsNever} from '../is-never.d.ts';
 import type {StringToNumber} from '../string-to-number.d.ts';
+import type {Primitive} from '../primitive.d.ts';
 import type {FilterDefinedKeys, FilterOptionalKeys} from './keys.d.ts';
-import type {MapsSetsOrArrays, NonRecursiveType} from './type.d.ts';
+import type {IfNotAnyOrNever, MapsSetsOrArrays, NonRecursiveType} from './type.d.ts';
 import type {ToString} from './string.d.ts';
 
 /**
@@ -273,6 +274,29 @@ export type CollapseLiterals<T> = {} extends T
 	: T extends infer U & {}
 		? U
 		: T;
+
+/**
+Returns the base type of a branded type.
+
+@example
+```
+type Brand = {readonly __brand: unique symbol};
+
+type A = UnwrapBrand<string & Brand>;
+//=> string
+
+type B = UnwrapBrand<number & Brand>;
+//=> number
+
+type C = UnwrapBrand<(1 | 200n | 'foo' | 'bar') & Brand>;
+//=> 1 | 200n | 'foo' | 'bar'
+```
+*/
+export type UnwrapBrand<T extends Primitive> = IfNotAnyOrNever<T, {ifNot: _UnwrapBrand<T, Primitive>}>;
+
+type _UnwrapBrand<T, Base> = T extends infer U & Pick<T, Exclude<keyof T, KeysOfUnion<Base>>>
+	? U
+	: never;
 
 /**
 Normalize keys by including string and number representations wherever applicable.

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -288,15 +288,20 @@ type A = UnwrapBrand<string & Brand>;
 type B = UnwrapBrand<number & Brand>;
 //=> number
 
-type C = UnwrapBrand<(1 | 200n | 'foo' | 'bar') & Brand>;
+type C = UnwrapBrand<PropertyKey & Brand>;
+//=> PropertyKey
+
+type D = UnwrapBrand<(1 | 200n | 'foo' | 'bar') & Brand>;
 //=> 1 | 200n | 'foo' | 'bar'
 ```
 */
-export type UnwrapBrand<T extends Primitive> = IfNotAnyOrNever<T, {ifNot: _UnwrapBrand<T, Primitive>}>;
+export type UnwrapBrand<T> = IfNotAnyOrNever<T, {ifNot: _UnwrapBrand<T, Primitive>}>;
 
-type _UnwrapBrand<T, Base> = T extends infer U & Pick<T, Exclude<keyof T, KeysOfUnion<Base>>>
-	? U
-	: never;
+type _UnwrapBrand<T, Base> = T extends Primitive
+	? T extends infer U & Pick<T, Exclude<keyof T, KeysOfUnion<Base>>>
+		? U
+		: never
+	: T;
 
 /**
 Normalize keys by including string and number representations wherever applicable.

--- a/source/internal/object.d.ts
+++ b/source/internal/object.d.ts
@@ -300,7 +300,7 @@ export type UnwrapBrand<T> = IfNotAnyOrNever<T, {ifNot: _UnwrapBrand<T, Primitiv
 type _UnwrapBrand<T, Base> = T extends Primitive
 	? T extends infer U & Pick<T, Exclude<keyof T, KeysOfUnion<Base>>>
 		? U
-		: never
+		: T
 	: T;
 
 /**

--- a/source/is-boolean-literal.d.ts
+++ b/source/is-boolean-literal.d.ts
@@ -1,4 +1,5 @@
-import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {CollapseLiterals} from './internal/object.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**

--- a/source/is-boolean-literal.d.ts
+++ b/source/is-boolean-literal.d.ts
@@ -1,6 +1,5 @@
-import type {CollapseLiterals} from './internal/object.d.ts';
+import type {CollapseLiterals, UnwrapBrand} from './internal/object.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**
 Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
@@ -26,7 +25,7 @@ type D = IsBooleanLiteral<true | false>;
 @category Utilities
 */
 export type IsBooleanLiteral<T> = IfNotAnyOrNever<T, {
-	ifNot: _IsBooleanLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifNot: _IsBooleanLiteral<CollapseLiterals<UnwrapBrand<T>>>;
 	ifAny: false;
 	ifNever: false;
 }>;

--- a/source/is-boolean-literal.d.ts
+++ b/source/is-boolean-literal.d.ts
@@ -1,0 +1,39 @@
+import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
+
+/**
+Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsBooleanLiteral} from 'type-fest';
+
+type A = IsBooleanLiteral<true>;
+//=> true
+
+type B = IsBooleanLiteral<false>;
+//=> true
+
+type C = IsBooleanLiteral<boolean>;
+//=> false
+
+type D = IsBooleanLiteral<true | false>;
+//=> false
+```
+
+@category Type Guard
+@category Utilities
+*/
+export type IsBooleanLiteral<T> = IfNotAnyOrNever<T, {
+	ifNot: _IsBooleanLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifAny: false;
+	ifNever: false;
+}>;
+
+type _IsBooleanLiteral<T> = boolean extends T
+	? false
+	: T extends boolean
+		? true
+		: false;
+
+export {};

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -35,9 +35,8 @@ type F = IsLiteral<string>;
 type G = IsLiteral<`on${string}`>;
 //=> false
 
-declare const sym1: unique symbol;
-
-type H = IsLiteral<typeof sym1>;
+declare const symbolLiteral: unique symbol;
+type H = IsLiteral<typeof symbolLiteral>;
 //=> true
 
 type I = IsLiteral<symbol>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -4,8 +4,7 @@ import type {IsBooleanLiteral} from './is-boolean-literal.d.ts';
 import type {IsSymbolLiteral} from './is-symbol-literal.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {CollapseLiterals} from './internal/object.d.ts';
-import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
+import type {CollapseLiterals, UnwrapBrand} from './internal/object.d.ts';
 
 /**
 Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
@@ -65,7 +64,7 @@ type O = IsLiteral<1000n | string | true>;
 @category Utilities
 */
 export type IsLiteral<T> = IfNotAnyOrNever<T, {
-	ifNot: _IsLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifNot: _IsLiteral<CollapseLiterals<UnwrapBrand<T>>>;
 	ifAny: false;
 	ifNever: false;
 }>;

--- a/source/is-literal.d.ts
+++ b/source/is-literal.d.ts
@@ -1,271 +1,14 @@
-import type {Primitive} from './primitive.d.ts';
-import type {_Numeric} from './numeric.d.ts';
-import type {CollapseLiterals, IfNotAnyOrNever, IsNotFalse, IsPrimitive} from './internal/index.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
+import type {IsNumericLiteral} from './is-numeric-literal.d.ts';
+import type {IsBooleanLiteral} from './is-boolean-literal.d.ts';
+import type {IsSymbolLiteral} from './is-symbol-literal.d.ts';
 import type {IsNever} from './is-never.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
+import type {CollapseLiterals} from './internal/object.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**
-Returns a boolean for whether the given type `T` is the specified `LiteralType`.
-
-@link https://stackoverflow.com/a/52806744/10292952
-
-@example
-```
-type A = LiteralCheck<1, number>;
-//=> true
-
-type B = LiteralCheck<number, number>;
-//=> false
-
-type C = LiteralCheck<1, string>;
-//=> false
-```
-*/
-type LiteralCheck<T, LiteralType extends Primitive> = (
-	IsNever<T> extends false // Must be wider than `never`
-		? [T] extends [LiteralType & infer U] // Remove any branding
-			? [U] extends [LiteralType] // Must be narrower than `LiteralType`
-				? [LiteralType] extends [U] // Cannot be wider than `LiteralType`
-					? false
-					: true
-				: false
-			: false
-		: false
-);
-
-/**
-Returns a boolean for whether the given type `T` is one of the specified literal types in `LiteralUnionType`.
-
-@example
-```
-type A = LiteralChecks<1, Numeric>;
-//=> true
-
-type B = LiteralChecks<1n, Numeric>;
-//=> true
-
-type C = LiteralChecks<bigint, Numeric>;
-//=> false
-```
-*/
-type LiteralChecks<T, LiteralUnionType> = (
-	// Conditional type to force union distribution.
-	// If `T` is none of the literal types in the union `LiteralUnionType`, then `LiteralCheck<T, LiteralType>` will evaluate to `false` for the whole union.
-	// If `T` is one of the literal types in the union, it will evaluate to `boolean` (i.e. `true | false`)
-	IsNotFalse<LiteralUnionType extends Primitive
-		? LiteralCheck<T, LiteralUnionType>
-		: never
-	>
-);
-
-/**
-Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-
-Useful for:
-	- providing strongly-typed string manipulation functions
-	- constraining strings to be a string literal
-	- type utilities, such as when constructing parsers and ASTs
-
-The implementation of this type is inspired by the trick mentioned in this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747).
-
-@example
-```
-import type {IsStringLiteral} from 'type-fest';
-
-type CapitalizedString<T extends string> = IsStringLiteral<T> extends true ? Capitalize<T> : string;
-
-// https://github.com/yankeeinlondon/native-dash/blob/master/src/capitalize.ts
-function capitalize<T extends Readonly<string>>(input: T): CapitalizedString<T> {
-	return (input.slice(0, 1).toUpperCase() + input.slice(1)) as CapitalizedString<T>;
-}
-
-const output = capitalize('hello, world!');
-//=> 'Hello, world!'
-```
-
-@example
-```
-// String types with infinite set of possible values return `false`.
-
-import type {IsStringLiteral} from 'type-fest';
-
-type AllUppercaseStrings = IsStringLiteral<Uppercase<string>>;
-//=> false
-
-type StringsStartingWithOn = IsStringLiteral<`on${string}`>;
-//=> false
-
-// This behaviour is particularly useful in string manipulation utilities, as infinite string types often require separate handling.
-
-type Length<S extends string, Counter extends never[] = []> =
-	IsStringLiteral<S> extends false
-		? number // return `number` for infinite string types
-		: S extends `${string}${infer Tail}`
-			? Length<Tail, [...Counter, never]>
-			: Counter['length'];
-
-type L1 = Length<Lowercase<string>>;
-//=> number
-
-type L2 = Length<`${number}`>;
-//=> number
-```
-
-@category Type Guard
-@category Utilities
-*/
-export type IsStringLiteral<S> = IfNotAnyOrNever<S, {
-	ifNot: _IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>;
-	ifAny: false;
-	ifNever: false;
-}>;
-
-export type _IsStringLiteral<S> =
-// If `T` is an infinite string type (e.g., `on${string}`), `Record<T, never>` produces an index signature,
-// and since `{}` extends index signatures, the result becomes `false`.
-	S extends string
-		? {} extends Record<S, never>
-			? false
-			: true
-		: false;
-
-/**
-Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-
-Useful for:
-	- providing strongly-typed functions when given literal arguments
-	- type utilities, such as when constructing parsers and ASTs
-
-@example
-```
-import type {IsNumericLiteral, IsStringLiteral} from 'type-fest';
-
-// https://github.com/inocan-group/inferred-types/blob/master/modules/types/src/boolean-logic/operators/EndsWith.ts
-type EndsWith<TValue, TEndsWith extends string> =
-	TValue extends string
-		? IsStringLiteral<TEndsWith> extends true
-			? IsStringLiteral<TValue> extends true
-				? TValue extends `${string}${TEndsWith}`
-					? true
-					: false
-				: boolean
-			: boolean
-		: TValue extends number
-			? IsNumericLiteral<TValue> extends true
-				? EndsWith<`${TValue}`, TEndsWith>
-				: false
-			: false;
-
-function endsWith<Input extends string | number, End extends string>(input: Input, end: End) {
-	return `${input}`.endsWith(end) as EndsWith<Input, End>;
-}
-
-endsWith('abc', 'c');
-//=> true
-
-endsWith(123_456, '456');
-//=> true
-
-const end = '123' as string;
-
-endsWith('abc123', end);
-//=> boolean
-```
-
-@category Type Guard
-@category Utilities
-*/
-export type IsNumericLiteral<T> = LiteralChecks<T, _Numeric>;
-
-/**
-Returns a boolean for whether the given type is a `true` or `false` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-
-Useful for:
-	- providing strongly-typed functions when given literal arguments
-	- type utilities, such as when constructing parsers and ASTs
-
-@example
-```
-import type {IsBooleanLiteral} from 'type-fest';
-
-const id = 123;
-
-type GetId<AsString extends boolean> =
-	IsBooleanLiteral<AsString> extends true
-		? AsString extends true
-			? `${typeof id}`
-			: typeof id
-		: number | string;
-
-function getId<AsString extends boolean = false>(options?: {asString: AsString}) {
-	return (options?.asString ? `${id}` : id) as GetId<AsString>;
-}
-
-const numberId = getId();
-//=> 123
-
-const stringId = getId({asString: true});
-//=> '123'
-
-declare const runtimeBoolean: boolean;
-const eitherId = getId({asString: runtimeBoolean});
-//=> string | number
-```
-
-@category Type Guard
-@category Utilities
-*/
-export type IsBooleanLiteral<T> = LiteralCheck<T, boolean>;
-
-/**
-Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-
-Useful for:
-	- providing strongly-typed functions when given literal arguments
-	- type utilities, such as when constructing parsers and ASTs
-
-@example
-```
-import type {IsSymbolLiteral} from 'type-fest';
-
-type Get<Object_ extends Record<symbol, number>, Key extends keyof Object_> =
-	IsSymbolLiteral<Key> extends true
-		? Object_[Key]
-		: number;
-
-function get<Object_ extends Record<symbol, number>, Key extends keyof Object_>(o: Object_, key: Key) {
-	return o[key] as Get<Object_, Key>;
-}
-
-const symbolLiteral = Symbol('literal');
-let symbolValue = Symbol('value1');
-symbolValue = Symbol('value2');
-
-get({[symbolLiteral]: 1} as const, symbolLiteral);
-//=> 1
-
-get({[symbolValue]: 1} as const, symbolValue);
-//=> number
-```
-
-@category Type Guard
-@category Utilities
-*/
-export type IsSymbolLiteral<T> = LiteralCheck<T, symbol>;
-
-/** Helper type for `IsLiteral`. */
-type IsLiteralUnion<T> =
-	| IsStringLiteral<T>
-	| IsNumericLiteral<T>
-	| IsBooleanLiteral<T>
-	| IsSymbolLiteral<T>;
-
-/**
 Returns a boolean for whether the given type is a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
-
-Useful for:
-	- providing strongly-typed functions when given literal arguments
-	- type utilities, such as when constructing parsers and ASTs
 
 @example
 ```
@@ -292,8 +35,9 @@ type F = IsLiteral<string>;
 type G = IsLiteral<`on${string}`>;
 //=> false
 
-declare const symbolLiteral: unique symbol;
-type H = IsLiteral<typeof symbolLiteral>;
+declare const sym1: unique symbol;
+
+type H = IsLiteral<typeof sym1>;
 //=> true
 
 type I = IsLiteral<symbol>;
@@ -302,16 +46,48 @@ type I = IsLiteral<symbol>;
 type J = IsLiteral<true>;
 //=> true
 
-type K = IsLiteral<boolean>;
+type K = IsLiteral<false>;
+//=> true
+
+type L = IsLiteral<boolean>;
 //=> false
+
+type M = IsLiteral<1 | 'foo' | false>;
+//=> true
+
+type N = IsLiteral<string | number | symbol>;
+//=> false
+
+type O = IsLiteral<1000n | string | true>;
+//=> boolean
 ```
 
 @category Type Guard
 @category Utilities
 */
-export type IsLiteral<T> =
-	IsPrimitive<T> extends true
-		? IsNotFalse<IsLiteralUnion<T>>
-		: false;
+export type IsLiteral<T> = IfNotAnyOrNever<T, {
+	ifNot: _IsLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifAny: false;
+	ifNever: false;
+}>;
+
+type _IsLiteral<T> =
+	| (Extract<T, boolean> extends infer Bools
+		// We can't instantiate `IsBooleanLiteral` with `never`,
+		// because that will add an extraneous `false` to the result if there are no booleans.
+		? IsNever<Bools> extends true
+			? never
+			: IsBooleanLiteral<Bools>
+		: never)
+	| (IsLiteralNonBools<Exclude<T, boolean>>);
+
+type IsLiteralNonBools<T> =
+	T extends number | bigint
+		? IsNumericLiteral<T>
+		: T extends string
+			? IsStringLiteral<T>
+			: T extends symbol
+				? IsSymbolLiteral<T>
+				: false;
 
 export {};

--- a/source/is-numeric-literal.d.ts
+++ b/source/is-numeric-literal.d.ts
@@ -1,0 +1,50 @@
+import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
+
+/**
+Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsNumericLiteral} from 'type-fest';
+
+type A = IsNumericLiteral<0>;
+//=> true
+
+type B = IsNumericLiteral<number>;
+//=> false
+
+type C = IsNumericLiteral<100n>;
+//=> true
+
+type D = IsNumericLiteral<bigint>;
+//=> false
+
+type E = IsNumericLiteral<1 | 2 | 10n | 20n>;
+//=> true
+
+type F = IsNumericLiteral<number | bigint>;
+//=> false
+
+type G = IsNumericLiteral<1 | bigint>;
+//=> boolean
+```
+
+@category Type Guard
+@category Utilities
+*/
+export type IsNumericLiteral<T> = IfNotAnyOrNever<T, {
+	ifNot: _IsNumericLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifAny: false;
+	ifNever: false;
+}>;
+
+export type _IsNumericLiteral<T> = T extends number | bigint
+	? number extends T
+		? false
+		: bigint extends T
+			? false
+			: true
+	: false;
+
+export {};

--- a/source/is-numeric-literal.d.ts
+++ b/source/is-numeric-literal.d.ts
@@ -1,4 +1,5 @@
-import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {CollapseLiterals} from './internal/object.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**

--- a/source/is-numeric-literal.d.ts
+++ b/source/is-numeric-literal.d.ts
@@ -39,7 +39,7 @@ export type IsNumericLiteral<T> = IfNotAnyOrNever<T, {
 	ifNever: false;
 }>;
 
-export type _IsNumericLiteral<T> = T extends number | bigint
+type _IsNumericLiteral<T> = T extends number | bigint
 	? number extends T
 		? false
 		: bigint extends T

--- a/source/is-numeric-literal.d.ts
+++ b/source/is-numeric-literal.d.ts
@@ -1,6 +1,5 @@
-import type {CollapseLiterals} from './internal/object.d.ts';
+import type {CollapseLiterals, UnwrapBrand} from './internal/object.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**
 Returns a boolean for whether the given type is a `number` or `bigint` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
@@ -35,7 +34,7 @@ type G = IsNumericLiteral<1 | bigint>;
 @category Utilities
 */
 export type IsNumericLiteral<T> = IfNotAnyOrNever<T, {
-	ifNot: _IsNumericLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifNot: _IsNumericLiteral<CollapseLiterals<UnwrapBrand<T>>>;
 	ifAny: false;
 	ifNever: false;
 }>;

--- a/source/is-string-literal.d.ts
+++ b/source/is-string-literal.d.ts
@@ -1,0 +1,73 @@
+import type {CollapseLiterals} from './internal/object.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
+import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
+
+/**
+Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+The implementation of this type is inspired by the trick mentioned in this [StackOverflow answer](https://stackoverflow.com/a/68261113/420747).
+
+@example
+```
+import type {IsStringLiteral} from 'type-fest';
+
+type A = IsStringLiteral<'foo'>;
+//=> true
+
+type B = IsStringLiteral<string>;
+//=> false
+
+// String types with infinite set of possible values return `false`
+type C = IsStringLiteral<`on${string}`>;
+//=> false
+
+type D = IsStringLiteral<Uppercase<string>>;
+//=> false
+
+type E = IsStringLiteral<'foo' | 'bar' | 'baz'>;
+//=> true
+
+type F = IsStringLiteral<'sm' | 'md' | 'lg' | `${number}px`>;
+//=> boolean
+```
+
+@example
+```
+import type {IsStringLiteral} from 'type-fest';
+
+type StringLength<S extends string, Counter extends never[] = []> =
+	IsStringLiteral<S> extends true
+		? S extends `${string}${infer Tail}`
+			? StringLength<Tail, [...Counter, never]>
+			: Counter['length']
+		: number; // return `number` for non-literal string types
+
+type L1 = StringLength<'foobar'>;
+//=> 6
+
+type L2 = StringLength<Lowercase<string>>;
+//=> number
+
+type L3 = StringLength<`${number}`>;
+//=> number
+```
+
+@category Type Guard
+@category Utilities
+*/
+export type IsStringLiteral<S> = IfNotAnyOrNever<S, {
+	ifNot: _IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>;
+	ifAny: false;
+	ifNever: false;
+}>;
+
+export type _IsStringLiteral<S> =
+	// If `S` is an infinite string type (e.g., `on${string}`), `Record<S, never>` produces an index signature,
+	// and since `{}` extends index signatures, the result becomes `false`.
+	S extends string
+		? {} extends Record<S, never>
+			? false
+			: true
+		: false;
+
+export {};

--- a/source/is-string-literal.d.ts
+++ b/source/is-string-literal.d.ts
@@ -61,7 +61,7 @@ export type IsStringLiteral<S> = IfNotAnyOrNever<S, {
 	ifNever: false;
 }>;
 
-export type _IsStringLiteral<S> =
+type _IsStringLiteral<S> =
 	// If `S` is an infinite string type (e.g., `on${string}`), `Record<S, never>` produces an index signature,
 	// and since `{}` extends index signatures, the result becomes `false`.
 	S extends string

--- a/source/is-string-literal.d.ts
+++ b/source/is-string-literal.d.ts
@@ -1,6 +1,5 @@
-import type {CollapseLiterals} from './internal/object.d.ts';
+import type {CollapseLiterals, UnwrapBrand} from './internal/object.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**
 Returns a boolean for whether the given type is a `string` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
@@ -56,7 +55,7 @@ type L3 = StringLength<`${number}`>;
 @category Utilities
 */
 export type IsStringLiteral<S> = IfNotAnyOrNever<S, {
-	ifNot: _IsStringLiteral<CollapseLiterals<S extends TagContainer<any> ? UnwrapTagged<S> : S>>;
+	ifNot: _IsStringLiteral<CollapseLiterals<UnwrapBrand<S>>>;
 	ifAny: false;
 	ifNever: false;
 }>;

--- a/source/is-symbol-literal.d.ts
+++ b/source/is-symbol-literal.d.ts
@@ -1,4 +1,5 @@
-import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {CollapseLiterals} from './internal/object.d.ts';
+import type {IfNotAnyOrNever} from './internal/type.d.ts';
 import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**

--- a/source/is-symbol-literal.d.ts
+++ b/source/is-symbol-literal.d.ts
@@ -1,6 +1,5 @@
-import type {CollapseLiterals} from './internal/object.d.ts';
+import type {CollapseLiterals, UnwrapBrand} from './internal/object.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
 
 /**
 Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
@@ -26,7 +25,7 @@ type C = IsSymbolLiteral<typeof symbolLiteral1 | typeof symbolLiteral2>;
 @category Utilities
 */
 export type IsSymbolLiteral<T> = IfNotAnyOrNever<T, {
-	ifNot: _IsSymbolLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifNot: _IsSymbolLiteral<CollapseLiterals<UnwrapBrand<T>>>;
 	ifAny: false;
 	ifNever: false;
 }>;

--- a/source/is-symbol-literal.d.ts
+++ b/source/is-symbol-literal.d.ts
@@ -8,16 +8,16 @@ Returns a boolean for whether the given type is a `symbol` [literal type](https:
 ```
 import type {IsSymbolLiteral} from 'type-fest';
 
-declare const sym1: unique symbol;
-declare const sym2: unique symbol;
+declare const symbolLiteral1: unique symbol;
+declare const symbolLiteral2: unique symbol;
 
-type A = IsSymbolLiteral<typeof sym1>;
+type A = IsSymbolLiteral<typeof symbolLiteral1>;
 //=> true
 
 type B = IsSymbolLiteral<symbol>;
 //=> false
 
-type C = IsSymbolLiteral<typeof sym1 | typeof sym2>;
+type C = IsSymbolLiteral<typeof symbolLiteral1 | typeof symbolLiteral2>;
 //=> true
 ```
 

--- a/source/is-symbol-literal.d.ts
+++ b/source/is-symbol-literal.d.ts
@@ -1,0 +1,39 @@
+import type {CollapseLiterals, IfNotAnyOrNever} from './internal/index.d.ts';
+import type {TagContainer, UnwrapTagged} from './tagged.d.ts';
+
+/**
+Returns a boolean for whether the given type is a `symbol` [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).
+
+@example
+```
+import type {IsSymbolLiteral} from 'type-fest';
+
+declare const sym1: unique symbol;
+declare const sym2: unique symbol;
+
+type A = IsSymbolLiteral<typeof sym1>;
+//=> true
+
+type B = IsSymbolLiteral<symbol>;
+//=> false
+
+type C = IsSymbolLiteral<typeof sym1 | typeof sym2>;
+//=> true
+```
+
+@category Type Guard
+@category Utilities
+*/
+export type IsSymbolLiteral<T> = IfNotAnyOrNever<T, {
+	ifNot: _IsSymbolLiteral<CollapseLiterals<T extends TagContainer<any> ? UnwrapTagged<T> : T>>;
+	ifAny: false;
+	ifNever: false;
+}>;
+
+type _IsSymbolLiteral<T> = T extends symbol
+	? symbol extends T
+		? false
+		: true
+	: false;
+
+export {};

--- a/source/remove-prefix.d.ts
+++ b/source/remove-prefix.d.ts
@@ -1,6 +1,6 @@
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, Not} from './internal/type.d.ts';
-import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {Or} from './or.d.ts';
 import type {If} from './if.d.ts';

--- a/source/remove-suffix.d.ts
+++ b/source/remove-suffix.d.ts
@@ -1,6 +1,6 @@
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever, Not} from './internal/type.d.ts';
-import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
 import type {IsNever} from './is-never.d.ts';
 import type {Or} from './or.d.ts';
 import type {If} from './if.d.ts';

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -1,6 +1,6 @@
 import type {And} from './and.d.ts';
 import type {ApplyDefaultOptions, Not} from './internal/index.d.ts';
-import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
 import type {Or} from './or.d.ts';
 
 /**

--- a/source/string-repeat.d.ts
+++ b/source/string-repeat.d.ts
@@ -1,4 +1,4 @@
-import type {IsNumericLiteral} from './is-literal.d.ts';
+import type {IsNumericLiteral} from './is-numeric-literal.d.ts';
 import type {IsNegative} from './numeric.d.ts';
 import type {DigitCharacter} from './characters.d.ts';
 

--- a/source/string-to-array.d.ts
+++ b/source/string-to-array.d.ts
@@ -1,6 +1,6 @@
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
-import type {IsStringLiteral} from './is-literal.d.ts';
+import type {IsStringLiteral} from './is-string-literal.d.ts';
 import type {Or} from './or.d.ts';
 
 /**

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -5,8 +5,7 @@ export type TagContainer<Token> = {
 	readonly [tag]: Token;
 };
 
-// eslint-disable-next-line type-fest/require-exported-types
-export type Tag<Token extends PropertyKey, TagMetadata> = TagContainer<{[K in Token]: TagMetadata}>;
+type Tag<Token extends PropertyKey, TagMetadata> = TagContainer<{[K in Token]: TagMetadata}>;
 
 /**
 Create a [tagged type](https://medium.com/@KevinBGreene/surviving-the-typescript-ecosystem-branding-and-type-tagging-6cf6e516523d) that can support [multiple tags](https://github.com/sindresorhus/type-fest/issues/665) and [per-tag metadata](https://medium.com/@ethanresnick/advanced-typescript-tagged-types-improved-with-type-level-metadata-5072fc125fcf).

--- a/source/tagged.d.ts
+++ b/source/tagged.d.ts
@@ -5,7 +5,8 @@ export type TagContainer<Token> = {
 	readonly [tag]: Token;
 };
 
-type Tag<Token extends PropertyKey, TagMetadata> = TagContainer<{[K in Token]: TagMetadata}>;
+// eslint-disable-next-line type-fest/require-exported-types
+export type Tag<Token extends PropertyKey, TagMetadata> = TagContainer<{[K in Token]: TagMetadata}>;
 
 /**
 Create a [tagged type](https://medium.com/@KevinBGreene/surviving-the-typescript-ecosystem-branding-and-type-tagging-6cf6e516523d) that can support [multiple tags](https://github.com/sindresorhus/type-fest/issues/665) and [per-tag metadata](https://medium.com/@ethanresnick/advanced-typescript-tagged-types-improved-with-type-level-metadata-5072fc125fcf).

--- a/test-d/internal/unwrap-brand.ts
+++ b/test-d/internal/unwrap-brand.ts
@@ -1,0 +1,49 @@
+import {expectType} from 'tsd';
+import type {UnwrapBrand} from '../../source/internal/object.d.ts';
+
+type Brand = {readonly __brand: unique symbol};
+declare const symbolLiteral: unique symbol;
+
+// Non-literal primitives
+expectType<string>({} as UnwrapBrand<string & Brand>);
+expectType<number>({} as UnwrapBrand<number & Brand>);
+expectType<bigint>({} as UnwrapBrand<bigint & Brand>);
+expectType<symbol>({} as UnwrapBrand<symbol & Brand>);
+expectType<boolean>({} as UnwrapBrand<boolean & Brand>);
+
+// Literal primitives
+expectType<'foo'>({} as UnwrapBrand<'foo' & Brand>);
+expectType<1>({} as UnwrapBrand<1 & Brand>);
+expectType<100n>({} as UnwrapBrand<100n & Brand>);
+expectType<typeof symbolLiteral>({} as UnwrapBrand<typeof symbolLiteral & Brand>);
+expectType<true>({} as UnwrapBrand<true & Brand>);
+expectType<false>({} as UnwrapBrand<false & Brand>);
+
+// Unions
+// All non-literals
+expectType<PropertyKey>({} as UnwrapBrand<PropertyKey & Brand>);
+expectType<number | bigint>({} as UnwrapBrand<(number | bigint) & Brand>);
+expectType<string | number | bigint | symbol | boolean>(
+	{} as UnwrapBrand<(string | number | bigint | symbol | boolean) & Brand>,
+);
+
+// All literals
+expectType<'a' | 'b'>({} as UnwrapBrand<('a' | 'b') & Brand>);
+expectType<1 | 2 | 3 | 4 | 5>({} as UnwrapBrand<(1 | 2 | 3 | 4 | 5) & Brand>);
+expectType<('foo' | 1 | 100n | typeof symbolLiteral | true)>(
+	{} as UnwrapBrand<('foo' | 1 | 100n | typeof symbolLiteral | true) & Brand>,
+);
+
+// Mix of non-literals and literals
+expectType<Uppercase<string> | 'foo' | 'bar'>({} as UnwrapBrand<(Uppercase<string> | 'foo' | 'bar') & Brand>);
+expectType<100 | 200 | 300 | bigint>({} as UnwrapBrand<(100 | 200 | 300 | bigint) & Brand>);
+expectType<(string | number | 5000n | typeof symbolLiteral)>(
+	{} as UnwrapBrand<(string | number | 5000n | typeof symbolLiteral) & Brand>,
+);
+expectType<('foo' | 0.5 | bigint | symbol | boolean)>(
+	{} as UnwrapBrand<('foo' | 0.5 | bigint | symbol | boolean) & Brand>,
+);
+
+// Edge cases
+expectType<any>({} as UnwrapBrand<any>);
+expectType<never>({} as UnwrapBrand<never>);

--- a/test-d/internal/unwrap-brand.ts
+++ b/test-d/internal/unwrap-brand.ts
@@ -4,14 +4,14 @@ import type {UnwrapBrand} from '../../source/internal/object.d.ts';
 type Brand = {readonly __brand: unique symbol};
 declare const symbolLiteral: unique symbol;
 
-// Non-literal primitives
+// Non-literals
 expectType<string>({} as UnwrapBrand<string & Brand>);
 expectType<number>({} as UnwrapBrand<number & Brand>);
 expectType<bigint>({} as UnwrapBrand<bigint & Brand>);
 expectType<symbol>({} as UnwrapBrand<symbol & Brand>);
 expectType<boolean>({} as UnwrapBrand<boolean & Brand>);
 
-// Literal primitives
+// Literals
 expectType<'foo'>({} as UnwrapBrand<'foo' & Brand>);
 expectType<1>({} as UnwrapBrand<1 & Brand>);
 expectType<100n>({} as UnwrapBrand<100n & Brand>);
@@ -33,10 +33,12 @@ expectType<typeof symbolLiteral>({} as UnwrapBrand<typeof symbolLiteral>);
 expectType<true>({} as UnwrapBrand<true>);
 expectType<false>({} as UnwrapBrand<false>);
 
-// Non-primitives
+// Non-primitives, `null` & `undefined`
 expectType<object>({} as UnwrapBrand<object>);
 expectType<{foo: string}>({} as UnwrapBrand<{foo: string}>);
 expectType<(() => string) & Brand>({} as UnwrapBrand<(() => string) & Brand>);
+expectType<null>({} as any as UnwrapBrand<null>);
+expectType<undefined>({} as any as UnwrapBrand<undefined>);
 
 // Unions
 // All non-literals

--- a/test-d/internal/unwrap-brand.ts
+++ b/test-d/internal/unwrap-brand.ts
@@ -19,6 +19,25 @@ expectType<typeof symbolLiteral>({} as UnwrapBrand<typeof symbolLiteral & Brand>
 expectType<true>({} as UnwrapBrand<true & Brand>);
 expectType<false>({} as UnwrapBrand<false & Brand>);
 
+// Non-branded types
+expectType<string>({} as UnwrapBrand<string>);
+expectType<number>({} as UnwrapBrand<number>);
+expectType<bigint>({} as UnwrapBrand<bigint>);
+expectType<symbol>({} as UnwrapBrand<symbol>);
+expectType<boolean>({} as UnwrapBrand<boolean>);
+
+expectType<'foo'>({} as UnwrapBrand<'foo'>);
+expectType<1>({} as UnwrapBrand<1>);
+expectType<100n>({} as UnwrapBrand<100n>);
+expectType<typeof symbolLiteral>({} as UnwrapBrand<typeof symbolLiteral>);
+expectType<true>({} as UnwrapBrand<true>);
+expectType<false>({} as UnwrapBrand<false>);
+
+// Non-primitives
+expectType<object>({} as UnwrapBrand<object>);
+expectType<{foo: string}>({} as UnwrapBrand<{foo: string}>);
+expectType<(() => string) & Brand>({} as UnwrapBrand<(() => string) & Brand>);
+
 // Unions
 // All non-literals
 expectType<PropertyKey>({} as UnwrapBrand<PropertyKey & Brand>);
@@ -42,6 +61,14 @@ expectType<(string | number | 5000n | typeof symbolLiteral)>(
 );
 expectType<('foo' | 0.5 | bigint | symbol | boolean)>(
 	{} as UnwrapBrand<('foo' | 0.5 | bigint | symbol | boolean) & Brand>,
+);
+
+// Mix of non-literals, literals, and non-primitives
+expectType<(string | number | ({foo: string} & Brand))>(
+	{} as UnwrapBrand<(string | number | {foo: string}) & Brand>,
+);
+expectType<('foo' | number | 100n | typeof symbolLiteral | boolean | ({foo: string} & Brand))>(
+	{} as UnwrapBrand<('foo' | number | 100n | typeof symbolLiteral | boolean | {foo: string}) & Brand>,
 );
 
 // Edge cases

--- a/test-d/internal/unwrap-brand.ts
+++ b/test-d/internal/unwrap-brand.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import type {UnwrapBrand} from '../../source/internal/object.d.ts';
+import type {Opaque, Tagged} from '../../source/tagged.d.ts';
 
 type Brand = {readonly __brand: unique symbol};
 declare const symbolLiteral: unique symbol;
@@ -72,6 +73,31 @@ expectType<(string | number | ({foo: string} & Brand))>(
 expectType<('foo' | number | 100n | typeof symbolLiteral | boolean | ({foo: string} & Brand))>(
 	{} as UnwrapBrand<('foo' | number | 100n | typeof symbolLiteral | boolean | {foo: string}) & Brand>,
 );
+
+// Types built using `Opaque`
+expectType<string | number | bigint | symbol | boolean>(
+	{} as UnwrapBrand<Opaque<string | number | bigint | symbol | boolean, 'Tag'>>,
+);
+expectType<'foo' | 1 | 100n | typeof symbolLiteral | true>(
+	{} as UnwrapBrand<Opaque<'foo' | 1 | 100n | typeof symbolLiteral | true, 'Tag'>>,
+);
+
+// Types built using `Tagged`
+expectType<string | number | bigint | symbol | boolean>(
+	{} as UnwrapBrand<Tagged<string | number | bigint | symbol | boolean, 'Tag'>>,
+);
+expectType<'foo' | 1 | 100n | typeof symbolLiteral | true>(
+	{} as UnwrapBrand<Tagged<'foo' | 1 | 100n | typeof symbolLiteral | true, 'Tag'>>,
+);
+
+// Mix
+expectType<string | number | 900n | typeof symbolLiteral | true | {foo: string}>(
+	{} as UnwrapBrand<
+		| ((string | number) & Brand)
+		| Tagged<900n | typeof symbolLiteral, 'Tag'>
+		| Opaque<true, 'Tag'>
+		| {foo: string}
+	>);
 
 // Edge cases
 expectType<any>({} as UnwrapBrand<any>);

--- a/test-d/is-boolean-literal.ts
+++ b/test-d/is-boolean-literal.ts
@@ -1,0 +1,56 @@
+import {expectType} from 'tsd';
+import type {IsBooleanLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+
+// Literals
+expectType<IsBooleanLiteral<false>>(true);
+expectType<IsBooleanLiteral<true>>(true);
+
+// Non-literals
+expectType<IsBooleanLiteral<boolean>>(false);
+
+// Non-booleans
+expectType<IsBooleanLiteral<string>>(false);
+expectType<IsBooleanLiteral<number>>(false);
+
+// Unions
+// All boolean literals
+expectType<IsBooleanLiteral<true | false>>(false);
+
+// All non-booleans
+expectType<IsBooleanLiteral<string | 1 | 2 | null>>(false);
+
+// Boolean literals and non-booleans
+expectType<IsBooleanLiteral<false | string | 1n>>({} as boolean);
+expectType<IsBooleanLiteral<null | undefined | true>>({} as boolean);
+
+// Boolean non-literals and non-booleans
+expectType<IsBooleanLiteral<boolean | string | bigint>>(false);
+expectType<IsBooleanLiteral<boolean | 100n | 'foo' | 'bar' | null>>(false);
+
+// Boundary types
+expectType<IsBooleanLiteral<any>>(false);
+expectType<IsBooleanLiteral<unknown>>(false);
+expectType<IsBooleanLiteral<never>>(false);
+
+// Tagged types
+// Literals
+expectType<IsBooleanLiteral<Tagged<true, 'Tag'>>>(true);
+expectType<IsBooleanLiteral<Tagged<false, 'Tag'>>>(true);
+// Non-literals
+expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'>>>(false);
+// Non-booleans
+expectType<IsBooleanLiteral<Tagged<string, 'Tag'>>>(false);
+// Literals and non-booleans
+expectType<IsBooleanLiteral<Tagged<true | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-booleans
+expectType<IsBooleanLiteral<Tagged<boolean | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'> | Tagged<string, 'Tag'>>>(false);
+expectType<IsBooleanLiteral<Tagged<true, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
+expectType<IsBooleanLiteral<Tagged<true, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Uncollapsed unions
+expectType<IsBooleanLiteral<true | 1 | 2 | (number & {})>>({} as boolean);
+expectType<IsBooleanLiteral<LiteralUnion<1 | 2 | false, number>>>({} as boolean);
+expectType<IsBooleanLiteral<LiteralUnion<'foo' | 'bar', string>>>(false);
+expectType<IsBooleanLiteral<Tagged<LiteralUnion<false | 'a' | 'b', string>, 'Tag'>>>({} as boolean);

--- a/test-d/is-boolean-literal.ts
+++ b/test-d/is-boolean-literal.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import type {IsBooleanLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+import type {IsBooleanLiteral} from '../source/is-boolean-literal.d.ts';
+import type {Tagged} from '../source/tagged.d.ts';
+import type {LiteralUnion} from '../source/literal-union.d.ts';
 
 // Literals
 expectType<IsBooleanLiteral<true>>(true);

--- a/test-d/is-boolean-literal.ts
+++ b/test-d/is-boolean-literal.ts
@@ -2,8 +2,8 @@ import {expectType} from 'tsd';
 import type {IsBooleanLiteral, Tagged, LiteralUnion} from '../index.d.ts';
 
 // Literals
-expectType<IsBooleanLiteral<false>>(true);
 expectType<IsBooleanLiteral<true>>(true);
+expectType<IsBooleanLiteral<false>>(true);
 
 // Non-literals
 expectType<IsBooleanLiteral<boolean>>(false);

--- a/test-d/is-boolean-literal.ts
+++ b/test-d/is-boolean-literal.ts
@@ -1,6 +1,6 @@
 import {expectType} from 'tsd';
 import type {IsBooleanLiteral} from '../source/is-boolean-literal.d.ts';
-import type {Tagged} from '../source/tagged.d.ts';
+import type {Opaque, Tagged} from '../source/tagged.d.ts';
 import type {LiteralUnion} from '../source/literal-union.d.ts';
 
 // Literals
@@ -50,6 +50,42 @@ expectType<IsBooleanLiteral<Tagged<boolean | string, 'Tag'>>>({} as false);
 expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'> | Tagged<string, 'Tag'>>>(false);
 expectType<IsBooleanLiteral<Tagged<true, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
 expectType<IsBooleanLiteral<Tagged<true, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Opaque types
+// Literals
+expectType<IsBooleanLiteral<Opaque<true, 'Tag'>>>(true);
+expectType<IsBooleanLiteral<Opaque<false, 'Tag'>>>(true);
+// Non-literals
+expectType<IsBooleanLiteral<Opaque<boolean, 'Tag'>>>(false);
+// Non-booleans
+expectType<IsBooleanLiteral<Opaque<string, 'Tag'>>>(false);
+// Literals and non-booleans
+expectType<IsBooleanLiteral<Opaque<true | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-booleans
+expectType<IsBooleanLiteral<Opaque<boolean | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsBooleanLiteral<Opaque<boolean, 'Tag'> | Opaque<string, 'Tag'>>>(false);
+expectType<IsBooleanLiteral<Opaque<true, 'Tag'> | Opaque<string, 'Tag'>>>({} as boolean);
+expectType<IsBooleanLiteral<Opaque<true, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Branded types
+type Brand = {readonly __brand: unique symbol};
+
+// Literals
+expectType<IsBooleanLiteral<true & Brand>>(true);
+expectType<IsBooleanLiteral<false & Brand>>(true);
+// Non-literals
+expectType<IsBooleanLiteral<boolean & Brand>>(false);
+// Non-booleans
+expectType<IsBooleanLiteral<string & Brand>>(false);
+// Literals and non-booleans
+expectType<IsBooleanLiteral<(true | string) & Brand>>({} as boolean);
+// Non-literals and non-booleans
+expectType<IsBooleanLiteral<(boolean | string) & Brand>>({} as false);
+// Unions
+expectType<IsBooleanLiteral<(boolean & Brand) | (string & Brand)>>(false);
+expectType<IsBooleanLiteral<(true & Brand) | (string & Brand)>>({} as boolean);
+expectType<IsBooleanLiteral<(true & Brand) | string>>({} as boolean); // Branded and untagged
 
 // Uncollapsed unions
 expectType<IsBooleanLiteral<true | 1 | 2 | (number & {})>>({} as boolean);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import type {IsLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+import type {IsLiteral} from '../source/is-literal.d.ts';
+import type {LiteralUnion} from '../source/literal-union.d.ts';
+import type {Tagged} from '../source/tagged.d.ts';
 
 declare const symbolLiteral: unique symbol;
 

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import type {IsLiteral} from '../source/is-literal.d.ts';
 import type {LiteralUnion} from '../source/literal-union.d.ts';
-import type {Tagged} from '../source/tagged.d.ts';
+import type {Opaque, Tagged} from '../source/tagged.d.ts';
 
 declare const symbolLiteral: unique symbol;
 
@@ -91,6 +91,40 @@ expectType<IsLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
 expectType<IsLiteral<Tagged<'foo', 'Tag'> | Tagged<bigint, 'Tag'>>>({} as boolean);
 expectType<IsLiteral<Tagged<'foo', 'Tag'> | number>>({} as boolean);
 expectType<IsLiteral<Tagged<symbol, 'Tag'> | 'foo'>>({} as boolean);
+
+// Opaque types
+// Literals
+expectType<IsLiteral<Opaque<'foo' | 'bar' | 1n | typeof symbolLiteral | false, 'Tag'>>>(true);
+// Non-literals
+expectType<IsLiteral<Opaque<string | number | symbol, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsLiteral<Opaque<'foo' | 'bar' | number, 'Tag'>>>({} as boolean);
+expectType<IsLiteral<Opaque<0 | '' | boolean, 'Tag'>>>({} as boolean);
+
+// Unions
+expectType<IsLiteral<Opaque<'foo', 'Tag'> | Opaque<1, 'Tag'>>>(true);
+expectType<IsLiteral<Opaque<string, 'Tag'> | Opaque<number, 'Tag'>>>(false);
+expectType<IsLiteral<Opaque<'foo', 'Tag'> | Opaque<bigint, 'Tag'>>>({} as boolean);
+expectType<IsLiteral<Opaque<'foo', 'Tag'> | number>>({} as boolean);
+expectType<IsLiteral<Opaque<symbol, 'Tag'> | 'foo'>>({} as boolean);
+
+// Branded types
+type Brand = {readonly __brand: unique symbol};
+
+// Literals
+expectType<IsLiteral<('foo' | 'bar' | 1n | typeof symbolLiteral | false) & Brand>>(true);
+// Non-literals
+expectType<IsLiteral<(string | number | symbol) & Brand>>(false);
+// Literals and non-literals
+expectType<IsLiteral<('foo' | 'bar' | number) & Brand>>({} as boolean);
+expectType<IsLiteral<(0 | '' | boolean) & Brand>>({} as boolean);
+
+// Unions
+expectType<IsLiteral<('foo' & Brand) | (1 & Brand)>>(true);
+expectType<IsLiteral<(string & Brand) | (number & Brand)>>(false);
+expectType<IsLiteral<('foo' & Brand) | (bigint & Brand)>>({} as boolean);
+expectType<IsLiteral<('foo' & Brand) | number>>({} as boolean);
+expectType<IsLiteral<(symbol & Brand) | 'foo'>>({} as boolean);
 
 // Uncollapsed unions
 expectType<IsLiteral<LiteralUnion<1n | 2n | 3n, bigint>>>(false);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import type {IsLiteral, Tagged, LiteralUnion} from '../index.d.ts';
 
-declare const sym1: unique symbol;
+declare const symbolLiteral: unique symbol;
 
 // Literals
 expectType<IsLiteral<'foo'>>(true);
@@ -9,7 +9,7 @@ expectType<IsLiteral<1>>(true);
 expectType<IsLiteral<1n>>(true);
 expectType<IsLiteral<true>>(true);
 expectType<IsLiteral<false>>(true);
-expectType<IsLiteral<typeof sym1>>(true);
+expectType<IsLiteral<typeof symbolLiteral>>(true);
 
 // Non-literals
 expectType<IsLiteral<string>>(false);
@@ -30,7 +30,7 @@ expectType<IsLiteral<string[]>>(false);
 // All literals
 expectType<IsLiteral<'a' | 'b'>>(true);
 expectType<IsLiteral<1 | 2n | 'two'>>(true);
-expectType<IsLiteral<'foo' | 10_000_000n | false | typeof sym1>>(true);
+expectType<IsLiteral<'foo' | 10_000_000n | false | typeof symbolLiteral>>(true);
 
 // All non-literals
 expectType<IsLiteral<string | number>>(false);
@@ -63,11 +63,11 @@ expectType<IsLiteral<true | bigint>>({} as boolean); // Literal boolean + `bigin
 expectType<IsLiteral<true | symbol>>({} as boolean); // Literal boolean + `symbol`
 expectType<IsLiteral<true | null>>({} as boolean); // Literal boolean + `null`
 
-expectType<IsLiteral<typeof sym1 | string>>({} as boolean); // Literal symbol + `string`
-expectType<IsLiteral<typeof sym1 | number>>({} as boolean); // Literal symbol + `number`
-expectType<IsLiteral<typeof sym1 | bigint>>({} as boolean); // Literal symbol + `bigint`
-expectType<IsLiteral<typeof sym1 | boolean>>({} as boolean); // Literal symbol + `boolean`
-expectType<IsLiteral<typeof sym1 | null>>(false); // Literal symbol + `null`
+expectType<IsLiteral<typeof symbolLiteral | string>>({} as boolean); // Literal symbol + `string`
+expectType<IsLiteral<typeof symbolLiteral | number>>({} as boolean); // Literal symbol + `number`
+expectType<IsLiteral<typeof symbolLiteral | bigint>>({} as boolean); // Literal symbol + `bigint`
+expectType<IsLiteral<typeof symbolLiteral | boolean>>({} as boolean); // Literal symbol + `boolean`
+expectType<IsLiteral<typeof symbolLiteral | null>>(false); // Literal symbol + `null`
 
 // Boundary types
 expectType<IsLiteral<any>>(false);
@@ -76,7 +76,7 @@ expectType<IsLiteral<never>>(false);
 
 // Tagged types
 // Literals
-expectType<IsLiteral<Tagged<'foo' | 'bar' | 1n | typeof sym1 | false, 'Tag'>>>(true);
+expectType<IsLiteral<Tagged<'foo' | 'bar' | 1n | typeof symbolLiteral | false, 'Tag'>>>(true);
 // Non-literals
 expectType<IsLiteral<Tagged<string | number | symbol, 'Tag'>>>(false);
 // Literals and non-literals

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -1,141 +1,98 @@
 import {expectType} from 'tsd';
-import type {
-	IsLiteral,
-	IsStringLiteral,
-	IsNumericLiteral,
-	IsBooleanLiteral,
-	IsSymbolLiteral,
-	Tagged,
-	LiteralUnion,
-} from '../index.d.ts';
+import type {IsLiteral, Tagged, LiteralUnion} from '../index.d.ts';
 
-const stringLiteral = '';
-const numberLiteral = 1;
-const bigintLiteral = 1n;
-const booleanLiteral = true;
-const symbolLiteral = Symbol('');
+declare const sym1: unique symbol;
 
-declare const _string: string;
-declare const _number: number;
-declare const _bigint: bigint;
-declare const _boolean: boolean;
-declare const _symbol: symbol;
+// Literals
+expectType<IsLiteral<'foo'>>(true);
+expectType<IsLiteral<1>>(true);
+expectType<IsLiteral<1n>>(true);
+expectType<IsLiteral<true>>(true);
+expectType<IsLiteral<false>>(true);
+expectType<IsLiteral<typeof sym1>>(true);
 
-// Literals should be true
-expectType<IsLiteral<typeof stringLiteral>>(true);
-expectType<IsLiteral<typeof numberLiteral>>(true);
-expectType<IsLiteral<typeof bigintLiteral>>(true);
-expectType<IsLiteral<typeof booleanLiteral>>(true);
-expectType<IsLiteral<typeof symbolLiteral>>(true);
+// Non-literals
+expectType<IsLiteral<string>>(false);
+expectType<IsLiteral<Uppercase<string>>>(false);
+expectType<IsLiteral<`${number}`>>(false);
+expectType<IsLiteral<number>>(false);
+expectType<IsLiteral<bigint>>(false);
+expectType<IsLiteral<boolean>>(false);
+expectType<IsLiteral<symbol>>(false);
 
-// Primitives should be false
-expectType<IsLiteral<typeof _string>>(false);
-expectType<IsLiteral<typeof _number>>(false);
-expectType<IsLiteral<typeof _bigint>>(false);
-expectType<IsLiteral<typeof _boolean>>(false);
-expectType<IsLiteral<typeof _symbol>>(false);
-
-// Null, undefined, and non-primitives should fail all literal checks
 expectType<IsLiteral<null>>(false);
 expectType<IsLiteral<undefined>>(false);
-expectType<IsLiteral<any>>(false);
-expectType<IsLiteral<never>>(false);
+expectType<IsLiteral<object>>(false);
+expectType<IsLiteral<(x: number) => number>>(false);
+expectType<IsLiteral<string[]>>(false);
 
-expectType<IsStringLiteral<typeof stringLiteral>>(true);
-expectType<IsStringLiteral<typeof _string>>(false);
+// Unions
+// All literals
+expectType<IsLiteral<'a' | 'b'>>(true);
+expectType<IsLiteral<1 | 2n | 'two'>>(true);
+expectType<IsLiteral<'foo' | 10_000_000n | false | typeof sym1>>(true);
 
-// Strings with infinite set of possible values return `false`
-expectType<IsStringLiteral<Uppercase<string>>>(false);
-expectType<IsStringLiteral<Lowercase<string>>>(false);
-expectType<IsStringLiteral<Capitalize<string>>>(false);
-expectType<IsStringLiteral<Uncapitalize<string>>>(false);
-expectType<IsStringLiteral<Capitalize<Lowercase<string>>>>(false);
-expectType<IsStringLiteral<Uncapitalize<Uppercase<string>>>>(false);
-expectType<IsStringLiteral<`abc${string}`>>(false);
-expectType<IsStringLiteral<`${string}abc`>>(false);
-expectType<IsStringLiteral<`${number}:${string}`>>(false);
-expectType<IsStringLiteral<`abc${Uppercase<string>}`>>(false);
-expectType<IsStringLiteral<`${Lowercase<string>}abc`>>(false);
-expectType<IsStringLiteral<`${number}`>>(false);
-expectType<IsStringLiteral<`${number}${string}`>>(false);
-expectType<IsStringLiteral<`${number}` | Uppercase<string>>>(false);
-expectType<IsStringLiteral<Capitalize<string> | Uppercase<string>>>(false);
-expectType<IsStringLiteral<`abc${string}` | `${string}abc`>>(false);
+// All non-literals
+expectType<IsLiteral<string | number>>(false);
+expectType<IsLiteral<bigint | symbol | boolean>>(false);
 
-// Strings with finite set of possible values return `true`
-expectType<IsStringLiteral<'a' | 'b'>>(true);
-expectType<IsStringLiteral<Uppercase<'a'>>>(true);
-expectType<IsStringLiteral<Lowercase<'a'>>>(true);
-expectType<IsStringLiteral<Uppercase<'a' | 'b'>>>(true);
-expectType<IsStringLiteral<Lowercase<'a' | 'b'>>>(true);
-expectType<IsStringLiteral<Capitalize<'abc' | 'xyz'>>>(true);
-expectType<IsStringLiteral<Uncapitalize<'Abc' | 'Xyz'>>>(true);
-expectType<IsStringLiteral<`ab${'c' | 'd' | 'e'}`>>(true);
-expectType<IsStringLiteral<Uppercase<'a' | 'b'> | 'C' | 'D'>>(true);
-expectType<IsStringLiteral<Lowercase<'xyz'> | Capitalize<'abc'>>>(true);
+expectType<IsLiteral<object | null | undefined>>(false);
 
-// Strings with union of literals and non-literals return `boolean`
-expectType<IsStringLiteral<Uppercase<string> | 'abc'>>({} as boolean);
-expectType<IsStringLiteral<Lowercase<string> | 'Abc'>>({} as boolean);
-expectType<IsStringLiteral<null | '1' | '2' | '3'>>({} as boolean);
-expectType<IsStringLiteral<1 | 2 | '3'>>({} as boolean);
-expectType<IsStringLiteral<'foo' | 'bar' | number>>({} as boolean);
+// Literals and non-literals
+expectType<IsLiteral<'foo' | number>>({} as boolean); // Literal string + `number`
+expectType<IsLiteral<'foo' | bigint>>({} as boolean); // Literal string + `bigint`
+expectType<IsLiteral<'foo' | boolean>>({} as boolean); // Literal string + `boolean`
+expectType<IsLiteral<'foo' | symbol>>({} as boolean); // Literal string + `symbol`
+expectType<IsLiteral<'foo' | null>>({} as boolean); // Literal string + `null`
 
-// Types other than string return `false`
-expectType<IsStringLiteral<bigint>>(false);
-expectType<IsStringLiteral<1 | 2 | 3>>(false);
-expectType<IsStringLiteral<object>>(false);
-expectType<IsStringLiteral<false | undefined | null>>(false);
+expectType<IsLiteral<1 | string>>({} as boolean); // Literal number + `string`
+expectType<IsLiteral<1 | bigint>>({} as boolean); // Literal number + `bigint`
+expectType<IsLiteral<1 | boolean>>({} as boolean); // Literal number + `boolean`
+expectType<IsLiteral<1 | symbol>>({} as boolean); // Literal number + `symbol`
+expectType<IsLiteral<1 | null>>({} as boolean); // Literal number + `null`
+
+expectType<IsLiteral<1n | string>>({} as boolean); // Literal bigint + `string`
+expectType<IsLiteral<1n | number>>({} as boolean); // Literal bigint + `number`
+expectType<IsLiteral<1n | boolean>>({} as boolean); // Literal bigint + `boolean`
+expectType<IsLiteral<1n | symbol>>({} as boolean); // Literal bigint + `symbol`
+expectType<IsLiteral<1n | null>>({} as boolean); // Literal bigint + `null`
+
+expectType<IsLiteral<true | string>>({} as boolean); // Literal boolean + `string`
+expectType<IsLiteral<true | number>>({} as boolean); // Literal boolean + `number`
+expectType<IsLiteral<true | bigint>>({} as boolean); // Literal boolean + `bigint`
+expectType<IsLiteral<true | symbol>>({} as boolean); // Literal boolean + `symbol`
+expectType<IsLiteral<true | null>>({} as boolean); // Literal boolean + `null`
+
+expectType<IsLiteral<typeof sym1 | string>>({} as boolean); // Literal symbol + `string`
+expectType<IsLiteral<typeof sym1 | number>>({} as boolean); // Literal symbol + `number`
+expectType<IsLiteral<typeof sym1 | bigint>>({} as boolean); // Literal symbol + `bigint`
+expectType<IsLiteral<typeof sym1 | boolean>>({} as boolean); // Literal symbol + `boolean`
+expectType<IsLiteral<typeof sym1 | null>>(false); // Literal symbol + `null`
 
 // Boundary types
-expectType<IsStringLiteral<{}>>(false);
-expectType<IsStringLiteral<any>>(false);
-expectType<IsStringLiteral<never>>(false);
-
-expectType<IsNumericLiteral<typeof numberLiteral>>(true);
-expectType<IsNumericLiteral<typeof bigintLiteral>>(true);
-expectType<IsNumericLiteral<typeof _number>>(false);
-expectType<IsNumericLiteral<typeof _bigint>>(false);
-
-expectType<IsBooleanLiteral<typeof booleanLiteral>>(true);
-expectType<IsBooleanLiteral<typeof _boolean>>(false);
-
-expectType<IsSymbolLiteral<typeof symbolLiteral>>(true);
-expectType<IsSymbolLiteral<typeof _symbol>>(false);
-
-// Missing generic parameter
-// @ts-expect-error
-type A0 = IsLiteral;
-// @ts-expect-error
-type A1 = IsStringLiteral;
-// @ts-expect-error
-type A2 = IsNumericLiteral;
-// @ts-expect-error
-type A3 = IsBooleanLiteral;
-// @ts-expect-error
-type A4 = IsSymbolLiteral;
+expectType<IsLiteral<any>>(false);
+expectType<IsLiteral<unknown>>(false);
+expectType<IsLiteral<never>>(false);
 
 // Tagged types
-expectType<IsStringLiteral<Tagged<string, 'Tag'>>>(false);
-expectType<IsStringLiteral<Tagged<Uppercase<string>, 'Tag'>>>(false);
-expectType<IsStringLiteral<Tagged<number, 'Tag'>>>(false);
-expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'>>>(true);
-expectType<IsStringLiteral<Tagged<'foo' | 'bar' | `on${string}`, 'Tag'>>>({} as boolean);
-expectType<IsStringLiteral<Tagged<'1st' | '2nd' | '3rd' | number, 'Tag'>>>({} as boolean);
+// Literals
+expectType<IsLiteral<Tagged<'foo' | 'bar' | 1n | typeof sym1 | false, 'Tag'>>>(true);
+// Non-literals
+expectType<IsLiteral<Tagged<string | number | symbol, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsLiteral<Tagged<'foo' | 'bar' | number, 'Tag'>>>({} as boolean);
+expectType<IsLiteral<Tagged<0 | '' | boolean, 'Tag'>>>({} as boolean);
 
-expectType<IsStringLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
-expectType<IsStringLiteral<Tagged<'foo', 'Tag'> | Tagged<'bar', 'Tag'>>>(true);
-expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | Tagged<number, 'Tag'>>>({} as boolean);
-expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | number>>({} as boolean);
+// Unions
+expectType<IsLiteral<Tagged<'foo', 'Tag'> | Tagged<1, 'Tag'>>>(true);
+expectType<IsLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
+expectType<IsLiteral<Tagged<'foo', 'Tag'> | Tagged<bigint, 'Tag'>>>({} as boolean);
+expectType<IsLiteral<Tagged<'foo', 'Tag'> | number>>({} as boolean);
+expectType<IsLiteral<Tagged<symbol, 'Tag'> | 'foo'>>({} as boolean);
 
-// Uncollapsed unions (e.g., `'foo' | 'bar' | (string & {})`)
-expectType<IsStringLiteral<'foo' | 'bar' | (string & {})>>(false);
-expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', string>>>(false);
-expectType<IsStringLiteral<LiteralUnion<'onClick' | 'onMouseDown', `on${string}`>>>(false);
-expectType<IsStringLiteral<LiteralUnion<'press' | 'onClick' | 'onMouseDown', `on${string}`>>>({} as boolean);
-expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', number>>>({} as boolean);
-expectType<IsStringLiteral<Tagged<LiteralUnion<'foo' | 'bar', string>, 'Tag'>>>(false);
-expectType<IsStringLiteral<Tagged<LiteralUnion<'click' | 'onMouseDown', `on${string}`>, 'Tag'>>>({} as boolean);
-
-expectType<IsNumericLiteral<Tagged<number, 'Tag'>>>(false);
-expectType<IsBooleanLiteral<Tagged<boolean, 'Tag'>>>(false);
+// Uncollapsed unions
+expectType<IsLiteral<'foo' | 1 | false | (string & {})>>(false);
+expectType<IsLiteral<LiteralUnion<1n | 2n | 3n, bigint>>>(false);
+expectType<IsLiteral<LiteralUnion<'foo' | 1 | false, string>>>({} as boolean);
+expectType<IsLiteral<Tagged<LiteralUnion<'foo' | 'bar', string>, 'Tag'>>>(false);
+expectType<IsLiteral<Tagged<LiteralUnion<'foo' | 'bar', number>, 'Tag'>>>({} as boolean);

--- a/test-d/is-literal.ts
+++ b/test-d/is-literal.ts
@@ -67,7 +67,7 @@ expectType<IsLiteral<typeof symbolLiteral | string>>({} as boolean); // Literal 
 expectType<IsLiteral<typeof symbolLiteral | number>>({} as boolean); // Literal symbol + `number`
 expectType<IsLiteral<typeof symbolLiteral | bigint>>({} as boolean); // Literal symbol + `bigint`
 expectType<IsLiteral<typeof symbolLiteral | boolean>>({} as boolean); // Literal symbol + `boolean`
-expectType<IsLiteral<typeof symbolLiteral | null>>(false); // Literal symbol + `null`
+expectType<IsLiteral<typeof symbolLiteral | null>>({} as boolean); // Literal symbol + `null`
 
 // Boundary types
 expectType<IsLiteral<any>>(false);
@@ -91,8 +91,8 @@ expectType<IsLiteral<Tagged<'foo', 'Tag'> | number>>({} as boolean);
 expectType<IsLiteral<Tagged<symbol, 'Tag'> | 'foo'>>({} as boolean);
 
 // Uncollapsed unions
-expectType<IsLiteral<'foo' | 1 | false | (string & {})>>(false);
 expectType<IsLiteral<LiteralUnion<1n | 2n | 3n, bigint>>>(false);
+expectType<IsLiteral<'foo' | 1 | false | (string & {})>>({} as boolean);
 expectType<IsLiteral<LiteralUnion<'foo' | 1 | false, string>>>({} as boolean);
 expectType<IsLiteral<Tagged<LiteralUnion<'foo' | 'bar', string>, 'Tag'>>>(false);
 expectType<IsLiteral<Tagged<LiteralUnion<'foo' | 'bar', number>, 'Tag'>>>({} as boolean);

--- a/test-d/is-numeric-literal.ts
+++ b/test-d/is-numeric-literal.ts
@@ -1,0 +1,74 @@
+import {expectType} from 'tsd';
+import type {IsNumericLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+
+// Literals
+expectType<IsNumericLiteral<1>>(true);
+expectType<IsNumericLiteral<1n>>(true);
+
+// Non-literals
+expectType<IsNumericLiteral<number>>(false);
+expectType<IsNumericLiteral<bigint>>(false);
+
+// Non-numerics
+expectType<IsNumericLiteral<string>>(false);
+expectType<IsNumericLiteral<object>>(false);
+
+// Unions
+// All numeric literals
+expectType<IsNumericLiteral<1 | 2 | 3>>(true);
+expectType<IsNumericLiteral<10n | 20n>>(true);
+expectType<IsNumericLiteral<3.14 | 0.01 | 5_000_000n>>(true);
+
+// All numeric non-literals
+expectType<IsNumericLiteral<number | bigint>>(false);
+
+// All non-numerics
+expectType<IsNumericLiteral<string | symbol | undefined>>(false);
+
+// Numeric literals and numeric non-literals
+expectType<IsNumericLiteral<1 | 2.5 | bigint>>({} as boolean);
+expectType<IsNumericLiteral<10n | number>>({} as boolean);
+
+// Numeric literals and non-numerics
+expectType<IsNumericLiteral<null | 1 | 2>>({} as boolean);
+expectType<IsNumericLiteral<'1' | '2' | 3n>>({} as boolean);
+expectType<IsNumericLiteral<1.96 | 2n | string>>({} as boolean);
+
+// Numeric non-literals and non-numerics
+expectType<IsNumericLiteral<bigint | 'foo'>>(false);
+expectType<IsNumericLiteral<number | null | '2'>>(false);
+
+// Boundary types
+expectType<IsNumericLiteral<any>>(false);
+expectType<IsNumericLiteral<unknown>>(false);
+expectType<IsNumericLiteral<never>>(false);
+
+// Tagged types
+// Literals
+expectType<IsNumericLiteral<Tagged<1 | 2, 'Tag'>>>(true);
+// Non-literals
+expectType<IsNumericLiteral<Tagged<number, 'Tag'>>>(false);
+// Non-numerics
+expectType<IsNumericLiteral<Tagged<string, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsNumericLiteral<Tagged<1 | 2 | bigint, 'Tag'>>>({} as boolean);
+expectType<IsNumericLiteral<Tagged<1n | 2n | number, 'Tag'>>>({} as boolean);
+// Literals and non-numerics
+expectType<IsNumericLiteral<Tagged<1 | 2n | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-numerics
+expectType<IsNumericLiteral<Tagged<number | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsNumericLiteral<Tagged<1, 'Tag'> | Tagged<2, 'Tag'>>>(true);
+expectType<IsNumericLiteral<Tagged<number, 'Tag'> | Tagged<string, 'Tag'>>>(false);
+expectType<IsNumericLiteral<Tagged<1 | 2, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
+expectType<IsNumericLiteral<Tagged<1 | 2, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Uncollapsed unions (e.g., `1 | 2 | (number & {})`)
+expectType<IsNumericLiteral<1 | 2 | (number & {})>>(false);
+expectType<IsNumericLiteral<100n | 200n | (bigint & {})>>(false);
+expectType<IsNumericLiteral<LiteralUnion<1 | 2, number>>>(false);
+expectType<IsNumericLiteral<LiteralUnion<1n | 2n, bigint>>>(false);
+expectType<IsNumericLiteral<LiteralUnion<1n | 2n, number>>>({} as boolean);
+expectType<IsNumericLiteral<LiteralUnion<1 | 2, string>>>({} as boolean);
+expectType<IsNumericLiteral<Tagged<LiteralUnion<1 | 2, number>, 'Tag'>>>(false);
+expectType<IsNumericLiteral<Tagged<LiteralUnion<1n | 2n, number>, 'Tag'>>>({} as boolean);

--- a/test-d/is-numeric-literal.ts
+++ b/test-d/is-numeric-literal.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import type {IsNumericLiteral} from '../source/is-numeric-literal.d.ts';
 import type {LiteralUnion} from '../source/literal-union.d.ts';
-import type {Tagged} from '../source/tagged.d.ts';
+import type {Opaque, Tagged} from '../source/tagged.d.ts';
 
 // Literals
 expectType<IsNumericLiteral<1>>(true);
@@ -64,6 +64,49 @@ expectType<IsNumericLiteral<Tagged<1, 'Tag'> | Tagged<2, 'Tag'>>>(true);
 expectType<IsNumericLiteral<Tagged<number, 'Tag'> | Tagged<string, 'Tag'>>>(false);
 expectType<IsNumericLiteral<Tagged<1 | 2, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
 expectType<IsNumericLiteral<Tagged<1 | 2, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Opaque types
+// Literals
+expectType<IsNumericLiteral<Opaque<1 | 2, 'Tag'>>>(true);
+// Non-literals
+expectType<IsNumericLiteral<Opaque<number, 'Tag'>>>(false);
+// Non-numerics
+expectType<IsNumericLiteral<Opaque<string, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsNumericLiteral<Opaque<1 | 2 | bigint, 'Tag'>>>({} as boolean);
+expectType<IsNumericLiteral<Opaque<1n | 2n | number, 'Tag'>>>({} as boolean);
+// Literals and non-numerics
+expectType<IsNumericLiteral<Opaque<1 | 2n | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-numerics
+expectType<IsNumericLiteral<Opaque<number | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsNumericLiteral<Opaque<1, 'Tag'> | Opaque<2, 'Tag'>>>(true);
+expectType<IsNumericLiteral<Opaque<number, 'Tag'> | Opaque<string, 'Tag'>>>(false);
+expectType<IsNumericLiteral<Opaque<1 | 2, 'Tag'> | Opaque<string, 'Tag'>>>({} as boolean);
+expectType<IsNumericLiteral<Opaque<1 | 2, 'Tag'> | string>>({} as boolean); // Opaque and non-opaque
+
+// Branded types
+type Brand = {readonly __brand: unique symbol};
+
+// Tagged types
+// Literals
+expectType<IsNumericLiteral<(1 | 2) & Brand>>(true);
+// Non-literals
+expectType<IsNumericLiteral<number & Brand>>(false);
+// Non-numerics
+expectType<IsNumericLiteral<string & Brand>>(false);
+// Literals and non-literals
+expectType<IsNumericLiteral<(1 | 2 | bigint) & Brand>>({} as boolean);
+expectType<IsNumericLiteral<(1n | 2n | number) & Brand>>({} as boolean);
+// Literals and non-numerics
+expectType<IsNumericLiteral<(1 | 2n | string) & Brand>>({} as boolean);
+// Non-literals and non-numerics
+expectType<IsNumericLiteral<(number | string) & Brand>>({} as false);
+// Unions
+expectType<IsNumericLiteral<(1 & Brand) | (2 & Brand)>>(true);
+expectType<IsNumericLiteral<(number & Brand) | (string & Brand)>>(false);
+expectType<IsNumericLiteral<((1 | 2) & Brand) | (string & Brand)>>({} as boolean);
+expectType<IsNumericLiteral<((1 | 2) & Brand) | string>>({} as boolean); // Branded and non-branded
 
 // Uncollapsed unions (e.g., `1 | 2 | (number & {})`)
 expectType<IsNumericLiteral<1 | 2 | (number & {})>>(false);

--- a/test-d/is-numeric-literal.ts
+++ b/test-d/is-numeric-literal.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import type {IsNumericLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+import type {IsNumericLiteral} from '../source/is-numeric-literal.d.ts';
+import type {LiteralUnion} from '../source/literal-union.d.ts';
+import type {Tagged} from '../source/tagged.d.ts';
 
 // Literals
 expectType<IsNumericLiteral<1>>(true);

--- a/test-d/is-string-literal.ts
+++ b/test-d/is-string-literal.ts
@@ -1,0 +1,97 @@
+import {expectType} from 'tsd';
+import type {IsStringLiteral} from '../source/is-string-literal.d.ts';
+import type {Tagged} from '../source/tagged.d.ts';
+import type {LiteralUnion} from '../source/literal-union.d.ts';
+
+// Literals
+expectType<IsStringLiteral<'foo'>>(true);
+expectType<IsStringLiteral<'1'>>(true);
+expectType<IsStringLiteral<Uppercase<'a'>>>(true);
+expectType<IsStringLiteral<Lowercase<'a'>>>(true);
+
+// Non-literals
+expectType<IsStringLiteral<string>>(false);
+expectType<IsStringLiteral<Uppercase<string>>>(false);
+expectType<IsStringLiteral<Lowercase<string>>>(false);
+expectType<IsStringLiteral<Capitalize<string>>>(false);
+expectType<IsStringLiteral<Uncapitalize<string>>>(false);
+expectType<IsStringLiteral<Capitalize<Lowercase<string>>>>(false);
+expectType<IsStringLiteral<Uncapitalize<Uppercase<string>>>>(false);
+expectType<IsStringLiteral<`abc${string}`>>(false);
+expectType<IsStringLiteral<`${string}abc`>>(false);
+expectType<IsStringLiteral<`${number}:${string}`>>(false);
+expectType<IsStringLiteral<`abc${Uppercase<string>}`>>(false);
+expectType<IsStringLiteral<`${Lowercase<string>}abc`>>(false);
+expectType<IsStringLiteral<`${number}`>>(false);
+expectType<IsStringLiteral<`${number}${string}`>>(false);
+
+// Non-strings
+expectType<IsStringLiteral<bigint>>(false);
+expectType<IsStringLiteral<object>>(false);
+
+// Unions
+// All string literals
+expectType<IsStringLiteral<'a' | 'b'>>(true);
+expectType<IsStringLiteral<Uppercase<'a' | 'b'>>>(true);
+expectType<IsStringLiteral<Lowercase<'a' | 'b'>>>(true);
+expectType<IsStringLiteral<Capitalize<'abc' | 'xyz'>>>(true);
+expectType<IsStringLiteral<Uncapitalize<'Abc' | 'Xyz'>>>(true);
+expectType<IsStringLiteral<`ab${'c' | 'd' | 'e'}`>>(true);
+expectType<IsStringLiteral<Uppercase<'a' | 'b'> | 'C' | 'D'>>(true);
+expectType<IsStringLiteral<Lowercase<'xyz'> | Capitalize<'abc'>>>(true);
+
+// All string non-literals
+expectType<IsStringLiteral<`${number}` | Uppercase<string>>>(false);
+expectType<IsStringLiteral<Capitalize<string> | Uppercase<string>>>(false);
+expectType<IsStringLiteral<`abc${string}` | `${string}abc`>>(false);
+
+// All non-strings
+expectType<IsStringLiteral<1 | 2 | 3>>(false);
+expectType<IsStringLiteral<false | undefined | null>>(false);
+
+// String literals and string non-literals
+expectType<IsStringLiteral<Uppercase<string> | 'abc'>>({} as boolean);
+expectType<IsStringLiteral<Lowercase<string> | 'Abc'>>({} as boolean);
+
+// String literals and non-strings
+expectType<IsStringLiteral<null | '1' | '2' | '3'>>({} as boolean);
+expectType<IsStringLiteral<1 | 2 | '3'>>({} as boolean);
+expectType<IsStringLiteral<'foo' | 'bar' | number>>({} as boolean);
+
+// String non-literals and non-strings
+expectType<IsStringLiteral<string | number | bigint>>({} as false);
+expectType<IsStringLiteral<`on${string}` | Uppercase<string> | 1n | null | undefined>>({} as false);
+
+// Boundary types
+expectType<IsStringLiteral<any>>(false);
+expectType<IsStringLiteral<unknown>>(false);
+expectType<IsStringLiteral<never>>(false);
+
+// Tagged types
+// Literals
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'>>>(true);
+// Non-literals
+expectType<IsStringLiteral<Tagged<string, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<Uppercase<string>, 'Tag'>>>(false);
+// Non-strings
+expectType<IsStringLiteral<Tagged<number, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsStringLiteral<Tagged<'foo' | 'bar' | `on${string}`, 'Tag'>>>({} as boolean);
+// Literals and non-strings
+expectType<IsStringLiteral<Tagged<'1st' | '2nd' | '3rd' | number, 'Tag'>>>({} as boolean);
+// Non-literals and non-strings
+expectType<IsStringLiteral<Tagged<string | number, 'Tag'>>>({} as false);
+// Unions
+expectType<IsStringLiteral<Tagged<'foo', 'Tag'> | Tagged<'bar', 'Tag'>>>(true);
+expectType<IsStringLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | Tagged<number, 'Tag'>>>({} as boolean);
+expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | number>>({} as boolean); // Tagged and untagged
+
+// Uncollapsed unions (e.g., `'foo' | 'bar' | (string & {})`)
+expectType<IsStringLiteral<'foo' | 'bar' | (string & {})>>(false);
+expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', string>>>(false);
+expectType<IsStringLiteral<LiteralUnion<'onClick' | 'onMouseDown', `on${string}`>>>(false);
+expectType<IsStringLiteral<LiteralUnion<'press' | 'onClick' | 'onMouseDown', `on${string}`>>>({} as boolean);
+expectType<IsStringLiteral<LiteralUnion<'foo' | 'bar', number>>>({} as boolean);
+expectType<IsStringLiteral<Tagged<LiteralUnion<'foo' | 'bar', string>, 'Tag'>>>(false);
+expectType<IsStringLiteral<Tagged<LiteralUnion<'click' | 'onMouseDown', `on${string}`>, 'Tag'>>>({} as boolean);

--- a/test-d/is-string-literal.ts
+++ b/test-d/is-string-literal.ts
@@ -1,6 +1,6 @@
 import {expectType} from 'tsd';
 import type {IsStringLiteral} from '../source/is-string-literal.d.ts';
-import type {Tagged} from '../source/tagged.d.ts';
+import type {Opaque, Tagged} from '../source/tagged.d.ts';
 import type {LiteralUnion} from '../source/literal-union.d.ts';
 
 // Literals
@@ -86,6 +86,48 @@ expectType<IsStringLiteral<Tagged<'foo', 'Tag'> | Tagged<'bar', 'Tag'>>>(true);
 expectType<IsStringLiteral<Tagged<string, 'Tag'> | Tagged<number, 'Tag'>>>(false);
 expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | Tagged<number, 'Tag'>>>({} as boolean);
 expectType<IsStringLiteral<Tagged<'foo' | 'bar', 'Tag'> | number>>({} as boolean); // Tagged and untagged
+
+// Opaque types
+// Literals
+expectType<IsStringLiteral<Opaque<'foo' | 'bar', 'Tag'>>>(true);
+// Non-literals
+expectType<IsStringLiteral<Opaque<string, 'Tag'>>>(false);
+expectType<IsStringLiteral<Opaque<Uppercase<string>, 'Tag'>>>(false);
+// Non-strings
+expectType<IsStringLiteral<Opaque<number, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsStringLiteral<Opaque<'foo' | 'bar' | `on${string}`, 'Tag'>>>({} as boolean);
+// Literals and non-strings
+expectType<IsStringLiteral<Opaque<'1st' | '2nd' | '3rd' | number, 'Tag'>>>({} as boolean);
+// Non-literals and non-strings
+expectType<IsStringLiteral<Opaque<string | number, 'Tag'>>>({} as false);
+// Unions
+expectType<IsStringLiteral<Opaque<'foo', 'Tag'> | Opaque<'bar', 'Tag'>>>(true);
+expectType<IsStringLiteral<Opaque<string, 'Tag'> | Opaque<number, 'Tag'>>>(false);
+expectType<IsStringLiteral<Opaque<'foo' | 'bar', 'Tag'> | Opaque<number, 'Tag'>>>({} as boolean);
+expectType<IsStringLiteral<Opaque<'foo' | 'bar', 'Tag'> | number>>({} as boolean); // Opaque and untagged
+
+// Branded types
+type Brand = {readonly __brand: unique symbol};
+
+// Literals
+expectType<IsStringLiteral<('foo' | 'bar') & Brand>>(true);
+// Non-literals
+expectType<IsStringLiteral<string & Brand>>(false);
+expectType<IsStringLiteral<Uppercase<string> & Brand>>(false);
+// Non-strings
+expectType<IsStringLiteral<number & Brand>>(false);
+// Literals and non-literals
+expectType<IsStringLiteral<('foo' | 'bar' | `on${string}`) & Brand>>({} as boolean);
+// Literals and non-strings
+expectType<IsStringLiteral<('1st' | '2nd' | '3rd' | number) & Brand>>({} as boolean);
+// Non-literals and non-strings
+expectType<IsStringLiteral<(string | number) & Brand>>({} as false);
+// Unions
+expectType<IsStringLiteral<('foo' & Brand) | ('bar' & Brand)>>(true);
+expectType<IsStringLiteral<(string & Brand) | (number & Brand)>>(false);
+expectType<IsStringLiteral<(('foo' | 'bar') & Brand) | (number & Brand)>>({} as boolean);
+expectType<IsStringLiteral<(('foo' | 'bar') & Brand) | number>>({} as boolean); // Branded and untagged
 
 // Uncollapsed unions (e.g., `'foo' | 'bar' | (string & {})`)
 expectType<IsStringLiteral<'foo' | 'bar' | (string & {})>>(false);

--- a/test-d/is-symbol-literal.ts
+++ b/test-d/is-symbol-literal.ts
@@ -1,0 +1,64 @@
+import {expectType} from 'tsd';
+import type {IsSymbolLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+
+const symbolLiteral1 = Symbol('');
+const symbolLiteral2 = Symbol('foo');
+
+// Literals
+expectType<IsSymbolLiteral<typeof symbolLiteral1>>(true);
+expectType<IsSymbolLiteral<typeof symbolLiteral2>>(true);
+
+// Non-literals
+expectType<IsSymbolLiteral<symbol>>(false);
+
+// Non-symbols
+expectType<IsSymbolLiteral<string>>(false);
+expectType<IsSymbolLiteral<object>>(false);
+
+// Unions
+// All symbol literals
+expectType<IsSymbolLiteral<typeof symbolLiteral1 | typeof symbolLiteral2>>(true);
+
+// All non-symbols
+expectType<IsSymbolLiteral<string | 100n | null>>(false);
+
+// Symbol literals and non-symbols
+expectType<IsSymbolLiteral<typeof symbolLiteral1 | 1 | false>>({} as boolean);
+expectType<IsSymbolLiteral<typeof symbolLiteral2 | bigint>>({} as boolean);
+
+// Symbol non-literals and non-symbols
+expectType<IsSymbolLiteral<symbol | '1' | '2' | 1>>(false);
+expectType<IsSymbolLiteral<symbol | string | bigint>>(false);
+expectType<IsSymbolLiteral<symbol | string | false>>(false);
+
+// Boundary types
+expectType<IsSymbolLiteral<any>>(false);
+expectType<IsSymbolLiteral<unknown>>(false);
+expectType<IsSymbolLiteral<never>>(false);
+
+// Tagged types
+declare const symbol1: unique symbol;
+declare const symbol2: unique symbol;
+// Literals
+expectType<IsSymbolLiteral<Tagged<typeof symbol1 | typeof symbol2, 'Tag'>>>(true);
+// Non-literals
+expectType<IsSymbolLiteral<Tagged<symbol, 'Tag'>>>(false);
+// Non-symbols
+expectType<IsSymbolLiteral<Tagged<string, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsSymbolLiteral<Tagged<typeof symbol1 | symbol, 'Tag'>>>(false);
+// Literals and non-symbols
+expectType<IsSymbolLiteral<Tagged<typeof symbol1 | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-symbols
+expectType<IsSymbolLiteral<Tagged<symbol | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsSymbolLiteral<Tagged<symbol, 'Tag'> | Tagged<string, 'Tag'>>>(false);
+expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | Tagged<typeof symbol2, 'Tag'>>>(true);
+expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
+expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Uncollapsed unions (e.g., `typeof symbol1 | (symbol & {})`)
+expectType<IsSymbolLiteral<typeof symbol1 | (symbol & {})>>(false);
+expectType<IsSymbolLiteral<LiteralUnion<typeof symbol1, symbol>>>(false);
+expectType<IsSymbolLiteral<LiteralUnion<typeof symbol1, string>>>({} as boolean);
+expectType<IsSymbolLiteral<Tagged<LiteralUnion<typeof symbol1, symbol>, 'Tag'>>>(false);

--- a/test-d/is-symbol-literal.ts
+++ b/test-d/is-symbol-literal.ts
@@ -47,8 +47,6 @@ expectType<IsSymbolLiteral<Tagged<typeof symbol1 | typeof symbol2, 'Tag'>>>(true
 expectType<IsSymbolLiteral<Tagged<symbol, 'Tag'>>>(false);
 // Non-symbols
 expectType<IsSymbolLiteral<Tagged<string, 'Tag'>>>(false);
-// Literals and non-literals
-expectType<IsSymbolLiteral<Tagged<typeof symbol1 | symbol, 'Tag'>>>(false);
 // Literals and non-symbols
 expectType<IsSymbolLiteral<Tagged<typeof symbol1 | string, 'Tag'>>>({} as boolean);
 // Non-literals and non-symbols
@@ -66,8 +64,6 @@ expectType<IsSymbolLiteral<Opaque<typeof symbol1 | typeof symbol2, 'Tag'>>>(true
 expectType<IsSymbolLiteral<Opaque<symbol, 'Tag'>>>(false);
 // Non-symbols
 expectType<IsSymbolLiteral<Opaque<string, 'Tag'>>>(false);
-// Literals and non-literals
-expectType<IsSymbolLiteral<Opaque<typeof symbol1 | symbol, 'Tag'>>>(false);
 // Literals and non-symbols
 expectType<IsSymbolLiteral<Opaque<typeof symbol1 | string, 'Tag'>>>({} as boolean);
 // Non-literals and non-symbols
@@ -87,8 +83,6 @@ expectType<IsSymbolLiteral<(typeof symbol1 | typeof symbol2) & Brand>>(true);
 expectType<IsSymbolLiteral<symbol & Brand>>(false);
 // Non-symbols
 expectType<IsSymbolLiteral<string & Brand>>(false);
-// Literals and non-literals
-expectType<IsSymbolLiteral<(typeof symbol1 | symbol) & Brand>>(false);
 // Literals and non-symbols
 expectType<IsSymbolLiteral<(typeof symbol1 | string) & Brand>>({} as boolean);
 // Non-literals and non-symbols

--- a/test-d/is-symbol-literal.ts
+++ b/test-d/is-symbol-literal.ts
@@ -1,6 +1,6 @@
 import {expectType} from 'tsd';
 import type {IsSymbolLiteral} from '../source/is-symbol-literal.d.ts';
-import type {Tagged} from '../source/tagged.d.ts';
+import type {Opaque, Tagged} from '../source/tagged.d.ts';
 import type {LiteralUnion} from '../source/literal-union.d.ts';
 
 const symbolLiteral1 = Symbol('');
@@ -58,6 +58,46 @@ expectType<IsSymbolLiteral<Tagged<symbol, 'Tag'> | Tagged<string, 'Tag'>>>(false
 expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | Tagged<typeof symbol2, 'Tag'>>>(true);
 expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | Tagged<string, 'Tag'>>>({} as boolean);
 expectType<IsSymbolLiteral<Tagged<typeof symbol1, 'Tag'> | string>>({} as boolean); // Tagged and untagged
+
+// Opaque types
+// Literals
+expectType<IsSymbolLiteral<Opaque<typeof symbol1 | typeof symbol2, 'Tag'>>>(true);
+// Non-literals
+expectType<IsSymbolLiteral<Opaque<symbol, 'Tag'>>>(false);
+// Non-symbols
+expectType<IsSymbolLiteral<Opaque<string, 'Tag'>>>(false);
+// Literals and non-literals
+expectType<IsSymbolLiteral<Opaque<typeof symbol1 | symbol, 'Tag'>>>(false);
+// Literals and non-symbols
+expectType<IsSymbolLiteral<Opaque<typeof symbol1 | string, 'Tag'>>>({} as boolean);
+// Non-literals and non-symbols
+expectType<IsSymbolLiteral<Opaque<symbol | string, 'Tag'>>>({} as false);
+// Unions
+expectType<IsSymbolLiteral<Opaque<symbol, 'Tag'> | Opaque<string, 'Tag'>>>(false);
+expectType<IsSymbolLiteral<Opaque<typeof symbol1, 'Tag'> | Opaque<typeof symbol2, 'Tag'>>>(true);
+expectType<IsSymbolLiteral<Opaque<typeof symbol1, 'Tag'> | Opaque<string, 'Tag'>>>({} as boolean);
+expectType<IsSymbolLiteral<Opaque<typeof symbol1, 'Tag'> | string>>({} as boolean); // Opaque and untagged
+
+// Branded types
+type Brand = {readonly __brand: unique symbol};
+
+// Literals
+expectType<IsSymbolLiteral<(typeof symbol1 | typeof symbol2) & Brand>>(true);
+// Non-literals
+expectType<IsSymbolLiteral<symbol & Brand>>(false);
+// Non-symbols
+expectType<IsSymbolLiteral<string & Brand>>(false);
+// Literals and non-literals
+expectType<IsSymbolLiteral<(typeof symbol1 | symbol) & Brand>>(false);
+// Literals and non-symbols
+expectType<IsSymbolLiteral<(typeof symbol1 | string) & Brand>>({} as boolean);
+// Non-literals and non-symbols
+expectType<IsSymbolLiteral<(symbol | string) & Brand>>({} as false);
+// Unions
+expectType<IsSymbolLiteral<(symbol & Brand) | (string & Brand)>>(false);
+expectType<IsSymbolLiteral<(typeof symbol1 & Brand) | (typeof symbol2 & Brand)>>(true);
+expectType<IsSymbolLiteral<(typeof symbol1 & Brand) | (string & Brand)>>({} as boolean);
+expectType<IsSymbolLiteral<(typeof symbol1 & Brand) | string>>({} as boolean); // Branded and untagged
 
 // Uncollapsed unions (e.g., `typeof symbol1 | (symbol & {})`)
 expectType<IsSymbolLiteral<typeof symbol1 | (symbol & {})>>(false);

--- a/test-d/is-symbol-literal.ts
+++ b/test-d/is-symbol-literal.ts
@@ -1,5 +1,7 @@
 import {expectType} from 'tsd';
-import type {IsSymbolLiteral, Tagged, LiteralUnion} from '../index.d.ts';
+import type {IsSymbolLiteral} from '../source/is-symbol-literal.d.ts';
+import type {Tagged} from '../source/tagged.d.ts';
+import type {LiteralUnion} from '../source/literal-union.d.ts';
 
 const symbolLiteral1 = Symbol('');
 const symbolLiteral2 = Symbol('foo');


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

This PR primarily fixes the behavior of `IsLiteral*` types when instantiated with a union of literals and non-literals. For example, `IsNumericLiteral<1 | bigint>` currently returns `false`, instead it should return `boolean`.

This PR also makes a couple of other things:
- Replaces certain complicated/contrived JSDoc examples with simpler ones.
- Removes unclear use-cases section from JSDoc. IMO, the use-cases mentioned were not adding much value.
- Separates the different literal types into individual files.
- Rewrites both the implementation and tests for all literal types from scratch.
- Fixes behavior with `Tagged`/`LiteralUnion` types.

Also, the input to these literal types is currently unconstrained, but I think that should be constrained. For example, `IsStringLiteral<T extends string> = ...` instead of _just_ `IsStringLiteral<T> = ...`.