### PR TITLE
`ConditionalKeys`: Fix declared keys being dropped when an index signature is present

### DIFF
--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -53,10 +53,28 @@ export type ConditionalKeys<Base, Condition> = (Base extends UnknownArray ? Tupl
 	? IfNotAnyOrNever<_Base, {ifNot: _ConditionalKeys<_Base, Condition>; ifAny: keyof _Base}>
 	: never;
 
-type _ConditionalKeys<Base, Condition> = keyof {
+// A string index signature widens `keyof` to `string | number`, which swallows the declared
+// literal keys, so they have to be collected separately and matched on their own.
+type _ConditionalKeys<Base, Condition> =
+	| _MatchingKeys<Base, Condition, keyof Base>
+	| _MatchingKeys<Base, Condition, DeclaredKeys<Base>>;
+
+type _MatchingKeys<Base, Condition, Keys> = keyof {
 	[
-	Key in (keyof Base & {}) as // `& {}` prevents homomorphism
+	Key in (Keys & keyof Base) as // The intersection prevents homomorphism
 	ExtendsStrict<Base[Key], Condition> extends true ? Key : never
+	]: never
+};
+
+// The keys `Base` declares itself, without the ones contributed by a `string`, `number` or
+// `symbol` index signature. Homomorphic on purpose — that is what keeps the declared keys
+// visible one by one instead of collapsed into the index signature.
+type DeclaredKeys<Base> = keyof {
+	[
+	Key in keyof Base as string extends Key ? never
+		: number extends Key ? never
+			: symbol extends Key ? never
+				: Key
 	]: never
 };
 

--- a/source/conditional-keys.d.ts
+++ b/source/conditional-keys.d.ts
@@ -1,5 +1,6 @@
 import type {ExtendsStrict} from './extends-strict.d.ts';
 import type {IfNotAnyOrNever} from './internal/type.d.ts';
+import type {OmitIndexSignature} from './omit-index-signature.d.ts';
 import type {TupleToObject} from './tuple-to-object.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
@@ -53,28 +54,18 @@ export type ConditionalKeys<Base, Condition> = (Base extends UnknownArray ? Tupl
 	? IfNotAnyOrNever<_Base, {ifNot: _ConditionalKeys<_Base, Condition>; ifAny: keyof _Base}>
 	: never;
 
-// A string index signature widens `keyof` to `string | number`, which swallows the declared
-// literal keys, so they have to be collected separately and matched on their own.
+// An index signature widens `keyof` — `string` to `string | number`, `` `data-${string}` `` to
+// itself — which swallows the declared literal keys it covers. So the declared keys are matched
+// a second time on their own. The two key sets have to stay separate: unioning them first just
+// collapses the literal keys back into the index signature.
 type _ConditionalKeys<Base, Condition> =
 	| _MatchingKeys<Base, Condition, keyof Base>
-	| _MatchingKeys<Base, Condition, DeclaredKeys<Base>>;
+	| _MatchingKeys<Base, Condition, keyof OmitIndexSignature<Base>>;
 
 type _MatchingKeys<Base, Condition, Keys> = keyof {
 	[
 	Key in (Keys & keyof Base) as // The intersection prevents homomorphism
 	ExtendsStrict<Base[Key], Condition> extends true ? Key : never
-	]: never
-};
-
-// The keys `Base` declares itself, without the ones contributed by a `string`, `number` or
-// `symbol` index signature. Homomorphic on purpose — that is what keeps the declared keys
-// visible one by one instead of collapsed into the index signature.
-type DeclaredKeys<Base> = keyof {
-	[
-	Key in keyof Base as string extends Key ? never
-		: number extends Key ? never
-			: symbol extends Key ? never
-				: Key
 	]: never
 };
 

--- a/test-d/conditional-except.ts
+++ b/test-d/conditional-except.ts
@@ -26,3 +26,7 @@ expectType<{run: () => void}>(awesomeConditionalExcept);
 
 declare const exampleConditionalExceptWithUndefined: ConditionalExcept<Example, string | undefined>;
 expectType<{b?: string | number; d: Record<string, unknown>}>(exampleConditionalExceptWithUndefined);
+
+// Declared keys are still excluded when a non-matching index signature widens `keyof` (https://github.com/sindresorhus/type-fest/issues/1501)
+declare const indexSignatureExcept: ConditionalExcept<{[x: string]: unknown; a: string; b: number}, string>;
+expectType<{[x: string]: unknown; b: number}>(indexSignatureExcept);

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -80,6 +80,12 @@ expectType<'a'>({} as ConditionalKeys<{[x: number]: unknown; [x: string]: unknow
 expectType<'a'>({} as ConditionalKeys<{[x: symbol]: unknown; a: string}, string>);
 expectType<'a'>({} as ConditionalKeys<{[x: string]: unknown; a?: string}, string | undefined>);
 expectType<never>({} as ConditionalKeys<{[x: string]: unknown; a: string}, boolean>);
+expectType<'data-known'>({} as ConditionalKeys<{[x: `data-${string}`]: unknown; 'data-known': string}, string>);
+expectType<'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: unknown; a: string}, string>);
+expectType<'A' | 'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: unknown; A: string; a: string}, string>);
+expectType<'a'>({} as ConditionalKeys<{[x: string]: unknown} & {a: string; b: number}, string>);
+// A pattern index signature that matches still contributes, and subsumes the literal keys it covers
+expectType<`data-${string}`>({} as ConditionalKeys<{[x: `data-${string}`]: string; 'data-known': string}, string>);
 
 // Arrays and tuples
 expectType<'0' | '2'>({} as ConditionalKeys<[string, number, string], string>);

--- a/test-d/conditional-keys.ts
+++ b/test-d/conditional-keys.ts
@@ -72,6 +72,15 @@ expectType<string | number>({} as ConditionalKeys<{[x: string]: string; a: strin
 expectType<Uppercase<string> | 'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: string; a: string}, string>);
 expectType<number | 'a'>({} as ConditionalKeys<{[x: Uppercase<string>]: string; [x: number]: number; a: number}, number>);
 
+// Declared keys are still matched when a non-matching index signature widens `keyof` (https://github.com/sindresorhus/type-fest/issues/1501)
+expectType<'a'>({} as ConditionalKeys<{[x: string]: unknown; a: string; b: number}, string>);
+expectType<'b'>({} as ConditionalKeys<{[x: string]: unknown; a: string; b: number}, number>);
+expectType<'a'>({} as ConditionalKeys<{[x: string]: string | number; a: string; b: number}, string>);
+expectType<'a'>({} as ConditionalKeys<{[x: number]: unknown; [x: string]: unknown; a: string; b: number}, string>);
+expectType<'a'>({} as ConditionalKeys<{[x: symbol]: unknown; a: string}, string>);
+expectType<'a'>({} as ConditionalKeys<{[x: string]: unknown; a?: string}, string | undefined>);
+expectType<never>({} as ConditionalKeys<{[x: string]: unknown; a: string}, boolean>);
+
 // Arrays and tuples
 expectType<'0' | '2'>({} as ConditionalKeys<[string, number, string], string>);
 expectType<'0' | '1'>({} as ConditionalKeys<[string, string, string | number], string>);

--- a/test-d/conditional-pick.ts
+++ b/test-d/conditional-pick.ts
@@ -33,3 +33,7 @@ expectType<never>(noMatchingKeys);
 
 declare const noMatchingKeys2: ConditionalPick<{a: string; b: number}, boolean>;
 expectType<never>(noMatchingKeys2);
+
+// Declared keys are still picked when a non-matching index signature widens `keyof` (https://github.com/sindresorhus/type-fest/issues/1501)
+declare const indexSignaturePick: ConditionalPick<{[x: string]: unknown; a: string; b: number}, string>;
+expectType<{a: string}>(indexSignaturePick);


### PR DESCRIPTION
Fixes #1501.

`ConditionalKeys` returns `never` for any type that has a `string` index signature whose value type doesn't match the condition, even when the declared keys do match:

```ts
type Example = {
	[x: string]: unknown;
	a: string;
	b: number;
};

type StringKeys = ConditionalKeys<Example, string>;
//=> never, expected 'a'
```

`ConditionalPick` and `ConditionalExcept` inherit it, so they come back as `never` and unchanged respectively.

The cause is that a `string` index signature widens `keyof` to `string | number`, which absorbs the literal keys — `'a' | 'b' | string` is just `string`. `_ConditionalKeys` iterates `keyof Base & {}`, and the `& {}` (added in #1198 to stop the mapped type distributing over unions) means it iterates that widened union rather than the declared members, so it only ever asks whether `Base[string]` matches. A `number` or pattern index signature like `[x: Uppercase<string>]` doesn't absorb string literals, which is why those already worked.

So I collect the declared keys separately, with a homomorphic mapped type that drops the index signatures, and match them on their own. The two results get unioned rather than the two key sets — unioning the key sets first would just collapse `'a' | string` back to `string`.

The existing behaviour is unchanged, including the case where the index signature *does* match: `ConditionalKeys<{[x: string]: string; a: string}, string>` still gives `string | number`, since that already subsumes `'a'`. The union handling from #1198 is intact too — `Keys & keyof Base` keeps it non-homomorphic and drops keys that aren't common to every union member.

Added tests to `conditional-keys`, `conditional-pick` and `conditional-except`. Five of them fail on `main` and pass with this change; the symbol-index and no-match cases already passed and are there to pin the surrounding behaviour. `npm test` is green.
