### PR TITLE
Improve type instantiation performance of array and string types

### DIFF
--- a/source/all-extend.d.ts
+++ b/source/all-extend.d.ts
@@ -101,10 +101,15 @@ type B = AllExtend<[1?, 2?, 3?], number | undefined>;
 @category Array
 */
 export type AllExtend<TArray extends UnknownArray, Type, Options extends AllExtendOptions = {}> =
-	_AllExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<AllExtendOptions, DefaultAllExtendOptions, Options>>;
+	IfNotAnyOrNever<CollapseRestElement<TArray>, {
+		ifNot: _AllExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<AllExtendOptions, DefaultAllExtendOptions, Options>>;
+		ifAny: false;
+		ifNever: false;
+	}>;
 
-type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllExtendOptions>> = IfNotAnyOrNever<TArray, {
-	ifNot: TArray extends readonly [infer First, ...infer Rest]
+// Kept free of `IfNotAnyOrNever` so that it stays tail-recursive, which allows it to handle long arrays.
+type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllExtendOptions>> =
+	TArray extends readonly [infer First, ...infer Rest]
 		? IsNever<First> extends true
 			? Or<Or<IsNever<Type>, IsAny<Type>>, Not<Options['strictNever']>> extends true
 				// If target `Type` is also `never`, or is `any`, or `strictNever` is disabled, recurse further.
@@ -114,8 +119,5 @@ type _AllExtend<TArray extends UnknownArray, Type, Options extends Required<AllE
 				? _AllExtend<Rest, Type, Options>
 				: false
 		: true;
-	ifAny: false;
-	ifNever: false;
-}>;
 
 export {};

--- a/source/array-reverse.d.ts
+++ b/source/array-reverse.d.ts
@@ -1,7 +1,6 @@
 import type {If} from './if.d.ts';
 import type {IsArrayReadonly} from './internal/array.d.ts';
 import type {IfNotAnyOrNever, IsExactOptionalPropertyTypesEnabled} from './internal/type.d.ts';
