### PR TITLE
Add `Destructurable` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export type {UnknownSet} from './source/unknown-set.d.ts';
 export type {UnknownMap} from './source/unknown-map.d.ts';
 export type {Except, ExceptOptions} from './source/except.d.ts';
 export type {TaggedUnion} from './source/tagged-union.d.ts';
+export type {Destructurable} from './source/destructurable.d.ts';
 export type {Writable} from './source/writable.d.ts';
 export type {WritableDeep} from './source/writable-deep.d.ts';
 export type {Merge} from './source/merge.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ Click the type names for complete docs.
 - [`Spread`](source/spread.d.ts) - Mimic the type inferred by TypeScript when merging two objects or two arrays/tuples using the spread syntax.
 - [`IsEqual`](source/is-equal.d.ts) - Returns a boolean for whether the two given types are equal.
 - [`TaggedUnion`](source/tagged-union.d.ts) - Create a union of types that share a common discriminant property.
+- [`Destructurable`](source/destructurable.d.ts) - Convert a union of object types into a type whose members can be destructured directly.
 - [`IntRange`](source/int-range.d.ts) - Generate a union of numbers between a specified start (inclusive) and end (exclusive), with an optional step.
 - [`IntClosedRange`](source/int-closed-range.d.ts) - Generate a union of numbers between a specified start and end (both inclusive), with an optional step.
 - [`ArrayIndices`](source/array-indices.d.ts) - Provides valid indices for a constant array or tuple.

--- a/source/destructurable.d.ts
+++ b/source/destructurable.d.ts
@@ -1,0 +1,62 @@
+import type {Simplify} from './simplify.d.ts';
+import type {UnionToIntersection} from './union-to-intersection.d.ts';
+
+/**
+Convert a union of object types into a type whose members can be destructured directly.
+
+When a function returns different object shapes and you let TypeScript infer the return type, the compiler describes each member with the keys of the *other* members added as optional `undefined` properties. That inferred shape is what lets you destructure the result in a single statement. As soon as you annotate the return type with a plain union (`Success | Failure`), that convenience is lost: destructuring a key that only exists on some members fails to compile, even though the value is present at runtime.
+
+`Destructurable` reconstructs the inferred shape from an explicit union, so the union stays destructurable. The original members are preserved, so narrowing on a discriminant property continues to work exactly as before.
+
+Use-cases:
+- Destructure the result of a function that returns a discriminated union in one statement, without narrowing first.
+- Keep a hand-written return type union destructurable, matching what TypeScript would have inferred.
+
+@example
+```
+import type {Destructurable} from 'type-fest';
+
+type Success = {
+	type: 'success';
+	value: number;
+};
+
+type Failure = {
+	type: 'failure';
+	error: Error;
+};
+
+type Result = Destructurable<Success | Failure>;
+
+function divide(x: number, y: number): Result {
+	return y === 0
+		? {type: 'failure', error: new Error('Division by zero')}
+		: {type: 'success', value: x / y};
+}
+
+// The result can be destructured directly.
+const {type, value, error} = divide(4, 2);
+
+// Narrowing on the discriminant still works.
+if (type === 'success') {
+	console.log('value:', value); // `value` is `number`
+} else {
+	console.log('error:', error.message);
+}
+```
+
+It works by first collecting every key of every member into a single object (`UnionToIntersection` merges the per-member key sets), then intersecting each member with the keys it is missing, typed as optional `undefined`.
+
+@category Utilities
+*/
+export type Destructurable<UnionType> = Simplify<
+	UnionToIntersection<{
+		[Key in keyof UnionType]?: undefined;
+	}> extends infer AllKeys
+		? UnionType extends unknown
+			? UnionType & Omit<AllKeys, keyof UnionType>
+			: never
+		: never
+>;
+
+export {};

--- a/test-d/destructurable.ts
+++ b/test-d/destructurable.ts
@@ -1,0 +1,57 @@
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
+import type {Destructurable} from '../index.d.ts';
+
+type Success = {
+	type: 'success';
+	value: number;
+};
+
+type Failure = {
+	type: 'failure';
+	error: Error;
+};
+
+type Result = Destructurable<Success | Failure>;
+
+declare const result: Result;
+
+// The union can be destructured directly, so every key is accessible.
+const {type, value, error} = result;
+expectType<'success' | 'failure'>(type);
+expectAssignable<number | undefined>(value);
+expectAssignable<Error | undefined>(error);
+
+// Narrowing on the discriminant still works, keeping the original members intact.
+if (result.type === 'success') {
+	expectType<number>(result.value);
+	expectType<undefined>(result.error);
+} else {
+	expectType<Error>(result.error);
+	expectType<undefined>(result.value);
+}
+
+// Each original member is still assignable to the result.
+expectAssignable<Result>({type: 'success', value: 1});
+expectAssignable<Result>({type: 'failure', error: new Error('failed')});
+
+// Members cannot be mixed together.
+expectNotAssignable<Result>({type: 'success', value: 1, error: new Error('failed')});
+
+// A single, non-union object is passed through unchanged and stays destructurable.
+type Single = Destructurable<{a: number; b: string}>;
+declare const single: Single;
+const {a, b} = single;
+expectType<number>(a);
+expectType<string>(b);
+expectType<{a: number; b: string}>(single);
+
+// Three members: each gains the keys of the others as optional.
+type A = {tag: 'a'; a: number};
+type B = {tag: 'b'; b: string};
+type C = {tag: 'c'; c: boolean};
+type Three = Destructurable<A | B | C>;
+declare const three: Three;
+const {a: threeA, b: threeB, c: threeC} = three;
+expectAssignable<number | undefined>(threeA);
+expectAssignable<string | undefined>(threeB);
+expectAssignable<boolean | undefined>(threeC);


### PR DESCRIPTION
Adds a `Destructurable` type that converts a union of object types into a shape whose members can be destructured directly, resolving #662.

When a function returns different object shapes and you let TypeScript infer the return type, the compiler describes each member with the keys of the *other* members added as optional `undefined` properties, and that inferred shape is exactly what makes the result destructurable in a single statement. The moment you annotate the return type with a plain union (`Success | Failure`), that convenience disappears — destructuring a key that only lives on some members no longer compiles, even though the value is there at runtime. `Destructurable` reconstructs the inferred shape from an explicit union so the union stays destructurable.

Importantly, the original members are preserved, so narrowing on a discriminant property still works exactly as before — the type only makes the pre-narrowing destructuring compile, it doesn't collapse the union. That addresses the main concern raised on the earlier attempt (#596): you don't lose discriminated-union safety.

This revives #596, which the maintainer bumped and then closed only for author inactivity, and follows the current contribution guidelines (new `source/destructurable.d.ts`, tests in `test-d/`, export in `index.d.ts`, readme entry under Utilities).

Tests cover direct destructuring, that narrowing still yields the correct per-branch types, that individual members remain assignable while mixed members are rejected, a single non-union object passing through unchanged, and a three-member union. `npm test` passes locally (tsc, tsd, xo, and the jsdoc-codeblock linter).
