### PR TITLE
Use NoInfer utility type in types

### DIFF
--- a/source/is-any.d.ts
+++ b/source/is-any.d.ts
@@ -5,6 +5,8 @@ Returns a boolean for whether the given type is `any`.
 
 Useful in type utilities, such as disallowing `any`s to be passed to a function.
 
+Uses the built-in [`NoInfer`](https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype) utility type to prevent circular constraint errors.
+
 @example
 ```
 import type {IsAny} from 'type-fest';
@@ -22,6 +24,8 @@ const typedA = get(typedObject, 'a');
 const anyA = get(anyObject, 'a');
 //=> any
 ```
+
+@see https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype
 
 @category Type Guard
 @category Utilities


### PR DESCRIPTION
Closes #848.

Adds a JSDoc reference to the built-in NoInfer<Type> utility type in the IsAny type definition, documenting that NoInfer prevents circular constraint errors when IsAny is used in function generic constraints.

The NoInfer type was already being used in the IsAny implementation (since #993) via a custom type alias, which was later replaced with the built-in after upgrading to TypeScript 5.4+. This PR adds documentation linking to the built-in NoInfer utility type and confirms that a review of all types in the library found no other types that would benefit from using NoInfer.

See the discussion in #848 for context.