### PR TITLE
fix: remove Partial from Dependency type

### DIFF
--- a/source/package-json.d.ts
+++ b/source/package-json.d.ts
@@ -206,7 +206,7 @@ export namespace PackageJson {
 	/**
 	Dependencies of the package. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or Git URL.
 	*/
-	type Dependency = Partial<Record<string, string>>;
+	type Dependency = Record<string, string>;
 
 	/**
 	Recursive map describing selective dependency version overrides supported by npm.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Currently the Dependency type is a partial of `Record<string, string>`, which allows `{ 'type-fest': undefined }`.

Tests are failing but I think they are not related.