### PR TITLE
NonEmptyObject: use OmitIndexSignature for better index signature handling

### DIFF
--- a/source/non-empty-object.d.ts
+++ b/source/non-empty-object.d.ts
@@ -1,4 +1,5 @@
 import type {HasRequiredKeys} from './has-required-keys.d.ts';
+import type {OmitIndexSignature} from './omit-index-signature.d.ts';
 import type {RequireAtLeastOne} from './require-at-least-one.d.ts';
 
 /**
@@ -33,6 +34,6 @@ const update2: UpdateRequest<User> = {};
 
 @category Object
 */
-export type NonEmptyObject<T extends object> = HasRequiredKeys<T> extends true ? T : RequireAtLeastOne<T, keyof T>;
+export type NonEmptyObject<T extends object> = HasRequiredKeys<OmitIndexSignature<T>> extends true ? T : RequireAtLeastOne<T, keyof T>;
 
 export {};

--- a/test-d/non-empty-object.ts
+++ b/test-d/non-empty-object.ts
@@ -18,12 +18,38 @@ type TestType3 = {
 
 type TestType4 = {};
 
+type TestTypeWithIndexSignature = {
+	[x: string]: string;
+};
+
+type TestTypeWithOptionalIndexSignature = {
+	[x: string]: string;
+	a?: string;
+};
+
+type TestTypeWithRequiredKeyAndIndexSignature = {
+	[x: string]: string;
+	a: string;
+};
+
 declare const test1: NonEmptyObject<TestType1>;
 declare const test2: NonEmptyObject<TestType2>;
 declare const test3: NonEmptyObject<TestType3>;
 declare const test4: NonEmptyObject<TestType4>;
+declare const test5: NonEmptyObject<TestTypeWithOptionalIndexSignature>;
+declare const test6: NonEmptyObject<TestTypeWithRequiredKeyAndIndexSignature>;
 
 expectType<TestType1>(test1);
 expectType<RequireAtLeastOne<TestType2>>(test2);
 expectType<TestType3>(test3);
 expectNever(test4);
+
+// Index-signature-only types should route through RequireAtLeastOne
+// (RequireAtLeastOne itself has a known limitation with pure index signatures)
+expectType<RequireAtLeastOne<TestTypeWithIndexSignature>>({} as NonEmptyObject<TestTypeWithIndexSignature>);
+
+// Types with optional keys + index signature should also be non-empty
+expectType<RequireAtLeastOne<TestTypeWithOptionalIndexSignature>>(test5);
+
+// Types with explicit required keys + index signature pass through
+expectType<TestTypeWithRequiredKeyAndIndexSignature>(test6);


### PR DESCRIPTION
Use `OmitIndexSignature` before `HasRequiredKeys` in `NonEmptyObject` so that types with only index signatures (no explicit keys) are routed through `RequireAtLeastOne` instead of being incorrectly considered as having required keys.

Previously, index-signature-only types like `{ [x: string]: string }` were incorrectly considered as having required keys (`HasRequiredKeys` returned `true` due to the index signature), causing `NonEmptyObject` to pass them through unchanged. This meant `{}` was silently accepted, defeating the purpose of `NonEmptyObject`.

Now `NonEmptyObject<{ [x: string]: string }>` correctly routes to `RequireAtLeastOne`. Note that `RequireAtLeastOne` itself has a known limitation with pure index signatures that prevents it from fully enforcing non-emptiness in that case, but this change is still an improvement over the previous behavior.

### Test plan
- Existing tests continue to pass
- Added test cases for index-signature-only, optional+index, and required+index type combinations