### PR TITLE
`Writable`: Fix support for polymorphic `this` and generics

### DIFF
--- a/source/writable.d.ts
+++ b/source/writable.d.ts
@@ -59,15 +59,13 @@ export type Writable<BaseType, Keys extends keyof BaseType | undefined = undefin
 				// Handle array
 				? WritableArray<BaseType>
 				// Handle object
-				: [undefined] extends [Keys]
+				: IsEqual<Keys, undefined> extends true
 					? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
-					: IsEqual<Extract<Keys, keyof BaseType>, keyof BaseType> extends true
-						? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
-						: Simplify<
-							// Pick just the keys that are not writable from the base type.
-							Except<BaseType, Extract<Keys, keyof BaseType>>
-							// Make the specified keys writable.
-							& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
-						>;
+					: Simplify<
+						// Pick just the keys that are not writable from the base type.
+						Except<BaseType, Extract<Keys, keyof BaseType>>
+						// Make the specified keys writable.
+						& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
+					>;
 
 export {};

--- a/source/writable.d.ts
+++ b/source/writable.d.ts
@@ -1,4 +1,6 @@
 import type {Except} from './except.d.ts';
+import type {IsEqual} from './is-equal.d.ts';
+import type {IsNever} from './is-never.d.ts';
 import type {Simplify} from './simplify.d.ts';
 
 /**
@@ -49,7 +51,7 @@ writableArray.push(4); // Will work as the array itself is now writable.
 
 @category Object
 */
-export type Writable<BaseType, Keys extends keyof BaseType = keyof BaseType> =
+export type Writable<BaseType, Keys extends keyof BaseType = never> =
 	BaseType extends ReadonlyMap<infer KeyType, infer ValueType>
 		? Map<KeyType, ValueType>
 		: BaseType extends ReadonlySet<infer ItemType>
@@ -58,11 +60,15 @@ export type Writable<BaseType, Keys extends keyof BaseType = keyof BaseType> =
 				// Handle array
 				? WritableArray<BaseType>
 				// Handle object
-				: Simplify<
-					// Pick just the keys that are not writable from the base type.
-					Except<BaseType, Keys>
-					// Make the specified keys writable.
-					& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
-				>;
+				: IsNever<Keys> extends true
+					? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
+					: IsEqual<Keys, keyof BaseType> extends true
+						? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
+						: Simplify<
+							// Pick just the keys that are not writable from the base type.
+							Except<BaseType, Keys>
+							// Make the specified keys writable.
+							& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
+						>;
 
 export {};

--- a/source/writable.d.ts
+++ b/source/writable.d.ts
@@ -1,6 +1,5 @@
 import type {Except} from './except.d.ts';
 import type {IsEqual} from './is-equal.d.ts';
-import type {IsNever} from './is-never.d.ts';
 import type {Simplify} from './simplify.d.ts';
 
 /**
@@ -51,7 +50,7 @@ writableArray.push(4); // Will work as the array itself is now writable.
 
 @category Object
 */
-export type Writable<BaseType, Keys extends keyof BaseType = never> =
+export type Writable<BaseType, Keys extends keyof BaseType | undefined = undefined> =
 	BaseType extends ReadonlyMap<infer KeyType, infer ValueType>
 		? Map<KeyType, ValueType>
 		: BaseType extends ReadonlySet<infer ItemType>
@@ -60,13 +59,13 @@ export type Writable<BaseType, Keys extends keyof BaseType = never> =
 				// Handle array
 				? WritableArray<BaseType>
 				// Handle object
-				: IsNever<Keys> extends true
+				: [undefined] extends [Keys]
 					? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
-					: IsEqual<Keys, keyof BaseType> extends true
+					: IsEqual<Extract<Keys, keyof BaseType>, keyof BaseType> extends true
 						? {-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}
 						: Simplify<
 							// Pick just the keys that are not writable from the base type.
-							Except<BaseType, Keys>
+							Except<BaseType, Extract<Keys, keyof BaseType>>
 							// Make the specified keys writable.
 							& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
 						>;

