### PR TITLE
Add `SetOptionalDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,7 @@ export type {Optional} from './source/optional.d.ts';
 export type {Opaque, UnwrapOpaque, Tagged, GetTagMetadata, UnwrapTagged} from './source/tagged.d.ts';
 export type {InvariantOf} from './source/invariant-of.d.ts';
 export type {SetOptional} from './source/set-optional.d.ts';
+export type {SetOptionalDeep} from './source/set-optional-deep.d.ts';
 export type {SetReadonly} from './source/set-readonly.d.ts';
 export type {SetRequired} from './source/set-required.d.ts';
 export type {SetRequiredDeep} from './source/set-required-deep.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ Click the type names for complete docs.
 - [`UnwrapTagged`](source/tagged.d.ts) - Get the untagged portion of a tagged type created with `Tagged`.
 - [`InvariantOf`](source/invariant-of.d.ts) - Create an [invariant type](https://basarat.gitbook.io/typescript/type-system/type-compatibility#footnote-invariance), which is a type that does not accept supertypes and subtypes.
 - [`SetOptional`](source/set-optional.d.ts) - Create a type that makes the given keys optional, while keeping the remaining keys as is.
+- [`SetOptionalDeep`](source/set-optional-deep.d.ts) - Create a type that makes the given keys optional, with support for deeply nested key paths, while keeping the remaining keys as is.
 - [`SetReadonly`](source/set-readonly.d.ts) - Create a type that makes the given keys readonly, while keeping the remaining keys as is.
 - [`SetRequired`](source/set-required.d.ts) - Create a type that makes the given keys required, while keeping the remaining keys as is.
 - [`SetRequiredDeep`](source/set-required-deep.d.ts) - Create a type that makes the given keys required, with support for deeply nested key paths, while keeping the remaining keys as is.

--- a/source/set-optional-deep.d.ts
+++ b/source/set-optional-deep.d.ts
@@ -83,9 +83,9 @@ the earliest requested index and everything from there on is made optional.
 */
 type SetArrayOptional<TArray extends UnknownArray, Keys> =
 	TArray extends unknown // For distributing `TArray` when it's a union
-		? number extends TArray['length']
-			// A non-tuple array (e.g. `string[]`) or a variadic tuple with a rest
-			// element has no fixed trailing index to mark optional, so leave it as is.
+		? keyof TArray & `${number}` extends never
+			// A non-tuple array (e.g. `string[]`) has no fixed index to mark optional, so leave it as is.
+			// Tuples that end in a rest element still have fixed leading elements, which `MakeTailOptional` handles.
 			? TArray
 			: MakeTailOptional<TArray, TupleCut<TArray, Keys>>
 		: never;

--- a/source/set-optional-deep.d.ts
+++ b/source/set-optional-deep.d.ts
@@ -1,0 +1,125 @@
+import type {If} from './if.d.ts';
+import type {IsAny} from './is-any.d.ts';
+import type {IsArrayReadonly, NonRecursiveType} from './internal/index.d.ts';
+import type {OptionalKeysOf} from './optional-keys-of.d.ts';
+import type {PartialDeep} from './partial-deep.d.ts';
+import type {Paths} from './paths.d.ts';
+import type {SetOptional} from './set-optional.d.ts';
+import type {SimplifyDeep} from './simplify-deep.d.ts';
+import type {StringToNumber} from './string-to-number.d.ts';
+import type {UnionToTuple} from './union-to-tuple.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
+
+/**
+Create a type that makes the given keys optional, with support for deeply nested key paths, while keeping the remaining keys as is.
+
+Use-case: Selectively make nested properties optional in complex types like models.
+
+@example
+```
+import type {SetOptionalDeep} from 'type-fest';
+
+type Foo = {
+	a: number;
+	b: string;
+	c: Array<{
+		d: number;
+	}>;
+};
+
+type SomeOptionalDeep = SetOptionalDeep<Foo, 'a' | `c.${number}.d`>;
+//=> {b: string; c: {d?: number}[]; a?: number}
+
+// Set specific indices in an array to be optional.
+type ArrayExample = SetOptionalDeep<{a: [number, number, number]}, 'a.1' | 'a.2'>;
+//=> {a: [number, number?, number?]}
+```
+
+@category Object
+*/
+export type SetOptionalDeep<BaseType, KeyPaths extends Paths<BaseType>> = IsAny<KeyPaths> extends true
+	? SimplifyDeep<PartialDeep<BaseType>>
+	: SetOptionalDeepHelper<BaseType, UnionToTuple<KeyPaths>>;
+
+/**
+Internal helper for {@link SetOptionalDeep}.
+
+Recursively transforms the `BaseType` by applying {@link SetOptionalDeepSinglePath} for each path in `KeyPathsTuple`.
+*/
+type SetOptionalDeepHelper<BaseType, KeyPathsTuple extends UnknownArray> =
+	KeyPathsTuple extends [infer KeyPath, ...infer RestPaths]
+		? SetOptionalDeepHelper<SetOptionalDeepSinglePath<BaseType, KeyPath>, RestPaths>
+		: BaseType;
+
+/**
+Makes a single path optional in `BaseType`.
+*/
+type SetOptionalDeepSinglePath<BaseType, KeyPath> = BaseType extends NonRecursiveType
+	? BaseType
+	: KeyPath extends `${infer Property}.${infer RestPath}`
+		? {
+			[Key in keyof BaseType]: Property extends `${Key & (string | number)}`
+				? SetOptionalDeepSinglePath<BaseType[Key], RestPath>
+				: BaseType[Key];
+		}
+		: SetOptionalLeaf<BaseType, (KeyPath | StringToNumber<KeyPath & string>) & keyof BaseType>;
+
+/**
+Makes the given keys optional at a single level, dispatching to array-aware handling for tuples.
+*/
+type SetOptionalLeaf<BaseType, Keys extends keyof BaseType> =
+	BaseType extends UnknownArray
+		? SetArrayOptional<BaseType, Keys> extends infer ResultantArray
+			? If<IsArrayReadonly<BaseType>, Readonly<ResultantArray>, ResultantArray>
+			: never
+		: SetOptional<BaseType, Keys>;
+
+/**
+Add the optional modifier to the specified keys in an array.
+
+Optional elements can only appear at the tail of a tuple, so making one element
+optional forces every element after it to become optional too. The tail is cut at
+the earliest requested index and everything from there on is made optional.
+*/
+type SetArrayOptional<TArray extends UnknownArray, Keys> =
+	TArray extends unknown // For distributing `TArray` when it's a union
+		? number extends TArray['length']
+			// A non-tuple array (e.g. `string[]`) or a variadic tuple with a rest
+			// element has no fixed trailing index to mark optional, so leave it as is.
+			? TArray
+			: MakeTailOptional<TArray, TupleCut<TArray, Keys>>
+		: never;
+
+/**
+Find the earliest requested index. Everything from that index to the end of the tuple can be made optional.
+*/
+type TupleCut<
+	TArray extends UnknownArray,
+	Keys,
+	Counter extends any[] = [],
+> = TArray extends readonly [(infer First)?, ...infer Rest]
+	? keyof TArray & `${number}` extends never
+		? Counter
+		: `${Counter['length']}` extends `${Keys & (string | number)}`
+			? Counter
+			: TupleCut<Rest, Keys, [...Counter, any]>
+	: Counter;
+
+/**
+Keep the first `Keep['length']` elements untouched and make every following element optional.
+*/
+type MakeTailOptional<
+	TArray extends UnknownArray,
+	Keep extends any[],
+	Accumulator extends UnknownArray = [],
+> = TArray extends readonly [(infer First)?, ...infer Rest]
+	? keyof TArray & `${number}` extends never
+		? [...Accumulator, ...TArray]
+		: Keep extends [any, ...infer KeepRest]
+			? '0' extends OptionalKeysOf<TArray>
+				? MakeTailOptional<Rest, KeepRest extends any[] ? KeepRest : [], [...Accumulator, First?]>
+				: MakeTailOptional<Rest, KeepRest extends any[] ? KeepRest : [], [...Accumulator, TArray[0]]>
+			: MakeTailOptional<Rest, [], [...Accumulator, First?]>
+	: [...Accumulator, ...TArray];
+
+export {};

--- a/test-d/set-optional-deep.ts
+++ b/test-d/set-optional-deep.ts
@@ -1,0 +1,101 @@
+import {expectType} from 'tsd';
+import type {SetOptionalDeep} from '../index.d.ts';
+
+// Set nested key to optional
+declare const variation1: SetOptionalDeep<{a: number; b: {c: string}}, 'b.c'>;
+expectType<{a: number; b: {c?: string}}>(variation1);
+
+// Set key to optional but not nested keys if not specified
+declare const variation2: SetOptionalDeep<{a: number; b: {c: string}}, 'b'>;
+expectType<{a: number; b?: {c: string}}>(variation2);
+
+// Set root key to optional
+declare const variation3: SetOptionalDeep<{a: number; b: {c: string}}, 'a'>;
+expectType<{a?: number; b: {c: string}}>(variation3);
+
+// Keeps optional key as optional
+declare const variation4: SetOptionalDeep<{a?: number; b: {c: string}}, 'a'>;
+expectType<{a?: number; b: {c: string}}>(variation4);
+
+// Set key to optional in a union.
+declare const variation5: SetOptionalDeep<{a: '1'; b: {c: boolean}} | {a: '2'; b: {c: boolean}}, 'a'>;
+expectType<{a?: '1'; b: {c: boolean}} | {a?: '2'; b: {c: boolean}}>(variation5);
+
+// Set key with array type to optional
+declare const variation6: SetOptionalDeep<{a: Array<{b: number}>}, 'a'>;
+expectType<{a?: Array<{b: number}>}>(variation6);
+
+// Can set both root and nested keys to optional
+declare const variation7: SetOptionalDeep<{a: number; b: {c: string}}, 'b' | 'b.c'>;
+expectType<{a: number; b?: {c?: string}}>(variation7);
+
+// Preserves optional root keys
+declare const variation8: SetOptionalDeep<{a?: 1; b: {c: 1}}, 'b.c'>;
+expectType<{a?: 1; b: {c?: 1}}>(variation8);
+
+// Preserves union in root keys
+declare const variation9: SetOptionalDeep<{a: 1; b: {c: 1} | number}, 'b.c'>;
+expectType<{a: 1; b: {c?: 1} | number}>(variation9);
+
+// Preserves readonly
+declare const variation10: SetOptionalDeep<{a: 1; readonly b: {c: 1}}, 'b.c'>;
+expectType<{a: 1; readonly b: {c?: 1}}>(variation10);
+
+declare const variation11: SetOptionalDeep<{readonly a: 1; readonly b: {readonly c: 1}}, 'a' | 'b'>;
+expectType<{readonly a?: 1; readonly b?: {readonly c: 1}}>(variation11);
+
+declare const variation12: SetOptionalDeep<{readonly a: 1; readonly b: {readonly c: 1}}, 'a' | 'b' | 'b.c'>;
+expectType<{readonly a?: 1; readonly b?: {readonly c?: 1}}>(variation12);
+
+// Works with number keys
+declare const variation13: SetOptionalDeep<{0: 1; 1: {2: string}}, '1.2'>;
+expectType<{0: 1; 1: {2?: string}}>(variation13);
+
+declare const variation14: SetOptionalDeep<{0: 1; 1: {2: string}}, 0 | 1>;
+expectType<{0?: 1; 1?: {2: string}}>(variation14);
+
+// Multiple keys
+declare const variation15: SetOptionalDeep<{a: 1; b: {c: 2}; d: {e: {f: 2}; g: 3}}, 'a' | 'b' | 'b.c' | 'd.e.f' | 'd.g'>;
+expectType<{a?: 1; b?: {c?: 2}; d: {e: {f?: 2}; g?: 3}}>(variation15);
+
+// Index signatures
+declare const variation16: SetOptionalDeep<{[x: string]: any; a: number; b: {c: number}}, 'a' | 'b.c'>;
+expectType<{[x: string]: any; a?: number; b: {c?: number}}>(variation16);
+
+// Does nothing when `KeyPaths` is `never`
+declare const variation17: SetOptionalDeep<{a: number; readonly b: {c: string}}, never>;
+expectType<{a: number; readonly b: {c: string}}>(variation17);
+
+// =================
+// Works with arrays
+// =================
+
+// Make trailing elements optional
+expectType<{a: [string, number?, boolean?]}>({} as SetOptionalDeep<{a: [string, number, boolean]}, 'a.1' | 'a.2'>);
+
+// Make only the last element optional
+expectType<{a: [string, number, boolean?]}>({} as SetOptionalDeep<{a: [string, number, boolean]}, 'a.2'>);
+
+// Making a middle element optional cascades to the following elements, since an optional element cannot precede a required one
+expectType<{a: [string, number?, boolean?]}>({} as SetOptionalDeep<{a: [string, number, boolean]}, 'a.1'>);
+
+// Extends an existing trailing optional run towards the front
+expectType<{a: [string, number?, boolean?]}>({} as SetOptionalDeep<{a: [string, number, boolean?]}, 'a.1'>);
+
+// Works with readonly arrays
+expectType<{readonly a: readonly [string, number?, boolean?]}>(
+	{} as SetOptionalDeep<{readonly a: readonly [string, number, boolean]}, 'a.1' | 'a.2'>,
+);
+
+// Ignores keys that are already optional
+expectType<{a: [string, number?, boolean?]}>({} as SetOptionalDeep<{a: [string, number?, boolean?]}, 'a.2'>);
+
+// Non tuple arrays are left unchanged
+expectType<{a: string[]}>({} as SetOptionalDeep<{a: string[]}, `a.${number}`>);
+
+// Set key inside array to optional
+expectType<{a: Array<{b?: number}>}>({} as SetOptionalDeep<{a: Array<{b: number}>}, `a.${number}.b`>);
+expectType<{readonly a: [{readonly b?: number}]}>({} as SetOptionalDeep<{readonly a: [{readonly b: number}]}, 'a.0.b'>);
+
+// Works with nested arrays
+expectType<{a: [[string, number?]]}>({} as SetOptionalDeep<{a: [[string, number]]}, 'a.0.1'>);

--- a/test-d/set-optional-deep.ts
+++ b/test-d/set-optional-deep.ts
@@ -93,6 +93,14 @@ expectType<{a: [string, number?, boolean?]}>({} as SetOptionalDeep<{a: [string, 
 // Non tuple arrays are left unchanged
 expectType<{a: string[]}>({} as SetOptionalDeep<{a: string[]}, `a.${number}`>);
 
+// Fixed elements of a tuple with a rest element can be made optional
+expectType<{a: [string, number?, ...boolean[]]}>({} as SetOptionalDeep<{a: [string, number, ...boolean[]]}, 'a.1'>);
+expectType<{a: [string?, number?, ...boolean[]]}>({} as SetOptionalDeep<{a: [string, number, ...boolean[]]}, 'a.0'>);
+expectType<{a: [string, number?, boolean?, ...string[]]}>({} as SetOptionalDeep<{a: [string, number, boolean?, ...string[]]}, 'a.1'>);
+expectType<{readonly a: readonly [string, number?, ...boolean[]]}>(
+	{} as SetOptionalDeep<{readonly a: readonly [string, number, ...boolean[]]}, 'a.1'>,
+);
+
 // Set key inside array to optional
 expectType<{a: Array<{b?: number}>}>({} as SetOptionalDeep<{a: Array<{b: number}>}, `a.${number}.b`>);
 expectType<{readonly a: [{readonly b?: number}]}>({} as SetOptionalDeep<{readonly a: [{readonly b: number}]}, 'a.0.b'>);


### PR DESCRIPTION
Closes #1308

This adds `SetOptionalDeep`, the optional counterpart to the existing `SetRequiredDeep`. It makes the given keys optional using dot separated paths, so you can reach into nested objects and arrays instead of only the top level.

```ts
import type {SetOptionalDeep} from 'type-fest';

type Foo = {
	a: number;
	b: string;
	c: Array<{
		d: number;
	}>;
};

type Example = SetOptionalDeep<Foo, 'a' | `c.${number}.d`>;
//=> {b: string; c: {d?: number}[]; a?: number}
```

It mirrors `SetRequiredDeep` closely so the two read the same way, and it reuses the shared internals (`Paths`, `SimplifyDeep`, `PartialDeep`, `UnionToTuple`).

One thing worth calling out about tuples. An optional element can only sit at the tail of a tuple, so making an element optional also makes every element after it optional. Asking for a middle index therefore cascades to the rest of the tuple rather than producing an invalid type.

```ts
type A = SetOptionalDeep<{a: [number, number, number]}, 'a.1'>;
//=> {a: [number, number?, number?]}
```

- [x] Added the type to `index.d.ts`
- [x] Added tests in `test-d/set-optional-deep.ts`
- [x] Added an entry to the readme
- [x] `tsd`, `tsc`, and `xo` all pass locally
