### PR TITLE
Add `UndefinableDeep` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ export type {PickDeep} from './source/pick-deep.d.ts';
 export type {OmitDeep} from './source/omit-deep.d.ts';
 export type {PartialOnUndefinedDeep, PartialOnUndefinedDeepOptions} from './source/partial-on-undefined-deep.d.ts';
 export type {UndefinedOnPartialDeep} from './source/undefined-on-partial-deep.d.ts';
+export type {UndefinableDeep} from './source/undefinable-deep.d.ts';
 export type {ReadonlyDeep} from './source/readonly-deep.d.ts';
 export type {LiteralUnion} from './source/literal-union.d.ts';
 export type {Promisable} from './source/promisable.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ Click the type names for complete docs.
 - [`PartialDeep`](source/partial-deep.d.ts) - Create a deeply optional version of another type.
 - [`PartialOnUndefinedDeep`](source/partial-on-undefined-deep.d.ts) - Create a deep version of another type where all keys accepting `undefined` type are set to optional.
 - [`UndefinedOnPartialDeep`](source/undefined-on-partial-deep.d.ts) - Create a deep version of another type where all optional keys are set to also accept `undefined`.
+- [`UndefinableDeep`](source/undefinable-deep.d.ts) - Create a deep version of another type where all keys are set to also accept `undefined`.
 - [`UnwrapPartial`](source/unwrap-partial.d.ts) - Revert the `Partial` modifier on an object type.
 - [`UnwrapRequired`](source/unwrap-required.d.ts) - Revert the `Required` modifier on an object type.
 - [`ReadonlyDeep`](source/readonly-deep.d.ts) - Create a deeply immutable version of another type.

--- a/source/undefinable-deep.d.ts
+++ b/source/undefinable-deep.d.ts
@@ -1,0 +1,98 @@
+import type {BuiltIns, HasMultipleCallSignatures} from './internal/index.d.ts';
+import type {IsNever} from './is-never.d.ts';
+import type {Simplify} from './simplify.d.ts';
+
+/**
+Create a deep version of another type where all keys are set to also accept `undefined`.
+
+This is like {@link UndefinedOnPartialDeep}, but instead of only widening the already-optional keys, it widens *every* key (required and optional alike) so that each value can additionally be `undefined`. Keys keep their original optionality and `readonly` modifiers, and the transformation is applied at every level.
+
+Use-cases:
+- Modeling a fully-shaped object whose fields are all present but may not yet be populated, such as a form-state object initialized from a schema before the user fills it in.
+- Describing the result of a reset or clear operation that keeps the object's structure while blanking out every value.
+- Typing partially-hydrated data where every field might be missing a value but the shape is fixed.
+
+Use `{[Key in keyof Type]: Type[Key] | undefined}` if you only need one level deep.
+
+@example
+```
+import type {UndefinableDeep} from 'type-fest';
+
+type Settings = {
+	textEditor: {
+		fontSize: number;
+		fontColor: string;
+	};
+	autosave: boolean;
+};
+
+type DraftSettings = UndefinableDeep<Settings>;
+//=> {
+// 	textEditor: {
+// 		fontSize: number | undefined;
+// 		fontColor: string | undefined;
+// 	} | undefined;
+// 	autosave: boolean | undefined;
+// }
+
+const draft: DraftSettings = {
+	textEditor: {
+		fontSize: undefined, // Present but not yet chosen
+		fontColor: undefined,
+	},
+	autosave: undefined,
+};
+```
+
+Note that types containing overloaded functions are not made deeply undefinable due to a [TypeScript limitation](https://github.com/microsoft/TypeScript/issues/29732).
+
+@see {@link UndefinedOnPartialDeep}
+
+@category Object
+@category Array
+@category Set
+@category Map
+*/
+export type UndefinableDeep<T> = T extends BuiltIns | ((new (...arguments_: any[]) => unknown))
+	? T
+	: T extends Map<infer KeyType, infer ValueType>
+		? Map<UndefinableDeep<KeyType>, UndefinableDeep<ValueType>>
+		: T extends Set<infer ItemType>
+			? Set<UndefinableDeep<ItemType>>
+			: T extends ReadonlyMap<infer KeyType, infer ValueType>
+				? ReadonlyMap<UndefinableDeep<KeyType>, UndefinableDeep<ValueType>>
+				: T extends ReadonlySet<infer ItemType>
+					? ReadonlySet<UndefinableDeep<ItemType>>
+					: T extends WeakMap<infer KeyType, infer ValueType>
+						? WeakMap<UndefinableDeep<KeyType>, UndefinableDeep<ValueType>>
+						: T extends WeakSet<infer ItemType>
+							? WeakSet<UndefinableDeep<ItemType>>
+							: T extends Promise<infer ValueType>
+								? Promise<UndefinableDeep<ValueType>>
+								: T extends (...arguments_: any[]) => unknown
+									? IsNever<keyof T> extends true
+										? T // For functions with no properties
+										: HasMultipleCallSignatures<T> extends true
+											? T
+											: ((...arguments_: Parameters<T>) => ReturnType<T>) & UndefinableObjectDeep<T>
+									: T extends readonly unknown[]
+										? UndefinableListDeep<T>
+										: T extends object
+											? Simplify<UndefinableObjectDeep<T>> // `Simplify` to prevent `UndefinableObjectDeep` from appearing in the resulting type
+											: unknown;
+
+/**
+Same as `UndefinableDeep`, but accepts only arrays and tuples as inputs, recursing into their elements without making the elements themselves `undefined`. Homomorphic mapping preserves the tuple structure along with `readonly`, optional, and rest modifiers. Internal helper for `UndefinableDeep`.
+*/
+type UndefinableListDeep<T extends readonly unknown[]> = {
+	[KeyType in keyof T]: UndefinableDeep<T[KeyType]>
+};
+
+/**
+Same as `UndefinableDeep`, but accepts only `object`s as inputs. Internal helper for `UndefinableDeep`.
+*/
+type UndefinableObjectDeep<ObjectType extends object> = {
+	[KeyType in keyof ObjectType]: UndefinableDeep<ObjectType[KeyType]> | undefined
+};
+
+export {};

