### PR TITLE
Add `EmptyArray` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export type {KeysOfUnion} from './source/keys-of-union.d.ts';
 export type {DistributedOmit} from './source/distributed-omit.d.ts';
 export type {DistributedPick} from './source/distributed-pick.d.ts';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object.d.ts';
+export type {EmptyArray, IsEmptyArray} from './source/empty-array.d.ts';
 export type {IfEmptyObject} from './source/if-empty-object.d.ts';
 export type {NonEmptyObject} from './source/non-empty-object.d.ts';
 export type {NonEmptyString} from './source/non-empty-string.d.ts';

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export type {KeysOfUnion} from './source/keys-of-union.d.ts';
 export type {DistributedOmit} from './source/distributed-omit.d.ts';
 export type {DistributedPick} from './source/distributed-pick.d.ts';
 export type {EmptyObject, IsEmptyObject} from './source/empty-object.d.ts';
-export type {EmptyArray, IsEmptyArray} from './source/empty-array.d.ts';
+export type {EmptyArray} from './source/empty-array.d.ts';
 export type {IfEmptyObject} from './source/if-empty-object.d.ts';
 export type {NonEmptyObject} from './source/non-empty-object.d.ts';
 export type {NonEmptyString} from './source/non-empty-string.d.ts';

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ Click the type names for complete docs.
 - [`IsNever`](source/is-never.d.ts) - Returns a boolean for whether the given type is `never`.
 - [`IsUnknown`](source/is-unknown.d.ts) - Returns a boolean for whether the given type is `unknown`.
 - [`IsEmptyObject`](source/empty-object.d.ts) - Returns a boolean for whether the type is strictly equal to an empty plain object, the `{}` value.
+- [`IsEmptyArray`](source/empty-array.d.ts) - Returns a boolean for whether the type is strictly equal to an empty readonly array, the `[]` value.
 - [`IsNull`](source/is-null.d.ts) - Returns a boolean for whether the given type is `null`.
 - [`IsUndefined`](source/is-undefined.d.ts) - Returns a boolean for whether the given type is `undefined`.
 - [`IsTuple`](source/is-tuple.d.ts) - Returns a boolean for whether the given array is a tuple.
@@ -260,6 +261,7 @@ Click the type names for complete docs.
 
 ### Array
 
+- [`EmptyArray`](source/empty-array.d.ts) - Represents a strictly empty readonly array, the `[]` value.
 - [`Arrayable`](source/arrayable.d.ts) - Create a type that represents either the value or an array of the value.
 - [`Includes`](source/includes.d.ts) - Returns a boolean for whether the given array includes the given item.
 - [`Join`](source/join.d.ts) - Join an array of strings and/or numbers using the given string as a delimiter.

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,6 @@ Click the type names for complete docs.
 - [`IsNever`](source/is-never.d.ts) - Returns a boolean for whether the given type is `never`.
 - [`IsUnknown`](source/is-unknown.d.ts) - Returns a boolean for whether the given type is `unknown`.
 - [`IsEmptyObject`](source/empty-object.d.ts) - Returns a boolean for whether the type is strictly equal to an empty plain object, the `{}` value.
-- [`IsEmptyArray`](source/empty-array.d.ts) - Returns a boolean for whether the type is strictly equal to an empty readonly array, the `[]` value.
 - [`IsNull`](source/is-null.d.ts) - Returns a boolean for whether the given type is `null`.
 - [`IsUndefined`](source/is-undefined.d.ts) - Returns a boolean for whether the given type is `undefined`.
 - [`IsTuple`](source/is-tuple.d.ts) - Returns a boolean for whether the given array is a tuple.
@@ -261,7 +260,7 @@ Click the type names for complete docs.
 
 ### Array
 
-- [`EmptyArray`](source/empty-array.d.ts) - Represents a strictly empty readonly array, the `[]` value.
+- [`EmptyArray`](source/empty-array.d.ts) - Represents a strictly empty readonly array, implemented as the readonly empty tuple `readonly []`.
 - [`Arrayable`](source/arrayable.d.ts) - Create a type that represents either the value or an array of the value.
 - [`Includes`](source/includes.d.ts) - Returns a boolean for whether the given array includes the given item.
 - [`Join`](source/join.d.ts) - Join an array of strings and/or numbers using the given string as a delimiter.

--- a/source/empty-array.d.ts
+++ b/source/empty-array.d.ts
@@ -1,0 +1,54 @@
+/**
+Represents a strictly empty readonly array, the `[]` value.
+
+When you annotate something as the type `unknown[]` or `any[]`, it can be any array, including a non-empty one. This means that you cannot use `unknown[]` or `any[]` to represent a strictly empty array.
+
+Useful as a stable default value for props or state that must never contain items, for example, to avoid unnecessary re-renders in React caused by a fresh `[]` literal on every render, while keeping the type narrow enough to prevent items from being added by mistake.
+
+@example
+```
+import type {EmptyArray} from 'type-fest';
+
+// The following illustrates the problem with `unknown[]`.
+const foo1: unknown[] = []; // Pass
+const foo2: unknown[] = [1, 2, 3]; // Pass
+
+// With `EmptyArray` only a strictly empty array is valid.
+const bar1: EmptyArray = []; // Pass
+// @ts-expect-error
+const bar2: EmptyArray = [1, 2, 3]; // Fail
+```
+
+@example
+```
+import type {EmptyArray} from 'type-fest';
+
+const DEFAULT_ITEMS: EmptyArray = [];
+
+function getItems(items: readonly string[] = DEFAULT_ITEMS) {
+	return items;
+}
+```
+
+@category Array
+*/
+export type EmptyArray = readonly [];
+
+/**
+Returns a boolean for whether the type is strictly equal to an empty readonly array, the `[]` value.
+
+@example
+```
+import type {IsEmptyArray} from 'type-fest';
+
+type Pass = IsEmptyArray<[]>; //=> true
+type Fail1 = IsEmptyArray<[1, 2, 3]>; //=> false
+type Fail2 = IsEmptyArray<string[]>; //=> false
+```
+
+@see {@link EmptyArray}
+@category Array
+*/
+export type IsEmptyArray<T> = T extends EmptyArray ? true : false;
+
+export {};