--- a/test-d/writable.ts
+++ b/test-d/writable.ts
@@ -60,9 +60,16 @@ expectType<{[key: string]: number; foo: number}>(variation12);
 declare const variation13: Writable<{readonly [key: string]: number; readonly foo: number}, 'foo'>;
 expectType<{readonly [key: string]: number; foo: number}>(variation13);
 
-// Support explicit `keyof BaseType` as Keys argument
+// Support explicit concrete `keyof BaseType` as Keys argument
 declare const variation14: Writable<Foo, keyof Foo>;
 expectType<{a: number; b: string}>(variation14);
+
+// A union with undefined selects only the specified keys, not all keys.
+declare const variationUnionWithUndefined: Writable<Foo, 'a' | undefined>;
+variationUnionWithUndefined.a = 2;
+// @ts-expect-error
+variationUnionWithUndefined.b = '2';
+expectType<{a: number; readonly b: string}>(variationUnionWithUndefined);
 
 // Explicit `never` makes no properties writable.
 declare const variationNever: Writable<Foo, never>;
@@ -90,7 +97,7 @@ indexNever['foo'] = 1;
 
 // Readonly index signature preserved when computed key selection resolves to `never`.
 type IndexRecord = {readonly [key: string]: number};
-type IndexKeys = Extract<keyof IndexRecord, number>;
+type IndexKeys = Extract<keyof IndexRecord, symbol>;
 declare const computedIndexNever: Writable<IndexRecord, IndexKeys>;
 expectType<IndexRecord>(computedIndexNever);
 // @ts-expect-error
@@ -116,4 +123,10 @@ class SomeClass {
 		(this as Writable<this>).field = 4;
 		(this as Writable<typeof this>).field = 4;
 	}
+}
+
+// Support uninstantiated generic types with default Writable<T>.
+function testGeneric<T extends {readonly a: number; readonly b: string}>(item: Writable<T>) {
+	item.a = 1;
+	item.b = 'test';
 }

--- a/test-d/writable.ts
+++ b/test-d/writable.ts
@@ -64,6 +64,40 @@ expectType<{readonly [key: string]: number; foo: number}>(variation13);
 declare const variation14: Writable<Foo, keyof Foo>;
 expectType<{a: number; b: string}>(variation14);
 
+// Explicit `never` makes no properties writable.
+declare const variationNever: Writable<Foo, never>;
+expectType<Foo>(variationNever);
+// @ts-expect-error
+variationNever.a = 2;
+// @ts-expect-error
+variationNever.b = '2';
+
+// Computed key selection resolving to `never` makes no properties writable.
+type RecordData = {readonly id: string};
+type EditableKeys = Extract<keyof RecordData, `editable${string}`>;
+declare const computedNeverData: Writable<RecordData, EditableKeys>;
+expectType<RecordData>(computedNeverData);
+// @ts-expect-error
+computedNeverData.id = 'changed';
+
+// Readonly index signature preserved when `never` is selected.
+declare const indexNever: Writable<{readonly [key: string]: number}, never>;
+expectType<{readonly [key: string]: number}>(indexNever);
+// @ts-expect-error
+indexNever.foo = 1;
+// @ts-expect-error
+indexNever['foo'] = 1;
+
+// Readonly index signature preserved when computed key selection resolves to `never`.
+type IndexRecord = {readonly [key: string]: number};
+type IndexKeys = Extract<keyof IndexRecord, number>;
+declare const computedIndexNever: Writable<IndexRecord, IndexKeys>;
+expectType<IndexRecord>(computedIndexNever);
+// @ts-expect-error
+computedIndexNever.foo = 1;
+// @ts-expect-error
+computedIndexNever['foo'] = 1;
+
 // Test edge cases: any, never, unknown
 declare const anyVariation: Writable<any>;
 expectType<any>(anyVariation);

--- a/test-d/writable.ts
+++ b/test-d/writable.ts
@@ -59,3 +59,27 @@ expectType<{[key: string]: number; foo: number}>(variation12);
 
 declare const variation13: Writable<{readonly [key: string]: number; readonly foo: number}, 'foo'>;
 expectType<{readonly [key: string]: number; foo: number}>(variation13);
