### PR TITLE
Add `Float16Array` to `TypedArray`

### DIFF
--- a/source/typed-array.d.ts
+++ b/source/typed-array.d.ts
@@ -11,6 +11,7 @@ export type TypedArray =
 	| Uint16Array
 	| Int32Array
 	| Uint32Array
+	| Float16Array
 	| Float32Array
 	| Float64Array
 	| BigInt64Array


### PR DESCRIPTION
As of recently, `Float16Array` has been added to typescript under `lib.es2025.float16.d.ts` but is not included in the `TypedArray` type, so just added it.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->