--- a/test-d/undefinable-deep.ts
+++ b/test-d/undefinable-deep.ts
@@ -1,0 +1,60 @@
+import {expectType} from 'tsd';
+import type {Simplify, UndefinableDeep} from '../index.d.ts';
+
+// Basic objects: every key's value additionally accepts `undefined`, at every level.
+expectType<UndefinableDeep<{a: string; b: number}>>({} as {a: string | undefined; b: number | undefined});
+expectType<UndefinableDeep<{a: {b: {c: string}}}>>({} as {a: {b: {c: string | undefined} | undefined} | undefined});
+
+// Optionality and `readonly` modifiers are preserved.
+expectType<UndefinableDeep<{a?: string; readonly b: number}>>({} as {a?: string | undefined; readonly b: number | undefined});
+expectType<UndefinableDeep<{readonly a: {b: string}}>>({} as {readonly a: {b: string | undefined} | undefined});
+
+// Built-ins pass through, but the property that holds them still accepts `undefined`.
+expectType<UndefinableDeep<{a: Date; b: RegExp}>>({} as {a: Date | undefined; b: RegExp | undefined});
+expectType<UndefinableDeep<string>>('' as string);
+expectType<UndefinableDeep<number>>(0 as number);
+
+// Index signatures.
+expectType<UndefinableDeep<{[key: string]: {a: number}}>>({} as {[key: string]: {a: number | undefined} | undefined});
+
+// Unions distribute.
+expectType<UndefinableDeep<{a: number} | {b: string}>>({} as {a: number | undefined} | {b: string | undefined});
+expectType<UndefinableDeep<{a: {b: number}} | {c: {d: string}}>>(
+	{} as {a: {b: number | undefined} | undefined} | {c: {d: string | undefined} | undefined},
+);
+
+// Non-tuple arrays: elements are recursed into but not themselves widened to `undefined`.
+expectType<UndefinableDeep<string[]>>({} as string[]);
+expectType<UndefinableDeep<ReadonlyArray<{a: number}>>>({} as ReadonlyArray<{a: number | undefined}>);
+expectType<UndefinableDeep<{a: Array<{b: number}>}>>({} as {a: Array<{b: number | undefined}> | undefined});
+
+// Tuples: structure and `readonly`, optional, and rest modifiers are preserved; nested objects are still widened.
+expectType<UndefinableDeep<[string, number]>>({} as [string, number]);
+expectType<UndefinableDeep<[string, number?]>>({} as [string, number?]);
+expectType<UndefinableDeep<[string, ...number[]]>>({} as [string, ...number[]]);
+expectType<UndefinableDeep<readonly [string, {a: number}]>>({} as readonly [string, {a: number | undefined}]);
+
+// Maps and Sets: recurse into keys/values/items without forcing the container slots to `undefined`.
+expectType<UndefinableDeep<Map<string, {a: number}>>>({} as Map<string, {a: number | undefined}>);
+expectType<UndefinableDeep<ReadonlyMap<string, {a: number}>>>({} as ReadonlyMap<string, {a: number | undefined}>);
+expectType<UndefinableDeep<WeakMap<{k: object}, {a: number}>>>({} as WeakMap<{k: object | undefined}, {a: number | undefined}>);
+expectType<UndefinableDeep<Set<{a: number}>>>({} as Set<{a: number | undefined}>);
+expectType<UndefinableDeep<ReadonlySet<{a: number}>>>({} as ReadonlySet<{a: number | undefined}>);
+expectType<UndefinableDeep<WeakSet<{a: object}>>>({} as WeakSet<{a: object | undefined}>);
+
+// Promises.
+expectType<UndefinableDeep<Promise<{a: number}>>>({} as Promise<{a: number | undefined}>);
+
+// Functions: the call signature is preserved and own properties are made deeply undefinable.
+type FunctionWithProperties = {(a1: string, a2: number): boolean; p1: string; readonly p2: {q: number}};
+declare const functionWithProperties: UndefinableDeep<FunctionWithProperties>;
+expectType<boolean>(functionWithProperties('foo', 1));
+expectType<{p1: string | undefined; readonly p2: {q: number | undefined} | undefined}>(
+	{} as Simplify<typeof functionWithProperties>,
+);
+
+// Functions with no properties pass through unchanged.
+expectType<UndefinableDeep<(a: string) => number>>({} as (a: string) => number);
+
+// `never` propagates.
+expectType<UndefinableDeep<never>>({} as never);


### PR DESCRIPTION
Closes #612

Adds `UndefinableDeep`, a deep type where every key is widened to also accept `undefined` (required and optional alike), preserving each key's optional/`readonly` modifiers. This is `UndefinedOnPartialDeep` but for all keys, not just the already-optional ones — useful for form-state objects initialized from a schema, reset/clear results, and partially-hydrated data with a fixed shape.

```ts
type Draft = UndefinableDeep<{textEditor: {fontSize: number}; autosave: boolean}>;
//=> {textEditor: {fontSize: number | undefined} | undefined; autosave: boolean | undefined}
```

Follows the existing deep-type conventions (the style you pointed to on readonly-deep). Tests, types, and docs (readme + TSDoc) included.
