### PR TITLE
`Jsonify`: Fix optional properties leaking `undefined` into the key set

### DIFF
--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -25,16 +25,11 @@ type JsonifyList<T extends UnknownArray> = T extends readonly []
 			? JsonValue[]
 			: Array<T[number] extends NotJsonable ? null : Jsonify<UndefinedToNull<T[number]>>>;
 
-// Note: `Exclude<..., undefined>` is required because optional properties add `undefined` to the resulting union, which would otherwise corrupt the key set of the resulting object (e.g., `keyof Jsonify<{a?: string}>` would include `undefined`).
-type FilterJsonableKeys<T extends object> = Exclude<{
-	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
-}[keyof T], undefined>;
-
 /**
 JSON serialize objects (not including arrays) and classes.
 */
 type JsonifyObject<T extends object> = {
-	[Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
+	[Key in keyof T as T[Key] extends NotJsonable ? never : Key]: Jsonify<T[Key]>;
 };
 
 /**

--- a/source/jsonify.d.ts
+++ b/source/jsonify.d.ts
@@ -25,9 +25,10 @@ type JsonifyList<T extends UnknownArray> = T extends readonly []
 			? JsonValue[]
 			: Array<T[number] extends NotJsonable ? null : Jsonify<UndefinedToNull<T[number]>>>;
 
-type FilterJsonableKeys<T extends object> = {
+// Note: `Exclude<..., undefined>` is required because optional properties add `undefined` to the resulting union, which would otherwise corrupt the key set of the resulting object (e.g., `keyof Jsonify<{a?: string}>` would include `undefined`).
+type FilterJsonableKeys<T extends object> = Exclude<{
 	[Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
-}[keyof T];
+}[keyof T], undefined>;
 
 /**
 JSON serialize objects (not including arrays) and classes.

--- a/test-d/jsonify.ts
+++ b/test-d/jsonify.ts
@@ -188,6 +188,9 @@ expectType<never>(plainFunction);
 declare const plainSymbol: Jsonify<typeof symbol>;
 expectType<never>(plainSymbol);
 
+declare const plainNever: Jsonify<never>;
+expectType<never>(plainNever);
+
 // Array members become null
 declare const arrayMemberUndefined: Jsonify<Array<typeof undefined>>;
 expectType<null[]>(arrayMemberUndefined);
@@ -304,6 +307,28 @@ declare const jsonifiedNonOptionalTypeUnion: Jsonify<NonOptionalTypeUnion>;
 expectType<{a?: string}>(jsonifiedOptionalPrimitive);
 expectType<{}>(jsonifiedOptionalTypeUnion);
 expectType<{a?: string}>(jsonifiedNonOptionalTypeUnion);
+
+// Test that optional properties don't leak `undefined` into the key set and that re-applying `Jsonify` is a no-op.
+type OptionalMixed = {
+	required: string;
+	optional?: string;
+};
+
+declare const keyOfJsonifiedOptionalMixed: keyof Jsonify<OptionalMixed>;
+expectType<'required' | 'optional'>(keyOfJsonifiedOptionalMixed);
+
+declare const doubleJsonifiedOptionalMixed: Jsonify<Jsonify<OptionalMixed>>;
+expectType<OptionalMixed>(doubleJsonifiedOptionalMixed);
+
+declare const keyOfJsonifiedOptionalUnknown: keyof Jsonify<{a?: unknown}>;
+expectType<'a'>(keyOfJsonifiedOptionalUnknown);
+
+declare const keyOfJsonifiedOptionalAny: keyof Jsonify<{a?: any}>;
+expectType<'a'>(keyOfJsonifiedOptionalAny);
+
+// An `a?: never` property can only hold `undefined`, so the key is dropped like `{a: undefined}`.
+declare const keyOfJsonifiedOptionalNever: keyof Jsonify<{a?: never}>;
+expectType<never>(keyOfJsonifiedOptionalNever);
 
 // Test for 'Jsonify support for optional object keys, unserializable object values' #424
 // See https://github.com/sindresorhus/type-fest/issues/424


### PR DESCRIPTION
`FilterJsonableKeys` maps each property to its own name and reads all values back out with an indexed access. Reading an optional property adds `undefined` to the result, so for `{a: string; b?: string}` the key union became `"a" | "b" | undefined`. Feeding that union to `Pick` silently builds an object whose key set includes `undefined`, and re-applying `Jsonify` to that output walks the corrupted key set, computes the illegal lookup `T[undefined]`, and collapses the object to `{}`.

Excluding `undefined` from the union keeps the key set clean and makes `Jsonify<Jsonify<T>>` equal `Jsonify<T>`.

Fixes discovered downstream in inngest/inngest#4483.