### PR TITLE
test: add ReadonlyDeep coverage for returns and getters

### DIFF
--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -138,3 +138,33 @@ expectAssignable<{
 	(foo: number): string;
 	readonly baz: readonly boolean[];
 }>(readonlyNamespace);
+
+// Function and method return types are not transformed, while getters are
+// structurally ordinary properties, so their values are.
+// See https://github.com/sindresorhus/type-fest/issues/826
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const readonlyFunctionReturningMap = {} as ReadonlyDeep<() => Map<string, number[]>>;
+expectType<() => Map<string, number[]>>(readonlyFunctionReturningMap);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const readonlyObjectWithMethod = {} as ReadonlyDeep<{
+	method: () => Map<string, number[]>;
+}>;
+// The method member becomes readonly, but its signature — including the
+// returned Map — is left untouched.
+expectType<{
+	readonly method: () => Map<string, number[]>;
+}>(readonlyObjectWithMethod);
+expectType<() => Map<string, number[]>>(readonlyObjectWithMethod.method);
+
+class ClassWithGetter {
+	get accessor(): Map<string, number[]> {
+		return new Map();
+	}
+}
+
+// A getter on a class is seen as a plain property of its type, so its value
+// is deep-readonly like any other property.
+declare const readonlyClassWithGetter: ReadonlyDeep<ClassWithGetter>;
+expectType<Readonly<ReadonlyMap<string, readonly number[]>>>(readonlyClassWithGetter.accessor);

--- a/test-d/readonly-deep.ts
+++ b/test-d/readonly-deep.ts
@@ -143,20 +143,16 @@ expectAssignable<{
 // structurally ordinary properties, so their values are.
 // See https://github.com/sindresorhus/type-fest/issues/826
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const readonlyFunctionReturningMap = {} as ReadonlyDeep<() => Map<string, number[]>>;
+declare const readonlyFunctionReturningMap: ReadonlyDeep<() => Map<string, number[]>>;
 expectType<() => Map<string, number[]>>(readonlyFunctionReturningMap);
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const readonlyObjectWithMethod = {} as ReadonlyDeep<{
+declare const readonlyObjectWithMethod: ReadonlyDeep<{
 	method: () => Map<string, number[]>;
 }>;
-// The method member becomes readonly, but its signature — including the
-// returned Map — is left untouched.
+// The method member becomes readonly, but its signature — including the returned Map — is left untouched.
 expectType<{
 	readonly method: () => Map<string, number[]>;
 }>(readonlyObjectWithMethod);
-expectType<() => Map<string, number[]>>(readonlyObjectWithMethod.method);
 
 class ClassWithGetter {
 	get accessor(): Map<string, number[]> {
@@ -164,7 +160,6 @@ class ClassWithGetter {
 	}
 }
 
-// A getter on a class is seen as a plain property of its type, so its value
-// is deep-readonly like any other property.
+// A getter on a class is seen as a plain property of its type, so its value is deep-readonly like any other property.
 declare const readonlyClassWithGetter: ReadonlyDeep<ClassWithGetter>;
 expectType<Readonly<ReadonlyMap<string, readonly number[]>>>(readonlyClassWithGetter.accessor);


### PR DESCRIPTION
## Summary

Adds focused tests for `ReadonlyDeep` behavior on function return types and class getters.

## Why

This locks in expected inference behavior and prevents regressions in edge cases.
