### PR TITLE
Ensure SharedUnionFieldsDeep doesn't distribute processed Union over mapped type

### DIFF
--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -106,10 +106,10 @@ export type SharedUnionFieldsDeep<Union, Options extends SharedUnionFieldsDeepOp
 Same as `SharedUnionFieldsDeep`, but accepts only `object`s and as inputs. Internal helper for `SharedUnionFieldsDeep`.
 */
 type SharedObjectUnionFieldsDeep<Union, Options extends Required<SharedUnionFieldsDeepOptions>> =
-	// `keyof Union` can extract the same key in union type, if there is no same key, return never.
+	// Extract the shared keys from the union. Throughout this type, use `Keys` instead of `keyof Union`
+	// to prevent the mapped type from distributing over the union.
 	keyof Union extends infer Keys extends keyof Union
 		? IsNever<Keys> extends false
-			// Prevent distributing the mapped type over the union type.
 			? {
 				[Key in Keys]:
 				Union[Key] extends NonRecursiveType

--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -107,20 +107,19 @@ Same as `SharedUnionFieldsDeep`, but accepts only `object`s and as inputs. Inter
 */
 type SharedObjectUnionFieldsDeep<Union, Options extends Required<SharedUnionFieldsDeepOptions>> =
 	// `keyof Union` can extract the same key in union type, if there is no same key, return never.
-	keyof Union extends infer Keys
+	keyof Union extends infer Keys extends keyof Union
 		? IsNever<Keys> extends false
-			// prevent distributing the mapped type over the union type
-			? keyof Union extends infer Keys extends keyof Union
-				? {
-					[Key in Keys]:
-					Union[Key] extends NonRecursiveType
-						? Union[Key]
-						// Remove `undefined` from the union to support optional
-						// fields, then recover `undefined` if union was already undefined.
-						: SharedUnionFieldsDeep<Exclude<Union[Key], undefined>, Options> | (
-							undefined extends Required<Union>[Key] ? undefined : never
-						)
-				} : never
+			// Prevent distributing the mapped type over the union type.
+			? {
+				[Key in Keys]:
+				Union[Key] extends NonRecursiveType
+					? Union[Key]
+					// Remove `undefined` from the union to support optional
+					// fields, then recover `undefined` if union was already undefined.
+					: SharedUnionFieldsDeep<Exclude<Union[Key], undefined>, Options> | (
+						undefined extends Required<Union>[Key] ? undefined : never
+					)
+			}
 			: {}
 		: Union;
 

--- a/source/shared-union-fields-deep.d.ts
+++ b/source/shared-union-fields-deep.d.ts
@@ -109,16 +109,18 @@ type SharedObjectUnionFieldsDeep<Union, Options extends Required<SharedUnionFiel
 	// `keyof Union` can extract the same key in union type, if there is no same key, return never.
 	keyof Union extends infer Keys
 		? IsNever<Keys> extends false
-			? {
-				[Key in keyof Union]:
-				Union[Key] extends NonRecursiveType
-					? Union[Key]
-					// Remove `undefined` from the union to support optional
-					// fields, then recover `undefined` if union was already undefined.
-					: SharedUnionFieldsDeep<Exclude<Union[Key], undefined>, Options> | (
-						undefined extends Required<Union>[Key] ? undefined : never
-					)
-			}
+			// prevent distributing the mapped type over the union type
+			? keyof Union extends infer Keys extends keyof Union
+				? {
+					[Key in Keys]:
+					Union[Key] extends NonRecursiveType
+						? Union[Key]
+						// Remove `undefined` from the union to support optional
+						// fields, then recover `undefined` if union was already undefined.
+						: SharedUnionFieldsDeep<Exclude<Union[Key], undefined>, Options> | (
+							undefined extends Required<Union>[Key] ? undefined : never
+						)
+				} : never
 			: {}
 		: Union;
 


### PR DESCRIPTION
Proposed change to TypeScript ([PR](https://github.com/microsoft/TypeScript/pull/63905)) breaks `type-fest` (see [this report](https://github.com/microsoft/typescript-go/pull/4596#issuecomment-5334466683)). This PR implements forwards-compatibility for that change