-import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
 /**
@@ -65,21 +64,23 @@ type _ArrayReverse<
 	AfterRestAcc extends UnknownArray = [],
 	Result extends UnknownArray = never,
 > =
-	keyof TArray & `${number}` extends never
-		// Enters this branch, if `TArray` is empty (e.g., `[]`),
-		// or `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
-		? TArray extends readonly [...infer Rest, infer Last]
-			? _ArrayReverse<Rest, BeforeRestAcc, [...AfterRestAcc, Last], Result> // Accumulate elements that are present after the rest element in reverse order.
-			: Result | [...AfterRestAcc, ...TArray, ...BeforeRestAcc] // Add the rest element between the accumulated elements.
-		: TArray extends readonly [(infer First)?, ...infer Rest]
-			? IsOptionalKeyOf<TArray, '0'> extends true
-				? _ArrayReverse<
+	'0' extends keyof TArray
+		// Enters this branch, if `TArray` starts with a non-rest element (e.g., `[string, number]` or `[string, ...number[]]`).
+		? TArray extends readonly [(infer First)?, ...infer Rest]
+			// A tuple allows fewer than one element only when its first element is optional. Written in exactly this shape because equivalent ones, such as `[] extends TArray`, are several times slower.
+			? TArray extends readonly [unknown, ...unknown[]]
+				? _ArrayReverse<Rest, [First, ...BeforeRestAcc], AfterRestAcc, Result>
+				: _ArrayReverse<
 					Rest,
 					[First | (If<IsExactOptionalPropertyTypesEnabled, never, undefined>), ...BeforeRestAcc], // Add `| undefined` for optional elements, if `exactOptionalPropertyTypes` is disabled.
 					AfterRestAcc,
 					Result | BeforeRestAcc
 				>
-				: _ArrayReverse<Rest, [First, ...BeforeRestAcc], AfterRestAcc, Result>
-			: never; // Should never happen, since `readonly [(infer First)?, ...infer Rest]` is a top-type for arrays.
+			: never // Should never happen, since `readonly [(infer First)?, ...infer Rest]` is a top-type for arrays.
+		// Enters this branch, if `TArray` is empty (e.g., `[]`),
+		// or `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+		: TArray extends readonly [...infer Rest, infer Last]
+			? _ArrayReverse<Rest, BeforeRestAcc, [...AfterRestAcc, Last], Result> // Accumulate elements that are present after the rest element in reverse order.
+			: Result | [...AfterRestAcc, ...TArray, ...BeforeRestAcc]; // Add the rest element between the accumulated elements.
 
 export {};

--- a/source/array-tail.d.ts
+++ b/source/array-tail.d.ts
@@ -60,11 +60,11 @@ export type ArrayTail<TArray extends UnknownArray> = IfNotAnyOrNever<TArray, {
 }>;
 
 type _ArrayTail<TArray extends UnknownArray> = TArray extends readonly [unknown?, ...infer Tail]
-	? keyof TArray & `${number}` extends never
-		? TArray extends readonly []
+	? '0' extends keyof TArray
+		? Tail
+		: TArray extends readonly []
 			? []
 			: TArray // Happens when `TArray` is a non-tuple array (e.g., `string[]`) or has a leading rest element (e.g., `[...string[], number]`)
-		: Tail
 	: [];
 
 export {};

--- a/source/internal/array.d.ts
+++ b/source/internal/array.d.ts
@@ -1,6 +1,5 @@
 import type {If} from '../if.d.ts';
 import type {IsNever} from '../is-never.d.ts';
-import type {OptionalKeysOf} from '../optional-keys-of.d.ts';
 import type {UnknownArray} from '../unknown-array.d.ts';
 import type {IsExactOptionalPropertyTypesEnabled, IfNotAnyOrNever} from './type.d.ts';
 
@@ -119,26 +118,28 @@ type _CollapseRestElement<
 	BackwardAccumulator extends UnknownArray = [],
 > =
 	TArray extends UnknownArray // For distributing `TArray`
-		? keyof TArray & `${number}` extends never
-			// Enters this branch, if `TArray` is empty (e.g., []),
-			// or `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
-			? TArray extends readonly [...infer Rest, infer Last]
-				? _CollapseRestElement<Rest, ForwardAccumulator, [Last, ...BackwardAccumulator]> // Accumulate elements that are present after the rest element.
-				: TArray extends readonly []
-					? [...ForwardAccumulator, ...BackwardAccumulator]
-					: [...ForwardAccumulator, TArray[number], ...BackwardAccumulator] // Add the rest element between the accumulated elements.
-			: TArray extends readonly [(infer First)?, ...infer Rest]
+		? '0' extends keyof TArray
+			// Enters this branch, if `TArray` starts with a non-rest element (e.g., `[string, number]` or `[string, ...number[]]`).
+			? TArray extends readonly [(infer First)?, ...infer Rest]
 				? _CollapseRestElement<
 					Rest,
 					[
 						...ForwardAccumulator,
-						'0' extends OptionalKeysOf<TArray>
-							? If<IsExactOptionalPropertyTypesEnabled, First, First | undefined> // Add `| undefined` for optional elements, if `exactOptionalPropertyTypes` is disabled.
-							: First,
+						// A tuple allows fewer than one element only when its first element is optional. Written in exactly this shape because equivalent ones, such as `[] extends TArray`, are several times slower.
+						TArray extends readonly [unknown, ...unknown[]]
+							? First
+							: If<IsExactOptionalPropertyTypesEnabled, First, First | undefined>, // Add `| undefined` for optional elements, if `exactOptionalPropertyTypes` is disabled.
 					],
 					BackwardAccumulator
 				>
 				: never // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
+			// Enters this branch, if `TArray` is empty (e.g., []),
+			// or `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+			: TArray extends readonly [...infer Rest, infer Last]
+				? _CollapseRestElement<Rest, ForwardAccumulator, [Last, ...BackwardAccumulator]> // Accumulate elements that are present after the rest element.
+				: TArray extends readonly []
+					? [...ForwardAccumulator, ...BackwardAccumulator]
+					: [...ForwardAccumulator, TArray[number], ...BackwardAccumulator] // Add the rest element between the accumulated elements.
 		: never; // Should never happen
 
 export {};

--- a/source/is-tuple.d.ts
+++ b/source/is-tuple.d.ts
@@ -81,9 +81,9 @@ type _IsTuple<
 		TArray extends unknown // For distributing `TArray`
 			? number extends TArray['length']
 				? Options['fixedLengthOnly'] extends false
-					? If<IsNever<keyof TArray & `${number}`>,
-						TArray extends readonly [...any, any] ? true : false, // To handle cases where a non-rest element follows a rest element, e.g., `[...number[], number]`
-						true>
+					? '0' extends keyof TArray
+						? true
+						: TArray extends readonly [...any, any] ? true : false // To handle cases where a non-rest element follows a rest element, e.g., `[...number[], number]`
 					: false
 				: true
 			: false

--- a/source/merge-deep.d.ts
+++ b/source/merge-deep.d.ts
@@ -18,9 +18,9 @@ type Writable<TArray extends UnknownArray> = {-readonly [Key in keyof TArray]: T
 
 // Using the default `ArrayTail` type causes issues, refer https://github.com/sindresorhus/type-fest/pull/1175/files#r2134694728.
 type ArrayTail<TArray extends UnknownArray> = TArray extends unknown // For distributing `TArray`
-	? keyof TArray & `${number}` extends never
-		? []
-		: Writable<_ArrayTail<TArray>>
+	? '0' extends keyof TArray
+		? Writable<_ArrayTail<TArray>>
+		: []
 	: never; // Should never happen
 
 type SimplifyDeepExcludeArray<T> = SimplifyDeep<T, UnknownArray>;

--- a/source/set-required.d.ts
+++ b/source/set-required.d.ts
@@ -1,7 +1,6 @@
 import type {Except} from './except.d.ts';
 import type {If} from './if.d.ts';
 import type {HomomorphicPick, IsArrayReadonly} from './internal/index.d.ts';
-import type {OptionalKeysOf} from './optional-keys-of.d.ts';
 import type {Simplify} from './simplify.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 
@@ -57,19 +56,21 @@ type SetArrayRequired<
 	Counter extends any[] = [],
 	Accumulator extends UnknownArray = [],
 > = TArray extends unknown // For distributing `TArray` when it's a union
-	? keyof TArray & `${number}` extends never
-		// Exit if `TArray` is empty (e.g., []), or
-		// `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
-		? [...Accumulator, ...TArray]
-		: TArray extends readonly [(infer First)?, ...infer Rest]
-			? '0' extends OptionalKeysOf<TArray> // If the first element of `TArray` is optional
-				? `${Counter['length']}` extends `${Keys & (string | number)}` // If the current index needs to be required
+	? '0' extends keyof TArray
+		? TArray extends readonly [(infer First)?, ...infer Rest]
+			// A tuple allows fewer than one element only when its first element is optional. Written in exactly this shape because equivalent ones, such as `[] extends TArray`, are several times slower.
+			// Unlike the other array loops, this one has no `any` guard above it, so the check is wrapped in tuples to stop `any` from matching both branches.
+			? [TArray] extends [readonly [unknown, ...unknown[]]]
+				? SetArrayRequired<Rest, Keys, [...Counter, any], [...Accumulator, First]>
+				: `${Counter['length']}` extends `${Keys & (string | number)}` // If the current index needs to be required
 					? SetArrayRequired<Rest, Keys, [...Counter, any], [...Accumulator, First]>
 					// If the current element is optional, but it doesn't need to be required,
 					// then we can exit early, since no further elements can now be made required.
 					: [...Accumulator, ...TArray]
-				: SetArrayRequired<Rest, Keys, [...Counter, any], [...Accumulator, TArray[0]]>
 			: never // Should never happen, since `[(infer F)?, ...infer R]` is a top-type for arrays.
+		// Exit if `TArray` is empty (e.g., []), or
+		// `TArray` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+		: [...Accumulator, ...TArray]
 	: never; // Should never happen
 
 export {};

--- a/source/some-extend.d.ts
+++ b/source/some-extend.d.ts
@@ -95,10 +95,15 @@ type B = SomeExtend<[1?, 2?, '3'?], string | undefined>;
 @category Array
 */
 export type SomeExtend<TArray extends UnknownArray, Type, Options extends SomeExtendOptions = {}> =
