### PR TITLE
fix: correct typo in docs

### DIFF
--- a/source/tsconfig-json.d.ts
+++ b/source/tsconfig-json.d.ts
@@ -1266,7 +1266,7 @@ export namespace TsConfigJson {
 		exclude?: string[];
 
 		/**
-		Disable infering what types should be added based on filenames in a project.
+		Disable inferring what types should be added based on filenames in a project.
 		*/
 		disableFilenameBasedTypeAcquisition?: boolean;
 	};


### PR DESCRIPTION
Fixes a small typo in the documentation.

- \`infering\` → \`inferring\` in \`source/tsconfig-json.d.ts\`