### PR TITLE
Add `AsyncFunction` types

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,9 @@ Click the type names for complete docs.
 - [`Constructor`](source/basic.d.ts) - Matches a [`class` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 - [`AbstractClass`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/2/classes.html#abstract-classes-and-members).
 - [`AbstractConstructor`](source/basic.d.ts) - Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#abstract-construct-signatures) constructor.
+- [`AsyncFunction`](source/basic.d.ts) - Matches an asynchronous function.
+- [`AnyAsyncFunction`](source/basic.d.ts) - Matches any asynchronous function.
+- [`AnyFunction`](source/basic.d.ts) - Matches any function.
 - [`TypedArray`](source/typed-array.d.ts) - Matches any [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), like `Uint8Array` or `Float64Array`.
 - [`ObservableLike`](source/globals/observable-like.d.ts) - Matches a value that is like an [Observable](https://github.com/tc39/proposal-observable).
 - [`LowercaseLetter`](source/characters.d.ts) - Matches any lowercase letter in the basic Latin alphabet (a-z).

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -35,4 +35,71 @@ Matches an [`abstract class`](https://www.typescriptlang.org/docs/handbook/relea
 */
 export type AbstractConstructor<T, Arguments extends unknown[] = any[]> = abstract new(...arguments_: Arguments) => T;
 
+/**
+Matches an asynchronous function.
+
+Use-cases:
+- Constrain a generic type to an asynchronous function.
+- Declare a reusable asynchronous callback signature.
+
+@example
+```
+import type {AsyncFunction} from 'type-fest';
+
+type FetchData = AsyncFunction<[url: URL], Uint8Array>;
+
+const fetchData: FetchData = async url => {
+	const response = await fetch(url);
+	return new Uint8Array(await response.arrayBuffer());
+};
+```
+
+@category Basic
+*/
+export type AsyncFunction<Arguments extends readonly unknown[] = readonly any[], ReturnValue = unknown> = (...arguments_: Arguments) => Promise<ReturnValue>;
+
+/**
+Matches any asynchronous function.
+
+Use-cases:
+- Constrain a generic type to any asynchronous function while erasing its parameters and return value.
+
+@example
+```
+import type {AnyAsyncFunction} from 'type-fest';
+
+function schedule(task: AnyAsyncFunction): void {
+	void task();
+}
+
+schedule(async () => {
+	await Promise.resolve();
+});
+```
+
+@category Basic
+*/
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyAsyncFunction = (...arguments_: readonly any[]) => Promise<unknown>;
+
+/**
+Matches any function.
+
+Use-cases:
+- Constrain a generic type to any function while erasing its parameters and return value.
+
+@example
+```
+import type {AnyFunction} from 'type-fest';
+
+function identity<FunctionType extends AnyFunction>(function_: FunctionType): FunctionType {
+	return function_;
+}
+```
+
+@category Basic
+*/
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyFunction = (...arguments_: readonly any[]) => any;
+
 export {};

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -62,19 +62,20 @@ export type AsyncFunction<Arguments extends readonly unknown[] = readonly any[],
 Matches any asynchronous function.
 
 Use-cases:
-- Constrain a generic type to any asynchronous function while erasing its parameters and return value.
+- Constrain a generic type to any asynchronous function without prescribing its parameters or return value.
 
 @example
 ```
 import type {AnyAsyncFunction} from 'type-fest';
 
-function schedule(task: AnyAsyncFunction): void {
-	void task();
+function register<FunctionType extends AnyAsyncFunction>(function_: FunctionType): FunctionType {
+	return function_;
 }
 
-schedule(async () => {
-	await Promise.resolve();
-});
+const parse = register(async (value: string) => Number.parseInt(value, 10));
+
+const result = parse('42');
+//=> Promise<number>
 ```
 
 @category Basic

--- a/source/basic.d.ts
+++ b/source/basic.d.ts
@@ -101,6 +101,6 @@ function identity<FunctionType extends AnyFunction>(function_: FunctionType): Fu
 @category Basic
 */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyFunction = (...arguments_: readonly any[]) => any;
+export type AnyFunction = (...arguments_: readonly any[]) => unknown;
 
 export {};

--- a/test-d/async-function.ts
+++ b/test-d/async-function.ts
@@ -1,0 +1,18 @@
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
+import type {AnyAsyncFunction, AnyFunction, AsyncFunction} from '../index.d.ts';
+
+declare const asyncFunction: AsyncFunction<[value: string], number>;
+expectType<Promise<number>>(asyncFunction('value'));
+
+declare const defaultAsyncFunction: AsyncFunction;
+expectType<Promise<unknown>>(defaultAsyncFunction());
+
+declare const anyAsyncFunction: AsyncFunction<any, any>;
+expectType<any>(anyAsyncFunction());
+
+expectAssignable<AnyAsyncFunction>(async () => 'value');
+expectNotAssignable<AnyAsyncFunction>(() => 'value');
+
+expectAssignable<AnyFunction>((value: never) => value);
+expectAssignable<AnyFunction>(async () => 'value');
+expectAssignable<AnyFunction>(() => 'value');

--- a/test-d/async-function.ts
+++ b/test-d/async-function.ts
@@ -4,8 +4,26 @@ import type {AnyAsyncFunction, AnyFunction, AsyncFunction} from '../index.d.ts';
 declare const asyncFunction: AsyncFunction<[value: string], number>;
 expectType<Promise<number>>(asyncFunction('value'));
 
+// `Arguments` is enforced.
+// The required `value` argument cannot be omitted.
+// @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+asyncFunction();
+// `value` must be a string.
+// @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+asyncFunction(123);
+
+// `ReturnValue` is enforced.
+expectNotAssignable<AsyncFunction<[value: string], number>>(
+	async (value: string) => value,
+);
+
 declare const defaultAsyncFunction: AsyncFunction;
 expectType<Promise<unknown>>(defaultAsyncFunction());
+
+// Defaults accept arbitrary arguments.
+expectType<Promise<unknown>>(defaultAsyncFunction('value', 123));
 
 declare const anyAsyncFunction: AsyncFunction<any, any>;
 expectType<Promise<any>>(anyAsyncFunction());
@@ -20,3 +38,13 @@ expectNotAssignable<AnyAsyncFunction>(synchronousFunction);
 expectAssignable<AnyFunction>((value: never) => value);
 expectAssignable<AnyFunction>(async () => 'value');
 expectAssignable<AnyFunction>(() => 'value');
+
+// Erased functions remain callable with an unknown result.
+declare const anyFunction: AnyFunction;
+expectType<unknown>(anyFunction('value', 123));
+
+declare const erasedAsyncFunction: AnyAsyncFunction;
+expectType<Promise<unknown>>(erasedAsyncFunction('value', 123));
+
+// Ordinary required parameters are supported.
+expectAssignable<AnyFunction>((value: string) => value);

--- a/test-d/async-function.ts
+++ b/test-d/async-function.ts
@@ -10,8 +10,12 @@ expectType<Promise<unknown>>(defaultAsyncFunction());
 declare const anyAsyncFunction: AsyncFunction<any, any>;
 expectType<Promise<any>>(anyAsyncFunction());
 
-expectAssignable<AnyAsyncFunction>(async () => 'value');
-expectNotAssignable<AnyAsyncFunction>(() => 'value');
+expectAssignable<AnyAsyncFunction>(async (value: string) => value.length);
+expectNotAssignable<AnyAsyncFunction>(async (value: never) => value);
+declare const promiseReturningFunction: (value: {id: string}) => Promise<string>;
+declare const synchronousFunction: (value: {id: string}) => string;
+expectAssignable<AnyAsyncFunction>(promiseReturningFunction);
+expectNotAssignable<AnyAsyncFunction>(synchronousFunction);
 
 expectAssignable<AnyFunction>((value: never) => value);
 expectAssignable<AnyFunction>(async () => 'value');

--- a/test-d/async-function.ts
+++ b/test-d/async-function.ts
@@ -8,7 +8,7 @@ declare const defaultAsyncFunction: AsyncFunction;
 expectType<Promise<unknown>>(defaultAsyncFunction());
 
 declare const anyAsyncFunction: AsyncFunction<any, any>;
-expectType<any>(anyAsyncFunction());
+expectType<Promise<any>>(anyAsyncFunction());
 
 expectAssignable<AnyAsyncFunction>(async () => 'value');
 expectNotAssignable<AnyAsyncFunction>(() => 'value');


### PR DESCRIPTION
Closes #121

This adds the three connected Basic function types from the final issue specification:

- `AsyncFunction<Arguments, ReturnValue>` for a reusable asynchronous signature;
- `AnyAsyncFunction` for an erased asynchronous function constraint;
- `AnyFunction` for an erased sync-or-async function constraint.

The definitions follow the names, defaults, and `any` edge-case decision discussed in #121. They live alongside the existing class and constructor types in `source/basic.d.ts`, with README entries and examples.

Tests cover generic arguments and return values, defaults, `any`, rejection of synchronous functions by `AnyAsyncFunction`, acceptance of synchronous and asynchronous functions by `AnyFunction`, and a `never` parameter.

Validation:

- `npx tsd --files test-d/async-function.ts`
- `npm run test:tsd`
- `npm run test:tsc`
- `npm run test:xo`
- `npm run test:linter`

Codex assisted with checking the type edge cases, naming, documentation, examples, and test coverage against the upstream discussion and repository conventions.

<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->