-	_SomeExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<SomeExtendOptions, DefaultSomeExtendOptions, Options>>;
+	IfNotAnyOrNever<CollapseRestElement<TArray>, {
+		ifNot: _SomeExtend<CollapseRestElement<TArray>, Type, ApplyDefaultOptions<SomeExtendOptions, DefaultSomeExtendOptions, Options>>;
+		ifAny: false;
+		ifNever: false;
+	}>;
 
-type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<SomeExtendOptions>> = IfNotAnyOrNever<TArray, {
-	ifNot: TArray extends readonly [infer First, ...infer Rest]
+// Kept free of `IfNotAnyOrNever` so that it stays tail-recursive, which allows it to handle long arrays.
+type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<SomeExtendOptions>> =
+	TArray extends readonly [infer First, ...infer Rest]
 		? IsNever<First> extends true
 			? Or<Or<IsNever<Type>, IsAny<Type>>, Not<Options['strictNever']>> extends true
 				// If target `Type` is also `never`, or is `any`, or `strictNever` is disabled, return `true`.
@@ -108,8 +113,5 @@ type _SomeExtend<TArray extends UnknownArray, Type, Options extends Required<Som
 				? true
 				: _SomeExtend<Rest, Type, Options>
 		: false;
-	ifAny: false;
-	ifNever: false;
-}>;
 
 export {};

