### PR TITLE
`PickDeep`: fix deep recursion path cases by adding a `PathsOptions` argument

### DIFF
--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -139,11 +139,7 @@ export type PathsOptions = {
 	depth?: number;
 };
 
-/**
-Exports for `PickDeep`.
-*/
-// eslint-disable-next-line type-fest/require-exported-types
-export type DefaultPathsOptions = {
+type DefaultPathsOptions = {
 	maxRecursionDepth: 5;
 	bracketNotation: false;
 	leavesOnly: false;

--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -139,6 +139,9 @@ export type PathsOptions = {
 	depth?: number;
 };
 
+/**
+Exports for `PickDeep`.
+*/
 // eslint-disable-next-line type-fest/require-exported-types
 export type DefaultPathsOptions = {
 	maxRecursionDepth: 5;

--- a/source/paths.d.ts
+++ b/source/paths.d.ts
@@ -139,7 +139,8 @@ export type PathsOptions = {
 	depth?: number;
 };
 
-type DefaultPathsOptions = {
+// eslint-disable-next-line type-fest/require-exported-types
+export type DefaultPathsOptions = {
 	maxRecursionDepth: 5;
 	bracketNotation: false;
 	leavesOnly: false;

--- a/source/pick-deep.d.ts
+++ b/source/pick-deep.d.ts
@@ -18,7 +18,7 @@ Use [`Pick<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#
 
 @example
 ```
-import type {PickDeep, PartialDeep} from 'type-fest';
+import type {PickDeep, PartialDeep, Get} from 'type-fest';
 
 type Configuration = {
 	userConfig: {
@@ -59,6 +59,34 @@ type AddressConfig = PickDeep<Configuration, 'userConfig.address.0'>;
 // Supports recurse into array
 type Street = PickDeep<Configuration, 'userConfig.address.1.street2'>;
 //=> {userConfig: {address: [unknown, {street2: string}]}}
+
+// Supports the same `PathsOptions` as `Paths`. The default `maxRecursionDepth` is `5`.
+type Leaf = {
+	bar?: 'LeafBar';
+	foo: 'LeafString';
+};
+
+type Tree = {
+	foo?: Array<
+		{
+			mode: 'test1';
+			bar: Array<{
+				foo: Leaf[] | Leaf;
+			}>;
+		}
+		| {
+			mode: 'test2';
+			foo: 'foo.number.foo';
+			bar: Array<{
+				foo: Leaf[] | Leaf;
+			}>;
+		}
+	>;
+};
+
+type DeepPath = `foo.${number}.bar.${number}.foo.${number}.bar`;
+type TreePick = Get<PickDeep<Tree, DeepPath, {maxRecursionDepth: 6}>, DeepPath>;
+//=> undefined | 'LeafBar'
 ```
 
 @category Object

--- a/source/pick-deep.d.ts
+++ b/source/pick-deep.d.ts
@@ -1,11 +1,12 @@
 import type {TupleOf} from './tuple-of.d.ts';
 import type {BuildObject, NonRecursiveType, ObjectValue} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
-import type {Paths, PathsOptions, DefaultPathsOptions} from './paths.d.ts';
 import type {Simplify} from './simplify.d.ts';
 import type {UnionToIntersection} from './union-to-intersection.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 import type {SimplifyDeep} from './simplify-deep.d.ts';
+import type {Paths} from './paths.d.ts';
+import type {LiteralUnion} from './literal-union.d.ts';
 
 /**
 Pick properties from a deeply-nested object.
@@ -18,7 +19,7 @@ Use [`Pick<T>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#
 
 @example
 ```
-import type {PickDeep, PartialDeep, Get} from 'type-fest';
+import type {PickDeep, PartialDeep} from 'type-fest';
 
 type Configuration = {
 	userConfig: {
@@ -59,41 +60,12 @@ type AddressConfig = PickDeep<Configuration, 'userConfig.address.0'>;
 // Supports recurse into array
 type Street = PickDeep<Configuration, 'userConfig.address.1.street2'>;
 //=> {userConfig: {address: [unknown, {street2: string}]}}
-
-// Supports the same `PathsOptions` as `Paths`. The default `maxRecursionDepth` is `5`.
-type Leaf = {
-	bar?: 'LeafBar';
-	foo: 'LeafString';
-};
-
-type Tree = {
-	foo?: Array<
-		{
-			mode: 'test1';
-			bar: Array<{
-				foo: Leaf[] | Leaf;
-			}>;
-		}
-		| {
-			mode: 'test2';
-			foo: 'foo.number.foo';
-			bar: Array<{
-				foo: Leaf[] | Leaf;
-			}>;
-		}
-	>;
-};
-
-type DeepPath = `foo.${number}.bar.${number}.foo.${number}.bar`;
-type TreePick = Get<PickDeep<Tree, DeepPath, {maxRecursionDepth: 6}>, DeepPath>;
-//=> undefined | 'LeafBar'
 ```
 
 @category Object
 @category Array
 */
-
-export type PickDeep<T, PathUnion extends Paths<T, OP>, OP extends PathsOptions = DefaultPathsOptions> =
+export type PickDeep<T, PathUnion extends LiteralUnion<Paths<T>, string>> =
 	T extends NonRecursiveType
 		? never
 		: T extends UnknownArray
@@ -110,8 +82,18 @@ Pick an object/array from the given object/array by one path.
 type InternalPickDeep<T, Path extends string | number> =
 	T extends NonRecursiveType
 		? never
-		: T extends UnknownArray ? PickDeepArray<T, Path>
-			: T extends object ? Simplify<PickDeepObject<T, Path>>
+		: T extends UnknownArray
+			? PickDeepArray<T, Path> extends infer DeepLeaf
+				? IsNever<DeepLeaf> extends false
+					? DeepLeaf
+					: never
+				: never
+			: T extends object
+				? PickDeepObject<T, Path> extends infer DeepLeaf
+					? IsNever<DeepLeaf> extends false
+						? Simplify<DeepLeaf>
+						: never
+					: never
 				: never;
 
 /**
@@ -121,7 +103,11 @@ type PickDeepObject<RecordType extends object, P extends string | number> =
 	P extends `${infer RecordKeyInPath}.${infer SubPath}`
 		? ObjectValue<RecordType, RecordKeyInPath> extends infer ObjectV
 			? IsNever<ObjectV> extends false
-				? BuildObject<RecordKeyInPath, InternalPickDeep<NonNullable<ObjectV>, SubPath>, RecordType>
+				? InternalPickDeep<NonNullable<ObjectV>, SubPath> extends infer NextLeaf
+					? IsNever<NextLeaf> extends false
+						? BuildObject<RecordKeyInPath, NextLeaf, RecordType>
+						: never
+					: never
 				: never
 			: never
 		: ObjectValue<RecordType, P> extends infer ObjectV
@@ -138,17 +124,24 @@ type PickDeepArray<ArrayType extends UnknownArray, P extends string | number> =
 	P extends `${infer ArrayIndex extends number}.${infer SubPath}`
 		// When `ArrayIndex` is equal to `number`
 		? number extends ArrayIndex
-			? ArrayType extends unknown[]
-				? Array<InternalPickDeep<NonNullable<ArrayType[number]>, SubPath>>
-				: ArrayType extends readonly unknown[]
-					? ReadonlyArray<InternalPickDeep<NonNullable<ArrayType[number]>, SubPath>>
+			? InternalPickDeep<NonNullable<ArrayType[number]>, SubPath> extends infer NextLeaf
+				? IsNever<NextLeaf> extends false
+					? ArrayType extends unknown[]
+						? NextLeaf[]
+						: ArrayType extends readonly unknown[]
+							? readonly NextLeaf[]
+							: never
 					: never
-			// When `ArrayIndex` is a number literal
-			: ArrayType extends unknown[]
-				? [...TupleOf<ArrayIndex>, InternalPickDeep<NonNullable<ArrayType[ArrayIndex]>, SubPath>]
-				: ArrayType extends readonly unknown[]
-					? readonly [...TupleOf<ArrayIndex>, InternalPickDeep<NonNullable<ArrayType[ArrayIndex]>, SubPath>]
+				: never
+			: InternalPickDeep<NonNullable<ArrayType[ArrayIndex]>, SubPath> extends infer NextLeaf
+				? IsNever<NextLeaf> extends false
+					? ArrayType extends unknown[]
+						? [...TupleOf<ArrayIndex>, NextLeaf]
+						: ArrayType extends readonly unknown[]
+							? readonly [...TupleOf<ArrayIndex>, NextLeaf]
+							: never
 					: never
+				: never
 		// When the path is equal to `number`
 		: P extends `${infer ArrayIndex extends number}`
 			// When `ArrayIndex` is `number`

--- a/source/pick-deep.d.ts
+++ b/source/pick-deep.d.ts
@@ -1,7 +1,7 @@
 import type {TupleOf} from './tuple-of.d.ts';
 import type {BuildObject, NonRecursiveType, ObjectValue} from './internal/index.d.ts';
 import type {IsNever} from './is-never.d.ts';
-import type {Paths} from './paths.d.ts';
+import type {Paths, PathsOptions, DefaultPathsOptions} from './paths.d.ts';
 import type {Simplify} from './simplify.d.ts';
 import type {UnionToIntersection} from './union-to-intersection.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
@@ -64,18 +64,16 @@ type Street = PickDeep<Configuration, 'userConfig.address.1.street2'>;
 @category Object
 @category Array
 */
-export type PickDeep<T, PathUnion extends Paths<T>> =
+
+export type PickDeep<T, PathUnion extends Paths<T, OP>, OP extends PathsOptions = DefaultPathsOptions> =
 	T extends NonRecursiveType
 		? never
 		: T extends UnknownArray
-			? UnionToIntersection<{
-				[P in PathUnion]: InternalPickDeep<T, P>;
-			}[PathUnion]
+			? UnionToIntersection<PathUnion extends infer P extends string | number ? InternalPickDeep<T, P> : never
 			>
 			: T extends object
-				? SimplifyDeep<UnionToIntersection<{
-					[P in PathUnion]: InternalPickDeep<T, P>;
-				}[PathUnion]>>
+				? SimplifyDeep<UnionToIntersection<PathUnion extends infer P extends string | number ? InternalPickDeep<T, P> : never
+				>>
 				: never;
 
 /**

--- a/test-d/pick-deep.ts
+++ b/test-d/pick-deep.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import type {PickDeep} from '../index.d.ts';
+import type {PickDeep, Get} from '../index.d.ts';
 
 declare class ClassA {
 	a: string;
@@ -126,3 +126,34 @@ expectType<{1: {0: number}}>(numberTest2);
 
 declare const numberTest3: PickDeep<Testing, '2.0'>;
 expectType<{2?: {0: number}}>(numberTest3);
+
+// Test for https://github.com/sindresorhus/type-fest/issues/1502.
+type Leaf = {
+	bar?: 'LeafBar';
+	foo: 'LeafString';
+};
+
+type Tree = {
+	foo?: Array<
+		{
+			mode: 'test1';
+			bar: Array<{
+				foo: Leaf[] | Leaf;
+			}>;
+		}
+		| {
+			mode: 'test2';
+			foo: 'foo.number.foo';
+			bar: Array<{
+				foo: Leaf[] | Leaf;
+			}>;
+		}
+	>;
+};
+
+declare const maxRecursionDepthPathTest0: Get<
+	PickDeep<Tree, `foo.${number}.bar.${number}.foo.${number}.bar`, {maxRecursionDepth: 6}>,
+	`foo.${number}.bar.${number}.foo.${number}.bar`
+>;
+expectType<'LeafBar' | undefined>(maxRecursionDepthPathTest0);
+

--- a/test-d/pick-deep.ts
+++ b/test-d/pick-deep.ts
@@ -152,8 +152,135 @@ type Tree = {
 };
 
 declare const maxRecursionDepthPathTest0: Get<
-	PickDeep<Tree, `foo.${number}.bar.${number}.foo.${number}.bar`, {maxRecursionDepth: 6}>,
+	PickDeep<Tree, `foo.${number}.bar.${number}.foo.${number}.bar`>,
 	`foo.${number}.bar.${number}.foo.${number}.bar`
 >;
 expectType<'LeafBar' | undefined>(maxRecursionDepthPathTest0);
 
+// Returns `never` if a path is invalid.
+type ValidTestObject = {
+	fooRoot: Array<{bar: 0}>;
+	barRoot: {foo: 1};
+};
+
+declare const invalidPathTest0: PickDeep<ValidTestObject, `fooRoot.${number}.bar.invalidPath`>;
+expectType<never>(invalidPathTest0);
+
+declare const invalidPathTest1: PickDeep<ValidTestObject, `fooRoot.${number}.invalidPath`>;
+expectType<never>(invalidPathTest1);
+
+declare const invalidPathTest2: PickDeep<ValidTestObject, `fooRoot.${number}..bar`>;
+expectType<never>(invalidPathTest2);
+
+declare const invalidPathTest3: PickDeep<ValidTestObject, `invalidValidTestObject.fooRoot.${number}.bar`>;
+expectType<never>(invalidPathTest3);
+
+declare const invalidPathTest4: PickDeep<ValidTestObject, `barRoot.${number}`>;
+expectType<never>(invalidPathTest4);
+
+declare const invalidPathTest5: PickDeep<ValidTestObject, `barRoot.foo.${number}`>;
+expectType<never>(invalidPathTest5);
+
+declare const invalidPathTest6: PickDeep<ValidTestObject, 'barRoot.invalidPath'>;
+expectType<never>(invalidPathTest6);
+
+type ValidTestArray = Array<{foo: 0; bar: 1}>;
+
+// Invalid property after a valid array index.
+declare const invalidArrayPathTest0: PickDeep<
+	ValidTestArray,
+	`${number}.invalidPath`
+>;
+expectType<never>(invalidArrayPathTest0);
+
+// Cannot recurse into a non-object/non-array value.
+declare const invalidArrayPathTest1: PickDeep<
+	ValidTestArray,
+	`${number}.foo.${number}`
+>;
+expectType<never>(invalidArrayPathTest1);
+
+// Malformed path.
+declare const invalidArrayPathTest2: PickDeep<
+	ValidTestArray,
+	`${number}..foo`
+>;
+expectType<never>(invalidArrayPathTest2);
+
+type ValidTestTuple = [
+	{foo: 0; bar: 1},
+	{foo: 2; bar: 3},
+];
+
+declare const invalidTuplePathTest0: PickDeep<ValidTestTuple, '0.invalidPath'>;
+expectType<never>(invalidTuplePathTest0);
+
+declare const invalidTuplePathTest1: PickDeep<ValidTestTuple, '1.foo.invalidPath'>;
+expectType<never>(invalidTuplePathTest1);
+
+declare const invalidTuplePathTest2: PickDeep<ValidTestTuple, '2.foo'>;
+expectType<never>(invalidTuplePathTest2);
+
+declare const invalidTuplePathTest3: PickDeep<ValidTestTuple, 'invalidPath.foo'>;
+expectType<never>(invalidTuplePathTest3);
+
+declare const invalidTuplePathTest4: PickDeep<ValidTestTuple, '0..foo'>;
+expectType<never>(invalidTuplePathTest4);
+
+type ValidTestReadonlyArray = ReadonlyArray<{foo: 0; bar: 1}>;
+
+// Invalid property after a valid array index.
+declare const invalidReadonlyArrayPathTest0: PickDeep<
+	ValidTestReadonlyArray,
+	`${number}.invalidPath`
+>;
+expectType<never>(invalidReadonlyArrayPathTest0);
+
+// Cannot recurse into a non-object/non-array value.
+declare const invalidReadonlyArrayPathTest1: PickDeep<
+	ValidTestReadonlyArray,
+	`${number}.foo.${number}`
+>;
+expectType<never>(invalidReadonlyArrayPathTest1);
+
+// Malformed path.
+declare const invalidReadonlyArrayPathTest2: PickDeep<
+	ValidTestReadonlyArray,
+	`${number}..foo`
+>;
+expectType<never>(invalidReadonlyArrayPathTest2);
+
+type ValidTestReadonlyTuple = readonly [
+	{foo: 0; bar: 1},
+	{foo: 2; bar: 3},
+];
+
+declare const invalidReadonlyTuplePathTest0: PickDeep<
+	ValidTestReadonlyTuple,
+	'0.invalidPath'
+>;
+expectType<never>(invalidReadonlyTuplePathTest0);
+
+declare const invalidReadonlyTuplePathTest1: PickDeep<
+	ValidTestReadonlyTuple,
+	'1.foo.invalidPath'
+>;
+expectType<never>(invalidReadonlyTuplePathTest1);
+
+declare const invalidReadonlyTuplePathTest2: PickDeep<
+	ValidTestReadonlyTuple,
+	'2.foo'
+>;
+expectType<never>(invalidReadonlyTuplePathTest2);
+
+declare const invalidReadonlyTuplePathTest3: PickDeep<
+	ValidTestReadonlyTuple,
+	'invalidPath.foo'
+>;
+expectType<never>(invalidReadonlyTuplePathTest3);
+
+declare const invalidReadonlyTuplePathTest4: PickDeep<
+	ValidTestReadonlyTuple,
+	'0..foo'
+>;
+expectType<never>(invalidReadonlyTuplePathTest4);


### PR DESCRIPTION
Closes #1502.

### Changes

Add a `PathsOptions` argument to `PickDeep` so that `maxRecursionDepth` can be configured when resolving deep paths.

This allows `PickDeep` to accept the same path options used by `Paths`, including a custom `maxRecursionDepth`.

```typescript
PickDeep<Tree, `foo.${number}.bar.${number}.foo.${number}.bar`, {maxRecursionDepth: 6}>
```

https://github.com/sindresorhus/type-fest/pull/1504/changes/f36fc07ced2afee54c448c822ba97ec5cd748dc5

### Reason

`PickDeep` uses `Paths` to validate the second argument, `PathUnion`, via `extends`, but `Paths` uses `DefaultPathsOptions` when the second argument is not specified.

```typescript
export type PickDeep<T, PathUnion extends Paths<T>> =
```

```typescript
export type DefaultPathsOptions = {
	maxRecursionDepth: 5;
	bracketNotation: false;
	leavesOnly: false;
	depth: number;
};
```

This causes `PickDeep` to break when the path exceeds the default recursion depth.
