### PR TITLE
`Replace`: Fix behavior with empty and non-literal search strings

### DIFF
--- a/source/replace.d.ts
+++ b/source/replace.d.ts
@@ -76,11 +76,19 @@ type _Replace<
 	Accumulator extends string = '',
 > = Search extends string // For distributing `Search`
 	? Replacement extends string // For distributing `Replacement`
-		? Input extends `${infer Head}${Search}${infer Tail}`
+		? Search extends ''
 			? Options['all'] extends true
-				? _Replace<Tail, Search, Replacement, Options, `${Accumulator}${Head}${Replacement}`>
-				: `${Head}${Replacement}${Tail}`
-			: `${Accumulator}${Input}`
+				? Input extends `${infer First}${infer Rest}`
+					? _Replace<Rest, Search, Replacement, Options, `${Accumulator}${Replacement}${First}`>
+					: `${Accumulator}${Replacement}`
+				: `${Accumulator}${Replacement}${Input}`
+			: Input extends `${Search}${infer Rest}`
+				? Options['all'] extends true
+					? _Replace<Rest, Search, Replacement, Options, `${Accumulator}${Replacement}`>
+					: `${Accumulator}${Replacement}${Rest}`
+				: Input extends `${infer First}${infer Rest}`
+					? _Replace<Rest, Search, Replacement, Options, `${Accumulator}${First}`>
+					: Accumulator
 		: never
 	: never;
 

--- a/test-d/replace.ts
+++ b/test-d/replace.ts
@@ -28,6 +28,19 @@ expectType<'userName'>(replaceAll('__userName__', '__', ''));
 expectType<'MyCoolTitle'>(replaceAll('My Cool Title', ' ', ''));
 expectType<'fobarfobar'>(replaceAll('foobarfoobar', 'ob', 'b'));
 
+// Empty search string
+expectType<'Xabc'>({} as Replace<'abc', '', 'X'>);
+expectType<'XaXbXcX'>({} as Replace<'abc', '', 'X', {all: true}>);
+expectType<'foo'>({} as Replace<'', '', 'foo'>);
+expectType<'foo'>({} as Replace<'', '', 'foo', {all: true}>);
+
+// Non-literal searches
+expectType<'foobarBaz'>({} as Replace<'fooBarBaz', Uppercase<string>, 'b'>);
+expectType<'foobarbaz'>({} as Replace<'fooBarBaz', Uppercase<string>, 'b', {all: true}>);
+
+expectType<`foo[0-9]bar${number}`>({} as Replace<`foo${number}bar${number}`, `${number}`, '[0-9]'>);
+expectType<'foo[0-9]bar[0-9]'>({} as Replace<`foo${number}bar${number}`, `${number}`, '[0-9]', {all: true}>);
+
 // Unions
 expectType<'bcabc' | 'cbcba'>({} as Replace<'abcabc' | 'cbacba', 'a', ''>);
 expectType<'bcabc' | 'acabc'>({} as Replace<'abcabc', 'a' | 'b', ''>);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

If you're submitting a new type, please review the contribution guidelines:
https://github.com/sindresorhus/type-fest/blob/main/.github/contributing.md

-->

Closes #1506

Also, fixes behavior with empty (`''`) search strings:
```ts
type Current = Replace<'abc', '', 'X'>;
//=> 'aXbc'

type Fixed = Replace<'abc', '', 'X'>;
//=> 'Xabc'
```

```ts
type Current = Replace<'abc', '', 'X', {all: true}>;
//=> 'aXbXcX'

type Fixed = Replace<'abc', '', 'X', {all: true}>;
//=> 'XaXbXcX'
```