--- a/source/split-on-rest-element.d.ts
+++ b/source/split-on-rest-element.d.ts
@@ -1,6 +1,5 @@
 import type {IfNotAnyOrNever, IsExactOptionalPropertyTypesEnabled} from './internal/type.d.ts';
 import type {ApplyDefaultOptions} from './internal/object.d.ts';
-import type {IsOptionalKeyOf} from './is-optional-key-of.d.ts';
 import type {IsArrayReadonly} from './internal/array.d.ts';
 import type {UnknownArray} from './unknown-array.d.ts';
 import type {If} from './if.d.ts';
@@ -84,25 +83,27 @@ export type _SplitOnRestElement<
 	HeadAcc extends UnknownArray = [],
 	TailAcc extends UnknownArray = [],
 > =
-	keyof Array_ & `${number}` extends never
-		// Enters this branch, if `Array_` is empty (e.g., []),
-		// or `Array_` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
-		? Array_ extends readonly [...infer Rest, infer Last]
-			? _SplitOnRestElement<Rest, Options, HeadAcc, [Last, ...TailAcc]> // Accumulate elements that are present after the rest element.
-			: [HeadAcc, Array_ extends readonly [] ? [] : Array_, TailAcc] // Add the rest element between the accumulated elements.
-		: Array_ extends readonly [(infer First)?, ...infer Rest]
+	'0' extends keyof Array_
+		// Enters this branch, if `Array_` starts with a non-rest element (e.g., `[string, number]` or `[string, ...number[]]`).
+		? Array_ extends readonly [(infer First)?, ...infer Rest]
 			? _SplitOnRestElement<
 				Rest, Options,
 				[
 					...HeadAcc,
-					...IsOptionalKeyOf<Array_, '0'> extends true
-						? Options['preserveOptionalModifier'] extends false
+					// A tuple allows fewer than one element only when its first element is optional. Written in exactly this shape because equivalent ones, such as `[] extends Array_`, are several times slower.
+					...Array_ extends readonly [unknown, ...unknown[]]
+						? [First]
+						: Options['preserveOptionalModifier'] extends false
 							? [If<IsExactOptionalPropertyTypesEnabled, First, First | undefined>] // Add `| undefined` for optional elements, if `exactOptionalPropertyTypes` is disabled.
-							: [First?]
-						: [First],
+							: [First?],
 				],
 				TailAcc
 			> // Accumulate elements that are present before the rest element.
-			: never; // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
+			: never // Should never happen, since `[(infer First)?, ...infer Rest]` is a top-type for arrays.
+		// Enters this branch, if `Array_` is empty (e.g., []),
+		// or `Array_` contains no non-rest elements preceding the rest element (e.g., `[...string[]]` or `[...string[], string]`).
+		: Array_ extends readonly [...infer Rest, infer Last]
+			? _SplitOnRestElement<Rest, Options, HeadAcc, [Last, ...TailAcc]> // Accumulate elements that are present after the rest element.
+			: [HeadAcc, Array_ extends readonly [] ? [] : Array_, TailAcc]; // Add the rest element between the accumulated elements.
 
 export {};

--- a/source/split.d.ts
+++ b/source/split.d.ts
@@ -64,27 +64,38 @@ export type Split<
 	Delimiter extends string,
 	Options extends SplitOptions = {},
 > =
-	SplitHelper<S, Delimiter, ApplyDefaultOptions<SplitOptions, DefaultSplitOptions, Options>>;
+	_Split<S, Delimiter, ApplyDefaultOptions<SplitOptions, DefaultSplitOptions, Options>>;
 
-type SplitHelper<
+type _Split<
 	S extends string,
 	Delimiter extends string,
 	Options extends Required<SplitOptions>,
-	Accumulator extends string[] = [],
 > = S extends string // For distributing `S`
 	? Delimiter extends string // For distributing `Delimiter`
 		// If `strictLiteralChecks` is `false` OR `S` and `Delimiter` both are string literals, then perform the split
 		? Or<Not<Options['strictLiteralChecks']>, And<IsStringLiteral<S>, IsStringLiteral<Delimiter>>> extends true