+
+// Support explicit `keyof BaseType` as Keys argument
+declare const variation14: Writable<Foo, keyof Foo>;
+expectType<{a: number; b: string}>(variation14);
+
+// Test edge cases: any, never, unknown
+declare const anyVariation: Writable<any>;
+expectType<any>(anyVariation);
+
+declare const neverVariation: Writable<never>;
+expectType<never>(neverVariation);
+
+declare const unknownVariation: Writable<unknown>;
+expectType<{}>(unknownVariation);
+
+// Support polymorphic `this` within class methods (https://github.com/sindresorhus/type-fest/issues/1515).
+class SomeClass {
+	readonly field!: number;
+
+	method() {
+		(this as Writable<this>).field = 4;
+		(this as Writable<typeof this>).field = 4;
+	}
+}


### PR DESCRIPTION
Fixes #1515.

### What was wrong

In #1470 (v5.9.0), `Writable` was updated to preserve index signatures by using an `as` clause to filter keys:
```ts
& {-readonly [KeyType in keyof BaseType as KeyType extends Keys ? KeyType : never]: BaseType[KeyType]}
```
When `BaseType` is an uninstantiated type variable (such as polymorphic `this` inside a class method or `typeof this`, or generic `T`), TypeScript cannot eagerly evaluate the key-filtering conditional in the `as` clause. As a result, properties on `Writable<this>` and uninstantiated `Writable<T>` were dropped, causing errors such as:
```ts
class SomeClass {
	readonly field!: number;

	method() {
		(this as Writable<this>).field = 4; // Error: Property 'field' does not exist on type 'Writable<this>'.
	}
}
```

### What changed

- The omitted `Keys` argument uses `undefined` as the sentinel (`Keys extends keyof BaseType | undefined = undefined`), checked with `IsEqual<Keys, undefined> extends true`.
- An exact check via `IsEqual<Keys, undefined>` ensures unions containing `undefined` (such as `Writable<Model, 'selected' | undefined>`) only make the selected keys writable rather than treating the argument as omitted.
- When `Keys` is omitted (resolving to `undefined`), `Writable` evaluates directly to `{-readonly [KeyType in keyof BaseType]: BaseType[KeyType]}`. This direct homomorphic mapping:
  - Works on polymorphic `this`, `typeof this`, and generic `Writable<T>` without dropping properties.
  - Preserves index signatures without adding spurious numeric index signatures (retaining the fix from #1470).
- Explicit `never` or computed key selections that resolve to `never` remain valid empty key selections and preserve readonly properties and index signatures.
- `Extract<Keys, keyof BaseType>` is used when forwarding selected keys to `Except`.
- When a subset of `Keys` is specified (e.g. `Writable<T, 'a'>` or `Writable<Foo, keyof Foo>`), it continues through the `Except` + filtered mapped type path as expected.

### How it was tested

- Added regression tests in `test-d/writable.ts` covering:
  - `(this as Writable<this>).field = 4` and `(this as Writable<typeof this>).field = 4` inside class methods.
  - Generic uninstantiated types using default `Writable<T>` (`testGeneric<T>(item: Writable<T>)`).
  - Unions with `undefined` like `Writable<Foo, 'a' | undefined>`, verifying non-selected properties remain readonly.
  - Explicit `Writable<T, never>` with negative assignment tests.
  - Computed empty key selections resolving to `never` (`Writable<RecordData, EditableKeys>`) with negative assignment tests.
  - Readonly index signatures preserved when explicit `never` or computed empty selection (`Extract<keyof IndexRecord, symbol>`) is passed.
  - Explicit concrete `keyof BaseType` as `Keys` argument (`Writable<Foo, keyof Foo>`).
  - Edge cases (`any`, `never`, `unknown`).
- Focused writable tests in `test-d/writable.ts` pass cleanly with `tsd`.
- Verified repository-wide typecheck (`tsc`), tests (`node --test`), and linter (`xo` on changed files).