--- a/source/empty-array.d.ts
+++ b/source/empty-array.d.ts
@@ -1,5 +1,5 @@
 /**
-Represents a strictly empty readonly array, the `[]` value.
+Represents a strictly empty readonly array, implemented as the readonly empty tuple `readonly []`.
 
 When you annotate something as the type `unknown[]` or `any[]`, it can be any array, including a non-empty one. This means that you cannot use `unknown[]` or `any[]` to represent a strictly empty array.
 
@@ -30,25 +30,9 @@ function getItems(items: readonly string[] = DEFAULT_ITEMS) {
 }
 ```
 
+@see https://github.com/sindresorhus/type-fest/issues/929
 @category Array
 */
 export type EmptyArray = readonly [];
-
-/**
-Returns a boolean for whether the type is strictly equal to an empty readonly array, the `[]` value.
-
-@example
-```
-import type {IsEmptyArray} from 'type-fest';
-
-type Pass = IsEmptyArray<[]>; //=> true
-type Fail1 = IsEmptyArray<[1, 2, 3]>; //=> false
-type Fail2 = IsEmptyArray<string[]>; //=> false
-```
-
-@see {@link EmptyArray}
-@category Array
-*/
-export type IsEmptyArray<T> = T extends EmptyArray ? true : false;
 
 export {};

--- a/test-d/empty-array.ts
+++ b/test-d/empty-array.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectType} from 'tsd';
-import type {EmptyArray, IsEmptyArray} from '../index.d.ts';
+import type {EmptyArray} from '../index.d.ts';
 
 declare let foo: EmptyArray;
 
@@ -16,14 +16,8 @@ foo = 42;
 foo = null;
 // @ts-expect-error
 foo[0] = 1;
-
-expectType<IsEmptyArray<[]>>(true);
-expectType<IsEmptyArray<typeof foo>>(true);
-
-expectType<IsEmptyArray<[1, 2, 3]>>(false);
-expectType<IsEmptyArray<string[]>>(false);
-expectType<IsEmptyArray<null>>(false);
-expectType<IsEmptyArray<() => void>>(false);
+// @ts-expect-error
+foo.push(1);
 
 type Union = EmptyArray | [id: number];
 

--- a/test-d/empty-array.ts
+++ b/test-d/empty-array.ts
@@ -17,6 +17,7 @@ foo = null;
 // @ts-expect-error
 foo[0] = 1;
 // @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 foo.push(1);
 
 type Union = EmptyArray | [id: number];

--- a/test-d/empty-array.ts
+++ b/test-d/empty-array.ts
@@ -1,0 +1,35 @@
+import {expectAssignable, expectType} from 'tsd';
+import type {EmptyArray, IsEmptyArray} from '../index.d.ts';
+
+declare let foo: EmptyArray;
+
+expectAssignable<readonly []>(foo);
+expectAssignable<readonly []>(foo = []);
+
+// @ts-expect-error
+foo = [1, 2, 3];
+// @ts-expect-error
+foo = {};
+// @ts-expect-error
+foo = 42;
+// @ts-expect-error
+foo = null;
+// @ts-expect-error
+foo[0] = 1;
+
+expectType<IsEmptyArray<[]>>(true);
+expectType<IsEmptyArray<typeof foo>>(true);
+
+expectType<IsEmptyArray<[1, 2, 3]>>(false);
+expectType<IsEmptyArray<string[]>>(false);
+expectType<IsEmptyArray<null>>(false);
+expectType<IsEmptyArray<() => void>>(false);
+
+type Union = EmptyArray | [id: number];
+
+const bar: Union = [];
+// @ts-expect-error
+const _a: number = bar[0];
+
+const baz: Union = [42];
+expectType<[id: number]>(baz);


### PR DESCRIPTION
Adds `EmptyArray` (and a companion `IsEmptyArray`), mirroring the existing `EmptyObject`/`IsEmptyObject` pair.

Closes #929

`unknown[]`/`any[]` can't represent a strictly empty array — this is the array equivalent of the `{}`-vs-`EmptyObject` problem already solved for objects. Modeled as `readonly []`, matching what `[] as const` already produces (as noted in the issue).

- `source/empty-array.d.ts` — `EmptyArray` + `IsEmptyArray`, following the `empty-object.d.ts` doc/test conventions
- `test-d/empty-array.ts` — assignability, mutation rejection, and union-narrowing tests, plus `any`/`never`/`unknown`-style edge cases
- Registered in `index.d.ts` and `readme.md`

`npm test` (tsc, tsd, xo) passes locally.