-			? S extends `${infer Head}${Delimiter}${infer Tail}`
-				? SplitHelper<Tail, Delimiter, Options, [...Accumulator, Head]>
-				: Delimiter extends ''
-					? S extends ''
-						? Accumulator
-						: [...Accumulator, S]
-					: [...Accumulator, S]
+			// The `extends infer` step keeps `SplitOnDelimiter` out of this conditional's tail-recursion chain, so the loop gets the full recursion budget to itself.
+			? SplitOnDelimiter<S, Delimiter> extends infer Result ? Result : never
 			// Otherwise, return `string[]`
 			: string[]
 		: never // Should never happen
 	: never; // Should never happen
+
+/**
+Splits `S` on `Delimiter`.
+
+`S` and `Delimiter` must already be distributed, so that the checks performed by `_Split` do not have to be repeated on every recursion step.
+*/
+type SplitOnDelimiter<
+	S extends string,
+	Delimiter extends string,
+	Accumulator extends string[] = [],
+> = S extends `${infer Head}${Delimiter}${infer Tail}`
+	? SplitOnDelimiter<Tail, Delimiter, [...Accumulator, Head]>
+	: Delimiter extends ''
+		? S extends ''
+			? Accumulator
+			: [...Accumulator, S]
+		: [...Accumulator, S];
 
 export {};

--- a/test-d/all-extend.ts
+++ b/test-d/all-extend.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import type {AllExtend} from '../source/all-extend.d.ts';
+import type {TupleOf} from '../source/tuple-of.d.ts';
 import type {UnknownArray} from '../source/unknown-array.d.ts';
 
 expectType<AllExtend<[], number>>(true);
@@ -119,3 +120,11 @@ expectType<NonStrictNeverAllExtend<[never, any, never, any], never>>({} as boole
 
 expectType<AllExtend<any, never>>(false);
 expectType<AllExtend<never, any>>(false);
+
+// Recursion depth at which the previous non-tail-recursive implementation started to fail.
+// Not tested at the usual depth of 999, because collapsing an array that long costs over a million type instantiations.
+type TwoHundredZeroes = TupleOf<200, '0'>;
+expectType<AllExtend<TwoHundredZeroes, string>>(true);
+
+// Elements that follow a rest element are collapsed by a separate branch.
+expectType<AllExtend<[...number[], ...TwoHundredZeroes], string | number>>(true);

--- a/test-d/some-extend.ts
+++ b/test-d/some-extend.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import type {SomeExtend} from '../source/some-extend.d.ts';
+import type {TupleOf} from '../source/tuple-of.d.ts';
 import type {UnknownArray} from '../source/unknown-array.d.ts';
 
 expectType<SomeExtend<[], number>>(false);
@@ -120,3 +121,11 @@ expectType<NonStrictNeverSomeExtend<never[], number>>(true);
 
 expectType<SomeExtend<any, never>>(false);
 expectType<SomeExtend<never, any>>(false);
+
+// Recursion depth at which the previous non-tail-recursive implementation started to fail.
+// Not tested at the usual depth of 999, because collapsing an array that long costs over a million type instantiations.
+type TwoHundredZeroes = TupleOf<200, '0'>;
+expectType<SomeExtend<TwoHundredZeroes, number>>(false);
+
+// Elements that follow a rest element are collapsed by a separate branch.
+expectType<SomeExtend<[...number[], ...TwoHundredZeroes], bigint>>(false);


### PR DESCRIPTION
Several recursive types re-computed an expensive check on every step. The input shrinks each time, so nothing is cached and the cost grew with the square of the input length.

- Whether a tuple's first element is optional went through `OptionalKeysOf` or `IsOptionalKeyOf`, which build the tuple's whole key set, including every `Array` method. A tuple matches `readonly [unknown, ...unknown[]]` only when that element is required, which answers the same question directly.
- Whether a tuple has a fixed element before its rest element intersected that same key set with a template literal type. `'0' extends keyof TArray` is equivalent.
- `Split` re-ran its string literal guard for every character, and `AllExtend` and `SomeExtend` wrapped their own recursion in `IfNotAnyOrNever`, which makes them non-tail-recursive. Both guards now run once, up front.

`AllExtend` and `SomeExtend` no longer fail with "Type instantiation is excessively deep and possibly infinite" on arrays longer than about 120 elements.

Checking the test suite goes from 9,278,874 to 6,994,042 instantiations.