### PR TITLE
Fix Get<T, Paths<T>> for generic T

### DIFF
--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -215,12 +215,18 @@ export type Get<
 	BaseType,
 	Path extends
 	| readonly string[]
+	// `Paths<BaseType>`, using `Paths`'s default options, is included directly (in addition to the `_LiteralStringUnion` below)
+	// so that `Get<BaseType, Paths<BaseType>>` is always valid, even when `BaseType` is an unresolved generic type. In that
+	// case, `Paths<BaseType>` can be structurally deferred to something TypeScript treats as `string | number` (for example,
+	// when `BaseType` may have number-like keys), which the plain `string`-based `_LiteralStringUnion` below does not accept.
+	// See: https://github.com/sindresorhus/type-fest/issues/991
+	| Paths<BaseType>
 	| _LiteralStringUnion<ToString<Paths<BaseType, {bracketNotation: false; maxRecursionDepth: 2}> | Paths<BaseType, {bracketNotation: true; maxRecursionDepth: 2}>>>,
 	Options extends GetOptions = {},
 > =
 	GetWithPath<
 		BaseType,
-		Path extends string ? ToPath<Path> : Path,
+		Path extends string | number ? ToPath<ToString<Path>> : Path,
 		ApplyDefaultOptions<GetOptions, DefaultGetOptions, Options>
 	>;
 

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -1,5 +1,5 @@
 import {expectTypeOf} from 'expect-type';
-import type {Get} from '../index.d.ts';
+import type {Get, Paths} from '../index.d.ts';
 
 type NonStrict = {strict: false};
 
@@ -151,4 +151,21 @@ expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, readonly []>>()
 
 	type FooPaths2 = 'array.1';
 	expectTypeOf<Get<Foo, FooPaths2>>().toEqualTypeOf<string | undefined>();
+}
+
+// eslint-disable-next-line no-lone-blocks
+{
+	// `Paths<GenericType>` must always be assignable to `Get`'s `Path` parameter, even when `GenericType` is an unresolved generic.
+	// https://github.com/sindresorhus/type-fest/issues/991
+	type WrapperOfGeneric<GenericType extends {}> = {
+		value: Get<GenericType, Paths<GenericType>>;
+	};
+
+	type Foo = {
+		key: number;
+	};
+
+	expectTypeOf<Get<Foo, 'key'>>().toEqualTypeOf<number>();
+	expectTypeOf<Get<Foo, Paths<Foo>>>().toEqualTypeOf<number>();
+	expectTypeOf<WrapperOfGeneric<Foo>['value']>().toEqualTypeOf<number>();
 }

--- a/test-d/get.ts
+++ b/test-d/get.ts
@@ -168,4 +168,11 @@ expectTypeOf<WithDictionary>().toEqualTypeOf<Get<WithDictionary, readonly []>>()
 	expectTypeOf<Get<Foo, 'key'>>().toEqualTypeOf<number>();
 	expectTypeOf<Get<Foo, Paths<Foo>>>().toEqualTypeOf<number>();
 	expectTypeOf<WrapperOfGeneric<Foo>['value']>().toEqualTypeOf<number>();
+
+	type WithNumberKey = {
+		1: boolean;
+	};
+
+	expectTypeOf<Get<WithNumberKey, Paths<WithNumberKey>>>().toEqualTypeOf<boolean>();
+	expectTypeOf<WrapperOfGeneric<WithNumberKey>['value']>().toEqualTypeOf<boolean>();
 }


### PR DESCRIPTION
`Get<T, Paths<T>>` fails to compile for a generic `T` (#991). `Paths<T>` can include bare numeric-literal keys (e.g. `1` alongside `'1'`), which for an unresolved generic `T` TypeScript treats structurally as `string | number`. `Get`'s `Path` parameter was constrained to string only, so it rejected the `number` and the whole expression failed to typecheck.

This widens `Get`'s `Path` constraint to also accept `Paths<BaseType>` and normalizes the path through `ToString` before splitting, so a bare-number path resolves the same as its string form.

Added a `test-d/get.ts` case for `Get<T, Paths<T>>` with a generic `T`. It fails to compile without the fix and passes with it. `test:tsc`, `test:tsd`, `test:xo` and `npm test` all green.

Closes #991
