### PR TITLE
Add `ReadonlyDeep` tests for function returns and class getters

### DIFF
--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -138,3 +138,33 @@ expectAssignable<{
 	(foo: number): string;
 	readonly baz: readonly boolean[];
 }>(readonlyNamespace);
+
+// Function and method return types are not transformed, while getters are
+// structurally ordinary properties, so their values are.
+// See https://github.com/sindresorhus/type-fest/issues/826
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const readonlyFunctionReturningMap = {} as ReadonlyDeep<() => Map<string, number[]>>;
+expectType<() => Map<string, number[]>>(readonlyFunctionReturningMap);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const readonlyObjectWithMethod = {} as ReadonlyDeep<{
+	method: () => Map<string, number[]>;
+}>;
+// The method member becomes readonly, but its signature — including the
+// returned Map — is left untouched.
+expectType<{
+	readonly method: () => Map<string, number[]>;
+}>(readonlyObjectWithMethod);
+expectType<() => Map<string, number[]>>(readonlyObjectWithMethod.method);
+
+class ClassWithGetter {
+	get accessor(): Map<string, number[]> {
+		return new Map();
+	}
+}
+
+// A getter on a class is seen as a plain property of its type, so its value
+// is deep-readonly like any other property.
+declare const readonlyClassWithGetter: ReadonlyDeep<ClassWithGetter>;
+expectType<Readonly<ReadonlyMap<string, readonly number[]>>>(readonlyClassWithGetter.accessor);

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -143,20 +143,16 @@ expectAssignable<{
 // structurally ordinary properties, so their values are.
 // See https://github.com/sindresorhus/type-fest/issues/826
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const readonlyFunctionReturningMap = {} as ReadonlyDeep<() => Map<string, number[]>>;
+declare const readonlyFunctionReturningMap: ReadonlyDeep<() => Map<string, number[]>>;
 expectType<() => Map<string, number[]>>(readonlyFunctionReturningMap);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const readonlyObjectWithMethod = {} as ReadonlyDeep<{
+declare const readonlyObjectWithMethod: ReadonlyDeep<{
 	method: () => Map<string, number[]>;
 }>;
-// The method member becomes readonly, but its signature — including the
-// returned Map — is left untouched.
+// The method member becomes readonly, but its signature — including the returned Map — is left untouched.
 expectType<{
 	readonly method: () => Map<string, number[]>;
 }>(readonlyObjectWithMethod);
-expectType<() => Map<string, number[]>>(readonlyObjectWithMethod.method);
 
 class ClassWithGetter {
 	get accessor(): Map<string, number[]> {
@@ -164,7 +160,6 @@ class ClassWithGetter {
 	}
 }
 
-// A getter on a class is seen as a plain property of its type, so its value
-// is deep-readonly like any other property.
+// A getter on a class is seen as a plain property of its type, so its value is deep-readonly like any other property.
 declare const readonlyClassWithGetter: ReadonlyDeep<ClassWithGetter>;
 expectType<Readonly<ReadonlyMap<string, readonly number[]>>>(readonlyClassWithGetter.accessor);


### PR DESCRIPTION
Fixes #826

Adds the `ReadonlyDeep` coverage asked for in #826 — what happens to a function or method returning a `Map`, and to a class getter:

- `ReadonlyDeep<() => Map<…>>` — the function type passes through **untransformed** (the returned `Map` is not made readonly), per the plain-function branch.
- An object method keeps its signature (return untouched) while the member itself becomes `readonly`.
- A **class getter** is structurally an ordinary property, so its value **is** made deeply readonly: `get accessor(): Map<string, number[]>` reads back as `Readonly<ReadonlyMap<string, readonly number[]>>`.

Test-only change — no behaviour is modified; the assertions document the current semantics so future refactors cannot silently change them.

Local runs: `tsd` on the file, full `tsc`, and `xo` all pass.
