### PR TITLE
Fix dead Lodash docs link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,7 @@ Click the type names for complete docs.
 - [`SetParameterType`](source/set-parameter-type.d.ts) - Create a function that replaces some parameters with the given parameters.
 - [`Simplify`](source/simplify.d.ts) - Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
 - [`SimplifyDeep`](source/simplify-deep.d.ts) - Deeply simplifies an object type.
-- [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.
+- [`Get`](source/get.d.ts) - Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs#get) function.
 - [`KeyAsString`](source/key-as-string.d.ts) - Get keys of the given type as strings.
 - [`Schema`](source/schema.d.ts) - Create a deep version of another object type where property values are recursively replaced into a given value type.
 - [`Exact`](source/exact.d.ts) - Create a type that does not allow extra properties, meaning it only allows properties that are explicitly declared.

--- a/source/get.d.ts
+++ b/source/get.d.ts
@@ -161,7 +161,7 @@ type PropertyOf<BaseType, Key extends string, Options extends Required<GetOption
 
 // This works by first splitting the path based on `.` and `[...]` characters into a tuple of string keys. Then it recursively uses the head key to get the next property of the current object, until there are no keys left. Number keys extract the item type from arrays, or are converted to strings to extract types from tuples and dictionaries with number keys.
 /**
-Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs/latest#get) function.
+Get a deeply-nested property from an object using a key path, like [Lodash's `.get()`](https://lodash.com/docs#get) function.
 
 Use-case: Retrieve a property from deep inside an API response or some other complex object.
 


### PR DESCRIPTION
The `Get` entry links to `https://lodash.com/docs/latest#get`, which returns 404 — lodash.com dropped the `/latest` alias. `https://lodash.com/docs` is the live docs page and the `#get` anchor still resolves there.

I checked every external link in the readme; this was the only broken one.