### PR TITLE
`SetOptional`: Add support for making tuple indices optional

### DIFF
--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -59,14 +59,13 @@ type SetArrayOptional<
 		// Enters this branch if `TArray` contains a rest element
 		? TArray extends readonly [...any[], any]
 			? TArray // If there are elements after the rest element, then we can't make any elements optional.
-			: SetArrayOptionalHelper<TArray, Keys, TArray>
-		: SetArrayOptionalHelper<TArray, Keys, TArray>
+			: SetArrayOptionalHelper<TArray, Keys>
+		: SetArrayOptionalHelper<TArray, Keys>
 	: never;
 
 type SetArrayOptionalHelper<
 	TArray extends UnknownArray,
 	Keys,
-	OriginalArray extends UnknownArray,
 	Counter extends any[] = [],
 	Accumulator extends UnknownArray = [],
 	OptionalsAccumulator extends UnknownArray = [],
@@ -78,10 +77,10 @@ type SetArrayOptionalHelper<
 		? '0' extends OptionalKeysOf<TArray> // If the first element of `TArray` is optional
 			? [...Accumulator, ...Partial<OptionalsAccumulator>, ...TArray]
 			: `${Counter['length']}` extends `${Keys & (string | number)}` // If the current index needs to be optional
-				? SetArrayOptionalHelper<Rest, Keys, OriginalArray, [...Counter, any], Accumulator, [...OptionalsAccumulator, First]>
+				? SetArrayOptionalHelper<Rest, Keys, [...Counter, any], Accumulator, [...OptionalsAccumulator, First]>
 				// If the current element is required, but it doesn't need to be optional,
 				// then clear the `OptionalsAccumulator` since optional elements cannot appear before required ones.
-				: SetArrayOptionalHelper<Rest, Keys, OriginalArray, [...Counter, any], [...Accumulator, ...OptionalsAccumulator, First]>
+				: SetArrayOptionalHelper<Rest, Keys, [...Counter, any], [...Accumulator, ...OptionalsAccumulator, First]>
 		: never; // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
 
 export {};

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -1,6 +1,10 @@
 import type {Except} from './except.d.ts';
-import type {HomomorphicPick} from './internal/index.d.ts';
+import type {If} from './if.d.ts';
+import type {HomomorphicPick, IsArrayReadonly} from './internal/index.d.ts';
 import type {Simplify} from './simplify.d.ts';
+import type {SplitOnRestElement} from './split-on-rest-element.d.ts';
+import type {Subtract} from './subtract.d.ts';
+import type {UnknownArray} from './unknown-array.d.ts';
 
 /**
 Create a type that makes the given keys optional, while keeping the remaining keys as is.
@@ -19,6 +23,10 @@ type Foo = {
 
 type SomeOptional = SetOptional<Foo, 'b' | 'c'>;
 //=> {a: number; b?: string; c?: boolean}
+
+// Set specific indices in an array to be optional.
+type ArrayExample = SetOptional<[number, number, number], 1 | 2>;
+//=> [number, number?, number?]
 ```
 
 @category Object
@@ -30,13 +38,48 @@ export type SetOptional<BaseType, Keys extends keyof BaseType> =
 	& _SetOptional<BaseType, Keys>;
 
 type _SetOptional<BaseType, Keys extends keyof BaseType> =
-	BaseType extends unknown // To distribute `BaseType` when it's a union type.
-		? Simplify<
+	BaseType extends UnknownArray
+		? SetArrayOptional<BaseType, Keys> extends infer ResultantArray
+			? If<IsArrayReadonly<BaseType>, Readonly<ResultantArray>, ResultantArray>
+			: never
+		: Simplify<
 			// Pick just the keys that are readonly from the base type.
 			Except<BaseType, Keys>
 			// Pick the keys that should be mutable from the base type and make them mutable.
 			& Partial<HomomorphicPick<BaseType, Keys>>
-		>
-		: never;
+		>;
+
+/**
+Add the optional modifier to the specified keys in an array.
+*/
+type SetArrayOptional<
+	TArray extends UnknownArray,
+	Keys,
+> = TArray extends unknown // For distributing `TArray` when it's a union
+	? SplitOnRestElement<TArray> extends readonly [infer BeforeRest extends UnknownArray, infer Rest extends UnknownArray, infer AfterRest extends UnknownArray]
+		? AfterRest extends readonly []
+			? SetArrayBeforeRestOptional<BeforeRest, Keys> extends infer ResultantArray extends UnknownArray
+				? [...ResultantArray, ...Rest]
+				: never
+			: TArray // If there are elements after the rest element, then we can't make any elements optional.
+		: never
+	: never;
+
+type SetArrayBeforeRestOptional<
+	TArray extends UnknownArray,
+	Keys,
+	ReverseCounter extends number = Subtract<Required<TArray>['length'], 1>,
+	Accumulator extends UnknownArray = [],
+> = TArray extends readonly []
+	? Accumulator
+	: TArray extends readonly [...infer Rest, (infer Last)?]
+		? TArray extends readonly [...any[], any] // If last element is required
+			? `${ReverseCounter}` extends `${Keys & (string | number)}` // If the current index needs to be optional
+				? SetArrayBeforeRestOptional<Rest, Keys, Subtract<ReverseCounter, 1>, [Last?, ...Accumulator]>
+				// If the current element is required, but it doesn't need to be optional,
+				// then we can exit early, since no further elements can now be made optional.
+				: [...TArray, ...Accumulator]
+			: SetArrayBeforeRestOptional<Rest, Keys, Subtract<ReverseCounter, 1>, [Last?, ...Accumulator]>
+		: never; // Should never happen, since `[...infer Rest, (infer Last)?]` is a top-type for arrays.
 
 export {};

--- a/source/set-optional.d.ts
+++ b/source/set-optional.d.ts
@@ -1,9 +1,8 @@
 import type {Except} from './except.d.ts';
 import type {If} from './if.d.ts';
 import type {HomomorphicPick, IsArrayReadonly} from './internal/index.d.ts';
+import type {OptionalKeysOf} from './optional-keys-of.d.ts';
 import type {Simplify} from './simplify.d.ts';
-import type {SplitOnRestElement} from './split-on-rest-element.d.ts';
-import type {Subtract} from './subtract.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
 /**
@@ -56,30 +55,33 @@ type SetArrayOptional<
 	TArray extends UnknownArray,
 	Keys,
 > = TArray extends unknown // For distributing `TArray` when it's a union
-	? SplitOnRestElement<TArray> extends readonly [infer BeforeRest extends UnknownArray, infer Rest extends UnknownArray, infer AfterRest extends UnknownArray]
-		? AfterRest extends readonly []
-			? SetArrayBeforeRestOptional<BeforeRest, Keys> extends infer ResultantArray extends UnknownArray
-				? [...ResultantArray, ...Rest]
-				: never
-			: TArray // If there are elements after the rest element, then we can't make any elements optional.
-		: never
+	? number extends TArray['length']
+		// Enters this branch if `TArray` contains a rest element
+		? TArray extends readonly [...any[], any]
+			? TArray // If there are elements after the rest element, then we can't make any elements optional.
+			: SetArrayOptionalHelper<TArray, Keys, TArray>
+		: SetArrayOptionalHelper<TArray, Keys, TArray>
 	: never;
 
-type SetArrayBeforeRestOptional<
+type SetArrayOptionalHelper<
 	TArray extends UnknownArray,
 	Keys,
-	ReverseCounter extends number = Subtract<Required<TArray>['length'], 1>,
+	OriginalArray extends UnknownArray,
+	Counter extends any[] = [],
 	Accumulator extends UnknownArray = [],
-> = TArray extends readonly []
-	? Accumulator
-	: TArray extends readonly [...infer Rest, (infer Last)?]
-		? TArray extends readonly [...any[], any] // If last element is required
-			? `${ReverseCounter}` extends `${Keys & (string | number)}` // If the current index needs to be optional
-				? SetArrayBeforeRestOptional<Rest, Keys, Subtract<ReverseCounter, 1>, [Last?, ...Accumulator]>
+	OptionalsAccumulator extends UnknownArray = [],
+> = keyof TArray & `${number}` extends never
+	// Enters this branch if `TArray` is empty (e.g., []), or
+	// `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+	? [...Accumulator, ...Partial<OptionalsAccumulator>, ...TArray]
+	: TArray extends readonly [(infer First)?, ...infer Rest]
+		? '0' extends OptionalKeysOf<TArray> // If the first element of `TArray` is optional
+			? [...Accumulator, ...Partial<OptionalsAccumulator>, ...TArray]
+			: `${Counter['length']}` extends `${Keys & (string | number)}` // If the current index needs to be optional
+				? SetArrayOptionalHelper<Rest, Keys, OriginalArray, [...Counter, any], Accumulator, [...OptionalsAccumulator, First]>
 				// If the current element is required, but it doesn't need to be optional,
-				// then we can exit early, since no further elements can now be made optional.
-				: [...TArray, ...Accumulator]
-			: SetArrayBeforeRestOptional<Rest, Keys, Subtract<ReverseCounter, 1>, [Last?, ...Accumulator]>
-		: never; // Should never happen, since `[...infer Rest, (infer Last)?]` is a top-type for arrays.
+				// then clear the `OptionalsAccumulator` since optional elements cannot appear before required ones.
+				: SetArrayOptionalHelper<Rest, Keys, OriginalArray, [...Counter, any], [...Accumulator, ...OptionalsAccumulator, First]>
+		: never; // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
 
 export {};

--- a/test-d/set-optional.ts
+++ b/test-d/set-optional.ts
@@ -49,3 +49,110 @@ expectType<{p1?: string; readonly p2?: number; p3: boolean}>({} as Simplify<type
 // Functions without properties are returned as is
 declare const variation12: SetOptional<(a: string) => number, never>;
 expectType<number>(variation12('foo'));
+
+// =================
+// Works with arrays
+// =================
+
+// Empty array
+expectType<[]>({} as SetOptional<[], never>);
+expectType<readonly []>({} as SetOptional<readonly [], never>);
+
+// All required elements
+expectType<[string, number?]>({} as SetOptional<[string, number], '1'>);
+expectType<[string?, number?, boolean?]>({} as SetOptional<[string, number, boolean], '0' | '1' | '2'>);
+expectType<[(string | number)?]>({} as SetOptional<[(string | number)], '0'>);
+
+// Works with number `Keys`, string `Keys`, and union of them.
+expectType<[string, number, boolean?]>({} as SetOptional<[string, number, boolean], 2>);
+expectType<[string, number?, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean, ...number[]], '1' | '2'>);
+expectType<readonly [string?, number?, boolean?]>({} as SetOptional<readonly [string, number, boolean], '0' | 1 | 2>);
+
+// Mix of optional and required elements
+expectType<[string, number?, boolean?]>({} as SetOptional<[string, number, boolean?], '1'>);
+expectType<readonly [string?, number?, boolean?]>({} as SetOptional<readonly [string, number, boolean?], '0' | '1'>);
+
+// Mix of required and rest elements
+expectType<[string, number, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean, ...number[]], '2'>);
+expectType<[string, number?, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean, ...number[]], '1' | 2>);
+
+// Mix of optional, required, and rest elements
+expectType<readonly [string, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean?, ...number[]], '1'>);
+expectType<[string?, number?, boolean?, ...string[]]>({} as SetOptional<[string, number, boolean?, ...string[]], '0' | 1>);
+
+// Works with readonly arrays
+expectType<readonly [(string | number)?]>({} as SetOptional<readonly [(string | number)], '0'>);
+expectType<readonly [string, number?, boolean?]>({} as SetOptional<readonly [string, number, boolean?], '1'>);
+expectType<readonly [string, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean, ...number[]], '1' | '2'>);
+expectType<readonly [string?, number?, boolean?, ...string[]]>({} as SetOptional<readonly [string, number, boolean?, ...string[]], 0 | '1'>);
+
+// Ignores `Keys` that are already optional
+expectType<[string, number, boolean?]>({} as SetOptional<[string, number, boolean?], '2'>);
+expectType<readonly [string, number?, boolean?]>({} as SetOptional<readonly [string, number?, boolean?], 1 | 2>);
+expectType<readonly [string, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number?, boolean?, ...number[]], 1 | 2>);
+expectType<[string, number?, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean?, ...number[]], '1' | '2'>);
+
+// Ignores `Keys` that are out of bounds
+expectType<[]>({} as SetOptional<[], 1>);
+expectType<[string, number, boolean]>({} as SetOptional<[string, number, boolean], 10>);
+expectType<[string?, number?, boolean?]>({} as SetOptional<[string, number, boolean], 0 | 1 | 2 | 3 | 4>);
+expectType<readonly [string, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean?, ...number[]], 10 | 1>);
+
+// Marks all keys as optional, if `Keys` is `any`.
+expectType<[string?, number?, boolean?]>({} as SetOptional<[string, number, boolean], any>);
+expectType<[string?, number?, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean, ...number[]], any>);
+expectType<readonly [string?, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean, ...number[]], any>);
+expectType<readonly [string?, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean?, ...number[]], any>);
+
+// Marks all keys as optional, if `Keys` is `number`.
+expectType<[string?, number?, boolean?]>({} as SetOptional<[string, number, boolean], number>);
+expectType<[string?, number?, boolean?, ...number[]]>({} as SetOptional<[string, number, boolean, ...number[]], number>);
+expectType<readonly [string?, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean, ...number[]], number>);
+expectType<readonly [string?, number?, boolean?, ...number[]]>({} as SetOptional<readonly [string, number, boolean?, ...number[]], number>);
+
+// Returns the array as-is, if `Keys` is `never`.
+expectType<[string, number?]>({} as SetOptional<[string, number?], never>);
+expectType<readonly [string, number?, ...number[]]>({} as SetOptional<readonly [string, number?, ...number[]], never>);
+
+// Arrays where non-rest elements appear after the rest element are left unchanged, because they can never have optional elements.
+expectType<[...string[], string | undefined, number]>({} as SetOptional<[...string[], string | undefined, number], any>);
+expectType<[boolean, ...string[], string, number]>({} as SetOptional<[boolean, ...string[], string, number], any>);
+
+// Preserves `| undefined`, similar to how built-in `Partial` works.
+expectType<[string | undefined, (number | undefined)?, boolean?]>({} as SetOptional<[string | undefined, number | undefined, boolean], 1 | 2>);
+expectType<readonly [(string | undefined)?, (number | undefined)?, boolean?]>({} as SetOptional<readonly [string | undefined, number | undefined, boolean], 0 | 1 | 2>);
+
+// Optional elements cannot appear before required ones, `Keys` leading to such situations are ignored.
+expectType<[string, number, boolean]>({} as SetOptional<[string, number, boolean], 0 | 1>); // `0` and `1` can't be optional when `2` is required
+expectType<[string, number, boolean, string, string?]>(
+	{} as SetOptional<[string, number, boolean, string, string], 0 | 2 | 4>, // `0` and `2` can't be optional when `3` is required
+);
+expectType<readonly [string, number, boolean?, ...string[]]>(
+	{} as SetOptional<readonly [string, number, boolean, ...string[]], 0 | 2>, // `0` can't be optional when `1` is required
+);
+
+// Works with unions of arrays
+expectType<readonly [] | []>({} as SetOptional<readonly [] | [], never>);
+expectType<[] | readonly [(string | number)?]>({} as SetOptional<[] | readonly [(string | number)], 0>);
+expectType<[string?] | [string, number, boolean?, ...number[]] | readonly [string, number]>(
+	{} as SetOptional<[string] | [string, number, boolean, ...number[]] | readonly [string, number], 0 | 2>,
+);
+expectType<readonly [number, string?] | [string, boolean?, ...number[]] | readonly [string, number, boolean, (string | undefined)?]>(
+	{} as SetOptional<readonly [number, string] | [string, boolean, ...number[]] | readonly [string, number, boolean, (string | undefined)], 1 | 3>,
+);
+expectType<readonly [...number[], number] | [string?, boolean?, ...number[]] | readonly [string?, (number | undefined)?, boolean?, string?]>(
+	{} as SetOptional<readonly [...number[], number] | [string, boolean, ...number[]] | readonly [string, number | undefined, boolean?, string?], any>,
+);
+expectType<readonly string[] | [x?: number, y?: number] | [string?, number?, ...string[]]>(
+	{} as SetOptional<readonly string[] | [x: number, y: number] | [string, number, ...string[]], number>,
+);
+
+// Works with labelled tuples
+expectType<[x: string, y?: number]>({} as SetOptional<[x: string, y: number], '1'>);
+expectType<readonly [x: number, y?: number, z?: number]>({} as SetOptional<readonly [x: number, y: number, z: number], 1 | 2>);
+expectType<readonly [x: number, y?: number, z?: number, ...rest: number[]]>({} as SetOptional<readonly [x: number, y: number, z: number, ...rest: number[]], 1 | 2>);
+
+// Non tuple arrays are left unchanged
+expectType<string[]>({} as SetOptional<string[], number>);
+expectType<ReadonlyArray<string | number>>({} as SetOptional<ReadonlyArray<string | number>, number>);
+expectType<number[]>({} as SetOptional<[...number[]], never>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Adds support for making tuple indices optional (similar to `SetRequired`):
```ts
type ArrayExample = SetOptional<[number, number, number], 1 | 2>;
//=> [number, number?, number?]
```

This will _also_ help simplify #1494.